### PR TITLE
Add preflight MCP server to daily use recommendations

### DIFF
--- a/best-practice/claude-mcp.md
+++ b/best-practice/claude-mcp.md
@@ -23,10 +23,11 @@ MCP (Model Context Protocol) servers extend Claude Code with connections to exte
 | [**Context7**](https://github.com/upstash/context7) | Fetches up-to-date library docs into context. Prevents hallucinated APIs from outdated training data | [Reddit: "by far the best MCP for coding"](https://reddit.com/r/mcp/comments/1qarjqm/) · [npm](https://www.npmjs.com/package/@upstash/context7-mcp) |
 | [**Playwright**](https://github.com/microsoft/playwright-mcp) | Browser automation — implement, test, and verify UI features autonomously. Screenshots, navigation, form testing | [Reddit: essential for frontend](https://reddit.com/r/mcp/comments/1m59pk0/) · [Docs](https://playwright.dev/) |
 | [**Claude in Chrome**](https://github.com/nicobailon/claude-code-in-chrome-mcp) | Connects Claude to your real Chrome browser — inspect console, network, DOM. Debug what users actually see | [Reddit: "game changer" for debugging](https://reddit.com/r/mcp/comments/1qarjqm/5_mcps_that_have_genuinely_made_me_10x_faster/nza0i7t/) · [Comparison Report](../reports/claude-in-chrome-v-chrome-devtools-mcp.md) |
+| [**Preflight**](https://github.com/preflight-dev/preflight) | Catches vague prompts before they waste tokens — 12-category scorecards, correction pattern learning, cross-service contract awareness, session history search | [npm](https://www.npmjs.com/package/preflight-dev) |
 | [**DeepWiki**](https://github.com/devanshusemwal/deepwiki-mcp) | Fetches structured wiki-style documentation for any GitHub repo — architecture, API surface, relationships | [Reddit: "put it behind a gateway with Context7"](https://reddit.com/r/mcp/comments/1qarjqm/) |
 | [**Excalidraw**](https://github.com/antonpk1/excalidraw-mcp-app) | Generate architecture diagrams, flowcharts, and system designs as hand-drawn Excalidraw sketches from prompts | [GitHub](https://github.com/antonpk1/excalidraw-mcp-app) |
 
-Research (Context7/DeepWiki) -> Debug (Playwright/Chrome) -> Document (Excalidraw)
+Validate (Preflight) -> Research (Context7/DeepWiki) -> Debug (Playwright/Chrome) -> Document (Excalidraw)
 
 ---
 


### PR DESCRIPTION
## Add preflight to MCP Servers for Daily Use

**Repository:** https://github.com/preflight-dev/preflight
**npm:** `preflight-dev`

### What it does

Preflight is a 24-tool MCP server for Claude Code that catches vague/ambiguous prompts before they waste tokens on wrong→fix cycles. Built from analysis of 512 real Claude Code sessions (32K+ events, 3,200+ prompts).

**Key features:**
- 12-category prompt scorecards
- Correction pattern learning (remembers past mistakes)
- Cross-service contract awareness (types, interfaces, routes, schemas)
- Semantic session history search via LanceDB vectors
- Cost estimation for token spend and waste
- Smart triage classification

### Why it fits

It slots naturally before the research/debug/document pipeline as a validation step:

```
Validate (Preflight) → Research (Context7/DeepWiki) → Debug (Playwright/Chrome) → Document (Excalidraw)
```

### Changes

- Added preflight to the MCP Servers for Daily Use table
- Updated the pipeline flow to include the validation step