### PR TITLE
Add Carmack Council to Development Workflows in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ claude
 - [Andrej Karpathy (Founding Member, OpenAI) Workflow](https://x.com/karpathy/status/2015883857489522876)
 - [Boris Cherny (Creator of Claude Code) - Feb 2026 Workflow](https://x.com/bcherny/status/2017742741636321619)
 - [Peter Steinberger (Creator of OpenClaw) Workflow](https://youtu.be/8lF7HmQ_RgY?t=2582)
+- [Carmack Council](https://github.com/SamJHudson01/Carmack-Council)
 
 ## TIPS AND TRICKS
 


### PR DESCRIPTION
Adding the Carmack Council — a Claude Code skill system that dispatches 10 domain expert subagents in parallel for a full spec → plan → implement → review loop. Each expert is grounded in the published principles of a named practitioner (Troy Hunt, Kent Beck, Simon Willison, Carmack etc.).

It also maintains a conventions.md that compounds learnings across review cycles.

Open source, MIT: https://github.com/SamJHudson01/Carmack-Council 