### PR TITLE
Add 6 missing best practice documents

### DIFF
--- a/best-practice/claude-agent-teams.md
+++ b/best-practice/claude-agent-teams.md
@@ -1,0 +1,270 @@
+# Agent Teams Best Practice
+
+![Last Updated](https://img.shields.io/badge/Last_Updated-Mar%2014%2C%202026-white?style=flat&labelColor=555)<br>
+[![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../implementation/claude-agent-teams-implementation.md)
+
+Multiple Claude Code instances working in parallel on the same codebase with shared task coordination.
+
+<table width="100%">
+<tr>
+<td><a href="../">← Back to Claude Code Best Practice</a></td>
+<td align="right"><img src="../!/claude-jumping.svg" alt="Claude" width="60" /></td>
+</tr>
+</table>
+
+---
+
+## What Are Agent Teams
+
+Agent teams let you coordinate multiple Claude Code instances working together. One session acts as the **team lead**, coordinating work, assigning tasks, and synthesizing results. **Teammates** work independently, each in its own context window, and communicate directly with each other via a shared mailbox.
+
+Unlike subagents (which run within a single session and only report back to the caller), teammates are fully independent Claude Code sessions that can message each other, claim tasks from a shared list, and be interacted with directly.
+
+| Component | Role |
+|-----------|------|
+| **Team lead** | The main Claude Code session that creates the team, spawns teammates, and coordinates work |
+| **Teammates** | Separate Claude Code instances that each work on assigned tasks |
+| **Task list** | Shared list of work items that teammates claim and complete |
+| **Mailbox** | Messaging system for communication between agents |
+
+> **Requirement:** Claude Code v2.1.32 or later. Check with `claude --version`.
+
+---
+
+## Agent Teams vs Subagents
+
+| | Subagents | Agent Teams |
+|---|-----------|-------------|
+| **Context** | Own context window; results return to the caller | Own context window; fully independent |
+| **Communication** | Report results back to the main agent only | Teammates message each other directly |
+| **Coordination** | Main agent manages all work | Shared task list with self-coordination |
+| **Best for** | Focused tasks where only the result matters | Complex work requiring discussion and collaboration |
+| **Token cost** | Lower: results summarized back to main context | Higher: each teammate is a separate Claude instance |
+
+Use subagents when you need quick, focused workers that report back. Use agent teams when teammates need to share findings, challenge each other, and coordinate on their own.
+
+---
+
+## Enabling Agent Teams
+
+Agent teams are experimental and disabled by default. Enable by setting the environment variable in your shell or via `settings.json`:
+
+```json
+{
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  }
+}
+```
+
+---
+
+## Display Modes
+
+| Mode | Setting Value | Behavior | Requirements |
+|------|---------------|----------|--------------|
+| **Auto** | `"auto"` (default) | Uses split panes if already inside a tmux session; in-process otherwise | None |
+| **In-process** | `"in-process"` | All teammates run inside the main terminal. Use `Shift+Down` to cycle through teammates | Any terminal |
+| **Split panes** | `"tmux"` | Each teammate gets its own pane. Auto-detects tmux vs iTerm2 | tmux or iTerm2 with `it2` CLI |
+
+### Configuring Display Mode
+
+In `settings.json`:
+
+```json
+{
+  "teammateMode": "in-process"
+}
+```
+
+Or per-session via CLI flag:
+
+```bash
+claude --teammate-mode in-process
+```
+
+### Split Pane Setup
+
+- **tmux**: install through your system package manager. `tmux -CC` in iTerm2 is the suggested entrypoint on macOS.
+- **iTerm2**: install the [`it2` CLI](https://github.com/mkusaka/it2), then enable the Python API in **iTerm2 > Settings > General > Magic > Enable Python API**.
+
+> **Note:** Split-pane mode is not supported in VS Code integrated terminal, Windows Terminal, or Ghostty.
+
+---
+
+## Task Coordination
+
+The shared task list coordinates work across the team. Tasks have three states: **pending**, **in progress**, and **completed**. Tasks can depend on other tasks — a pending task with unresolved dependencies cannot be claimed until those dependencies are completed.
+
+### How Tasks Flow
+
+1. The lead creates tasks and assigns them to teammates (or teammates self-claim)
+2. Task claiming uses file locking to prevent race conditions when multiple teammates try to claim the same task simultaneously
+3. When a teammate completes a task that others depend on, blocked tasks unblock automatically
+4. The lead synthesizes findings after teammates finish
+
+### Storage
+
+| Data | Location |
+|------|----------|
+| Team config | `~/.claude/teams/{team-name}/config.json` |
+| Task list | `~/.claude/tasks/{team-name}/` |
+
+---
+
+## Interacting with Teammates
+
+### In-Process Mode
+
+| Key | Action |
+|-----|--------|
+| `Shift+Down` | Cycle through teammates (wraps back to lead after last teammate) |
+| `Enter` | View a teammate's session |
+| `Escape` | Interrupt a teammate's current turn |
+| `Ctrl+T` | Toggle the task list |
+
+### Split-Pane Mode
+
+Click into a teammate's pane to interact with their session directly. Each teammate has a full view of its own terminal.
+
+### Messaging
+
+- **message**: send a message to one specific teammate
+- **broadcast**: send to all teammates simultaneously (use sparingly — costs scale with team size)
+
+---
+
+## Git Worktrees with Teams
+
+For parallel branch work that avoids file conflicts entirely, combine agent teams with git worktrees using the `isolation` field on subagent definitions:
+
+```yaml
+isolation: "worktree"
+```
+
+When set, the teammate runs in a temporary git worktree. This gives each teammate its own working directory on a separate branch, eliminating merge conflicts during parallel work. The worktree is auto-cleaned if no changes are made.
+
+For manual parallel sessions without automated team coordination, see the [Git worktrees workflow](https://code.claude.com/docs/en/common-workflows#run-parallel-claude-code-sessions-with-git-worktrees).
+
+---
+
+## Relevant Settings
+
+| Setting / Variable | Type | Default | Description |
+|--------------------|------|---------|-------------|
+| `teammateMode` | string | `"auto"` | Display mode: `"auto"`, `"in-process"`, or `"tmux"` |
+| `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` | env var | unset | Set to `"1"` to enable agent teams |
+
+---
+
+## Plan Approval for Teammates
+
+For complex or risky tasks, require teammates to plan before implementing:
+
+```text
+Spawn an architect teammate to refactor the authentication module.
+Require plan approval before they make any changes.
+```
+
+The teammate works in read-only plan mode until the lead approves. If rejected, the teammate revises and resubmits. The lead makes approval decisions autonomously — influence its judgment by giving criteria in your prompt (e.g., "only approve plans that include test coverage").
+
+---
+
+## Hooks for Quality Gates
+
+| Hook Event | When It Runs | Exit Code 2 Behavior |
+|------------|-------------|----------------------|
+| `TeammateIdle` | When a teammate is about to go idle | Sends feedback and keeps the teammate working |
+| `TaskCompleted` | When a task is being marked complete | Prevents completion and sends feedback |
+
+---
+
+## Best Practices
+
+### Task Decomposition
+
+- **Too small**: coordination overhead exceeds the benefit
+- **Too large**: teammates work too long without check-ins, increasing risk of wasted effort
+- **Just right**: self-contained units that produce a clear deliverable (a function, a test file, a review)
+- Aim for **5-6 tasks per teammate** to keep everyone productive without excessive context switching
+
+### Team Size
+
+Start with **3-5 teammates** for most workflows. Token costs scale linearly with each teammate. Three focused teammates often outperform five scattered ones. Scale up only when the work genuinely benefits from simultaneous parallel exploration.
+
+### Avoiding Merge Conflicts
+
+- Break work so each teammate owns a **different set of files**
+- Use `isolation: "worktree"` when teammates must work on overlapping areas
+- Two teammates editing the same file leads to overwrites — structure tasks to prevent this
+
+### When to Use Teams vs Sequential Agents
+
+| Use Agent Teams | Use a Single Session / Subagents |
+|-----------------|----------------------------------|
+| Research and review across multiple dimensions | Sequential tasks with dependencies |
+| New modules or features with clear boundaries | Same-file edits |
+| Debugging with competing hypotheses | Work with many inter-step dependencies |
+| Cross-layer coordination (frontend, backend, tests) | Routine tasks where token cost matters |
+
+### Keeping Tasks Independent
+
+- Give teammates enough context in the spawn prompt — they do not inherit the lead's conversation history
+- Teammates load `CLAUDE.md`, MCP servers, and skills automatically, but need task-specific details explicitly
+- Monitor and steer: check in on progress, redirect approaches that are not working
+- Tell the lead to wait for teammates if it starts implementing tasks itself:
+  ```text
+  Wait for your teammates to complete their tasks before proceeding
+  ```
+
+### Start with Low-Risk Tasks
+
+If new to agent teams, begin with tasks that have clear boundaries and do not require writing code: reviewing a PR, researching a library, or investigating a bug. These show the value of parallel exploration without the coordination challenges of parallel implementation.
+
+---
+
+## Permissions and Context
+
+- Teammates start with the lead's permission settings. If the lead runs with `--dangerously-skip-permissions`, all teammates do too.
+- Each teammate has its own context window. `CLAUDE.md`, MCP servers, and skills load normally. The lead's conversation history does not carry over.
+- You can change individual teammate permissions after spawning, but cannot set per-teammate modes at spawn time.
+
+---
+
+## Limitations
+
+- **No session resumption with in-process teammates**: `/resume` and `/rewind` do not restore in-process teammates
+- **Task status can lag**: teammates sometimes fail to mark tasks as completed, blocking dependent tasks
+- **One team per session**: clean up the current team before starting a new one
+- **No nested teams**: teammates cannot spawn their own teams — only the lead can manage the team
+- **Lead is fixed**: the session that creates the team is the lead for its lifetime
+- **Permissions set at spawn**: all teammates start with the lead's permission mode
+- **Split panes require tmux or iTerm2**: not supported in VS Code integrated terminal, Windows Terminal, or Ghostty
+
+---
+
+## Cleanup
+
+Always use the lead to clean up:
+
+```text
+Clean up the team
+```
+
+The lead checks for active teammates and fails if any are still running — shut them down first. Teammates should not run cleanup because their team context may not resolve correctly.
+
+If orphaned tmux sessions persist:
+
+```bash
+tmux ls
+tmux kill-session -t <session-name>
+```
+
+---
+
+## Sources
+
+- [Orchestrate teams of Claude Code sessions — Claude Code Docs](https://code.claude.com/docs/en/agent-teams)
+- [Create custom subagents — Claude Code Docs](https://code.claude.com/docs/en/sub-agents)
+- [Git worktrees workflow — Claude Code Docs](https://code.claude.com/docs/en/common-workflows#run-parallel-claude-code-sessions-with-git-worktrees)
+- [Claude Code Settings Documentation](https://code.claude.com/docs/en/settings)

--- a/best-practice/claude-checkpointing.md
+++ b/best-practice/claude-checkpointing.md
@@ -1,0 +1,135 @@
+# Checkpointing Best Practice
+
+![Last Updated](https://img.shields.io/badge/Last_Updated-Mar%2014%2C%202026-white?style=flat&labelColor=555)<br>
+
+Automatic git-based tracking of every file edit Claude makes — rewind, restore, and summarize session state.
+
+<table width="100%">
+<tr>
+<td><a href="../">← Back to Claude Code Best Practice</a></td>
+<td align="right"><img src="../!/claude-jumping.svg" alt="Claude" width="60" /></td>
+</tr>
+</table>
+
+---
+
+## 1. What is Checkpointing
+
+Checkpointing is Claude Code's built-in safety net that automatically captures the state of your code before each edit. Every time Claude uses a file editing tool (Edit, Write, NotebookEdit), a shadow checkpoint is created — allowing you to rewind to any previous state if something goes wrong.
+
+Key characteristics:
+
+- **Invisible to your git history** — checkpoints are shadow commits that do not appear in `git log` or pollute your branch
+- **Automatic** — no manual action required; every user prompt creates a new checkpoint
+- **Persistent across sessions** — checkpoints survive session restarts and are available when you resume a conversation
+- **Auto-cleaned** — removed along with sessions after 30 days (configurable via `cleanupPeriodDays`)
+
+---
+
+## 2. How Checkpoints Work
+
+| Aspect | Detail |
+|--------|--------|
+| **Trigger** | Every user prompt creates a new checkpoint |
+| **Scope** | Only tracks files modified via Claude's editing tools (Edit, Write, NotebookEdit) |
+| **Storage** | Shadow git commits — not visible in your actual git history |
+| **Persistence** | Survives session restarts; available in resumed conversations |
+| **Cleanup** | Automatically deleted with sessions after 30 days |
+
+### What is NOT Tracked
+
+| Not Tracked | Example |
+|-------------|---------|
+| Bash command changes | `rm file.txt`, `mv old.txt new.txt`, `cp source.txt dest.txt` |
+| External edits | Manual changes you make outside Claude Code |
+| Concurrent sessions | Edits from other Claude Code sessions (unless modifying the same files) |
+
+---
+
+## 3. Rewind Methods
+
+| Method | How to Invoke | Behavior |
+|--------|---------------|----------|
+| `Esc` `Esc` | Press Escape twice quickly | Opens the rewind menu — same as `/rewind` |
+| `/rewind` | Type the slash command | Opens a scrollable list of every prompt from the session |
+
+Both methods open the same interactive picker. Select the checkpoint you want to act on, then choose an action:
+
+| Action | Code Reverted | Conversation Reverted | Description |
+|--------|:-------------:|:---------------------:|-------------|
+| **Restore code and conversation** | Yes | Yes | Full rewind — revert both files and conversation to that point |
+| **Restore conversation** | No | Yes | Rewind conversation while keeping current files on disk |
+| **Restore code** | Yes | No | Revert files while keeping the full conversation history |
+| **Summarize from here** | No | Compressed | Replace messages from that point forward with a compact summary |
+| **Never mind** | No | No | Return to the message list without changes |
+
+After restoring or summarizing, the original prompt from the selected message is restored into the input field so you can re-send or edit it.
+
+---
+
+## 4. When to Use Rewind
+
+| Scenario | Why Rewind Helps |
+|----------|------------------|
+| Claude goes off-track | Wrong files edited, incorrect logic applied — rewind to before the wrong turn |
+| Wrong architectural approach | Claude chose the wrong pattern (e.g., inheritance vs. composition) — rewind and re-prompt with clearer direction |
+| Exploring alternatives | Try one approach, rewind, try another — compare results without manual cleanup |
+| Introduced bugs | Changes broke functionality — rewind to a known-good state faster than debugging |
+| Context pollution | A long debugging thread filled the context with noise — rewind and start fresh |
+
+---
+
+## 5. Rewind vs. Manual Undo
+
+A common instinct when Claude makes a mistake is to tell it to fix the problem within the same conversation. This is usually worse than rewinding.
+
+| Approach | Pros | Cons |
+|----------|------|------|
+| **Rewind** | Clean context, fresh start, no accumulated errors | Loses conversation after rewind point |
+| **Manual "fix it" in same context** | Preserves conversation continuity | Polluted context — Claude carries forward its wrong assumptions; may compound errors; wastes context window on debugging noise |
+
+**Rule of thumb:** If Claude's approach was fundamentally wrong (not just a small typo), rewind. Trying to fix a wrong approach in the same context often leads to more mistakes because Claude's reasoning is now anchored to the incorrect path.
+
+---
+
+## 6. Targeted Summarization
+
+The "Summarize from here" action in the rewind menu enables **targeted context compaction** — a more precise alternative to `/compact`.
+
+| Feature | `/compact` | Summarize from here |
+|---------|-----------|---------------------|
+| **Scope** | Entire conversation | From selected checkpoint forward |
+| **Early context** | Summarized | Preserved in full detail |
+| **Files on disk** | Unchanged | Unchanged |
+| **Original messages** | Replaced with summary | Preserved in session transcript (Claude can reference details if needed) |
+| **Custom focus** | Optional prompt to guide summary | Optional instructions to guide what the summary focuses on |
+
+### When to Use Targeted Summarization
+
+- A verbose debugging session consumed significant context, but your initial setup instructions need to stay intact
+- You want to keep early architectural decisions in full detail while compressing implementation chatter
+- You are approaching context limits but only the middle portion of the conversation is expendable
+
+> **Note:** Summarize keeps you in the same session and compresses context. If you want to branch off and try a different approach while preserving the original session intact, use fork instead (`claude --continue --fork-session`).
+
+---
+
+## 7. Best Practices
+
+| Practice | Why |
+|----------|-----|
+| **Rewind early rather than trying to fix** | The longer you let Claude continue down a wrong path, the more context is wasted and the harder it is to recover |
+| **Use rewind for wrong architectural decisions** | Telling Claude to "undo what you just did" rarely produces clean results — rewind gives a genuinely clean slate |
+| **Combine rewind with `/compact`** | After rewinding, if the remaining conversation is long, run `/compact` to free additional context space |
+| **Use targeted summarization for long sessions** | When only part of the conversation is noisy, summarize from that point rather than compacting everything |
+| **Re-prompt with more specificity after rewind** | Rewinding to the same prompt and re-sending it will likely produce the same result — edit the prompt to give Claude better direction |
+| **Remember bash changes are not tracked** | If Claude ran destructive bash commands (`rm`, `mv`), rewind cannot undo those — use git to recover if needed |
+| **Think of checkpoints as local undo, not version control** | Continue using git for commits, branches, and long-term history — checkpoints complement but do not replace proper version control |
+
+---
+
+## Sources
+
+- [Claude Code Checkpointing Documentation](https://code.claude.com/docs/en/checkpointing)
+- [Claude Code Interactive Mode — Keyboard Shortcuts](https://code.claude.com/docs/en/interactive-mode)
+- [Claude Code Built-in Commands](https://code.claude.com/docs/en/commands)

--- a/best-practice/claude-git-worktrees.md
+++ b/best-practice/claude-git-worktrees.md
@@ -1,0 +1,152 @@
+# Git Worktrees Best Practice
+
+![Last Updated](https://img.shields.io/badge/Last_Updated-Mar%2014%2C%202026-white?style=flat&labelColor=555)<br>
+
+Git worktrees in Claude Code — isolated parallel workspaces for concurrent development without branch conflicts.
+
+<table width="100%">
+<tr>
+<td><a href="../">← Back to Claude Code Best Practice</a></td>
+<td align="right"><img src="../!/claude-jumping.svg" alt="Claude" width="60" /></td>
+</tr>
+</table>
+
+---
+
+## What Are Git Worktrees
+
+Git worktrees create separate working directories that each have their own files and branch, while sharing the same repository history and remote connections. This allows multiple Claude sessions to work in parallel without file changes in one session interfering with another.
+
+| Concept | Description |
+|---------|-------------|
+| **Shared history** | All worktrees share the same `.git` directory, commits, and remote connections |
+| **Separate branches** | Each worktree checks out its own branch independently |
+| **Isolated files** | File changes in one worktree do not affect another |
+| **No stashing needed** | Unlike switching branches, worktrees eliminate the need to stash or commit in-progress work |
+
+---
+
+## Using Worktrees in Claude Code (3 Ways)
+
+| Method | Syntax | Context | Description |
+|--------|--------|---------|-------------|
+| CLI flag | `--worktree` / `-w` | Terminal startup | Starts Claude in an isolated worktree branched from the default remote branch |
+| Subagent frontmatter | `isolation: worktree` | `.claude/agents/*.md` | Runs subagent in its own worktree, auto-cleaned if no changes |
+| Agent tool parameter | `isolation: "worktree"` | Agent tool call | Spawns an agent in a dedicated worktree at runtime |
+
+### CLI flag: `--worktree` / `-w`
+
+Start Claude in an isolated worktree from the terminal. The value becomes both the directory name and the branch name:
+
+```bash
+# Named worktree — creates .claude/worktrees/feature-auth/ with branch worktree-feature-auth
+claude --worktree feature-auth
+
+# Another session in a separate worktree
+claude -w bugfix-123
+
+# Auto-generated name (e.g., "bright-running-fox")
+claude --worktree
+```
+
+Worktrees are created at `<repo>/.claude/worktrees/<name>` and branch from the default remote branch. The worktree branch is named `worktree-<name>`.
+
+You can also ask Claude to "work in a worktree" or "start a worktree" during a session, and it will create one automatically.
+
+### Subagent frontmatter: `isolation: worktree`
+
+Add `isolation: worktree` to a custom subagent definition in `.claude/agents/*.md`:
+
+```yaml
+---
+name: feature-builder
+description: Implements features in an isolated worktree
+tools: Read, Write, Edit, Bash, Glob, Grep
+isolation: worktree
+---
+```
+
+Each subagent instance gets its own worktree that is automatically cleaned up when the subagent finishes without changes.
+
+### Agent tool parameter
+
+When spawning an agent programmatically, pass `isolation: "worktree"` to run it in a dedicated worktree:
+
+```
+Agent(subagent_type="general-purpose", description="...", prompt="...", isolation="worktree")
+```
+
+---
+
+## Boris Cherny's 5 Ways to Use Worktrees
+
+Boris Cherny ([@bcherny](https://x.com/bcherny/status/2025007393290272904)) outlined five patterns for using worktrees with Claude Code:
+
+| # | Pattern | Description |
+|---|---------|-------------|
+| 1 | **CLI flag** | `claude -w` to start a session in an isolated worktree from the terminal |
+| 2 | **In-session request** | Ask Claude to "work in a worktree" during an active session |
+| 3 | **Subagent frontmatter** | `isolation: worktree` in `.claude/agents/*.md` for automatic worktree isolation |
+| 4 | **Agent tool parameter** | Pass `isolation: "worktree"` when invoking the Agent tool |
+| 5 | **Parallel agent teams** | Combine worktrees with agent teams so multiple agents each work in their own isolated copy of the codebase simultaneously |
+
+---
+
+## Cleanup Behavior
+
+| Scenario | What happens |
+|----------|-------------|
+| **No changes made** | Worktree and its branch are removed automatically on exit |
+| **Changes or commits exist** | Claude prompts you to keep or remove the worktree |
+| **Keep** | Preserves the directory and branch so you can return later |
+| **Remove** | Deletes the worktree directory and its branch, discarding all uncommitted changes and commits |
+| **Subagent worktree** | Auto-cleaned when the subagent finishes without changes; worktree path and branch returned if changes were made |
+
+To clean up worktrees outside of a Claude session, use standard Git commands:
+
+```bash
+git worktree list
+git worktree remove <path>
+```
+
+Add `.claude/worktrees/` to your `.gitignore` to prevent worktree contents from appearing as untracked files in your main repository.
+
+---
+
+## Combining with Agent Teams
+
+Worktrees and agent teams are complementary. Each agent in a team can operate in its own worktree, enabling true parallel development across multiple features or bug fixes.
+
+| Setup | Description |
+|-------|-------------|
+| **Single agent, single worktree** | One Claude session in an isolated worktree — good for focused feature work |
+| **Multiple agents, each with a worktree** | Several subagents each in their own worktree — good for parallelizing independent tasks |
+| **Agent team + worktrees** | Full agent team coordination with shared task queues and messaging, each member in an isolated worktree |
+
+Example: a team of three agents each implementing a separate module, all running concurrently without file conflicts, then merging their branches back when done.
+
+---
+
+## Best Practices
+
+| Practice | Why |
+|----------|-----|
+| **One task per worktree** | Keep worktrees focused on a single feature or bug fix to simplify merging and reduce conflicts |
+| **Use named worktrees** | `claude -w auth-refactor` is easier to find later than an auto-generated name |
+| **Add `.claude/worktrees/` to `.gitignore`** | Prevents worktree contents from appearing as untracked files in your main repo |
+| **Initialize dependencies per worktree** | Each worktree needs its own `npm install`, virtual environment setup, or equivalent |
+| **Merge promptly** | Merge worktree branches back to the main branch promptly to avoid long-lived divergence |
+| **Prefer worktrees over branch switching** | Worktrees avoid the stash/unstash cycle and let you keep multiple features open simultaneously |
+| **Use regular branches for quick edits** | If the change is small and fast, a worktree adds unnecessary overhead |
+| **Clean up after merging** | Run `git worktree remove` after merging to keep your workspace tidy |
+| **Non-git VCS** | Configure `WorktreeCreate` and `WorktreeRemove` hooks for SVN, Perforce, or Mercurial |
+
+---
+
+## Sources
+
+- [Claude Code Common Workflows — Git Worktrees](https://code.claude.com/docs/en/common-workflows)
+- [Claude Code Sub-agents — Isolation](https://code.claude.com/docs/en/sub-agents)
+- [Claude Code CLI Reference](https://code.claude.com/docs/en/cli-reference)
+- [Git Worktree Documentation](https://git-scm.com/docs/git-worktree)
+- [Boris Cherny — 5 Ways to Use Worktrees](https://x.com/bcherny/status/2025007393290272904)

--- a/best-practice/claude-hooks.md
+++ b/best-practice/claude-hooks.md
@@ -1,0 +1,306 @@
+# Hooks Best Practice
+
+![Last Updated](https://img.shields.io/badge/Last_Updated-Mar%2014%2C%202026-white?style=flat&labelColor=555)<br>
+[![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](https://github.com/shanraisshan/claude-code-voice-hooks)
+
+Claude Code hooks — lifecycle events, hook types, exit codes, matchers, and environment variables.
+
+<table width="100%">
+<tr>
+<td><a href="../">← Back to Claude Code Best Practice</a></td>
+<td align="right"><img src="../!/claude-jumping.svg" alt="Claude" width="60" /></td>
+</tr>
+</table>
+
+---
+
+## Hook Events (22)
+
+| # | Event | When It Fires | Can Block? | Useful For |
+|---|-------|---------------|------------|------------|
+| 1 | `PreToolUse` | Before a tool executes | Yes | Validating or modifying tool input, enforcing policies, auto-approving safe operations |
+| 2 | `PostToolUse` | After a tool completes successfully | No | Logging, injecting additional context, replacing MCP tool output |
+| 3 | `PostToolUseFailure` | After a tool execution fails | No | Error tracking, custom failure diagnostics |
+| 4 | `UserPromptSubmit` | When the user submits a prompt | Yes | Input validation, prompt rewriting, guardrails |
+| 5 | `Notification` | When a notification is sent | No | Sound alerts, desktop notifications, Slack messages |
+| 6 | `Stop` | When the main agent finishes | Yes | Forcing continuation, post-task verification, cleanup |
+| 7 | `SubagentStart` | When a subagent is spawned | No | Logging subagent activity, resource tracking |
+| 8 | `SubagentStop` | When a subagent finishes | Yes | Validating subagent output, forcing subagent continuation |
+| 9 | `PreCompact` | Before context compaction | No | Saving context snapshots, analytics |
+| 10 | `PostCompact` | After context compaction | No | Logging compaction results, cache warming |
+| 11 | `SessionStart` | New session, resume, clear, or compact | No | Environment setup, persisting env vars via `CLAUDE_ENV_FILE`, loading project context |
+| 12 | `SessionEnd` | Session terminates | No | Cleanup, analytics, saving session summaries |
+| 13 | `InstructionsLoaded` | CLAUDE.md or `.claude/rules` loaded | No | Tracking which instructions are active, auditing rule changes |
+| 14 | `PermissionRequest` | Permission dialog is shown | Yes | Auto-approving/denying permissions programmatically |
+| 15 | `TeammateIdle` | Team teammate is about to idle | Yes | Keeping teammates active, assigning new work |
+| 16 | `TaskCompleted` | A task is marked complete | Yes | Validation gates, notification pipelines, CI integration |
+| 17 | `ConfigChange` | A config file changes | Yes | Auditing config drift, blocking unsafe changes (policy changes cannot be blocked) |
+| 18 | `Elicitation` | MCP server requests user input | Yes | Auto-responding to MCP prompts without user dialog |
+| 19 | `ElicitationResult` | User responds to elicitation | Yes | Intercepting or modifying MCP input responses |
+| 20 | `WorktreeCreate` | Git worktree is created | Yes | Custom worktree paths, non-git VCS setup |
+| 21 | `WorktreeRemove` | Git worktree is removed | No | Cleanup for non-git version control systems |
+| 22 | `Setup` | First-run setup flow | No | Bootstrapping developer environments |
+
+---
+
+## Hook Types (4)
+
+| Type | Description | Default Timeout | Multi-turn? |
+|------|-------------|-----------------|-------------|
+| `command` | Executes a shell command; receives JSON on stdin, returns exit code + stdout/stderr | 600s | No |
+| `http` | Sends a JSON POST request to a URL; response body follows the same format as command hooks | 30s | No |
+| `prompt` | Single-turn LLM evaluation; responds with `{"ok": true/false, "reason": "..."}` | 30s | No |
+| `agent` | Multi-turn agentic verification with tool access (Read, Grep, Glob); up to 50 turns | 60s | Yes |
+
+### Supported Hook Types by Event
+
+| Events | command | http | prompt | agent |
+|--------|---------|------|--------|-------|
+| PreToolUse, PostToolUse, PostToolUseFailure, PermissionRequest, Stop, SubagentStop, TaskCompleted, UserPromptSubmit | Yes | Yes | Yes | Yes |
+| ConfigChange, Elicitation, ElicitationResult, InstructionsLoaded, Notification, PostCompact, PreCompact, SessionEnd, SessionStart, SubagentStart, TeammateIdle, WorktreeCreate, WorktreeRemove | Yes | No | No | No |
+
+---
+
+## Hook Properties
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `type` | string | Yes | Hook type: `command`, `http`, `prompt`, or `agent` |
+| `command` | string | For `command` | Shell command to execute. Supports `$CLAUDE_PROJECT_DIR` and `${CLAUDE_PLUGIN_ROOT}` |
+| `url` | string | For `http` | HTTP endpoint URL |
+| `prompt` | string | For `prompt`/`agent` | LLM prompt text. Use `$ARGUMENTS` placeholder for JSON input |
+| `model` | string | For `prompt`/`agent` | Model to use (e.g., `claude-3-5-haiku-20241022`) |
+| `headers` | object | No | HTTP headers for `http` hooks. Supports env var interpolation (e.g., `"Bearer $MY_TOKEN"`) |
+| `timeout` | number | No | Timeout in seconds (defaults vary by type) |
+| `async` | boolean | No | Run in background (command hooks only). Cannot block or control behavior |
+| `once` | boolean | No | Run only once per session |
+| `statusMessage` | string | No | Custom message displayed while the hook is running |
+
+### Matcher Configuration
+
+Matchers filter which specific events trigger a hook. Configured at the event-handler level, not on individual hooks.
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash|Edit|Write",
+        "hooks": [{ "type": "command", "command": "validate.sh" }]
+      }
+    ]
+  }
+}
+```
+
+| Pattern | Meaning |
+|---------|---------|
+| `""`, `"*"`, or omitted | Match all |
+| `"Bash\|Edit\|Write"` | Match any of these tool names |
+| `"mcp__memory__.*"` | Regex — match MCP tools from the memory server |
+| `"mcp__.*__write.*"` | Regex — match write tools across all MCP servers |
+| `".*test"` | Regex — match any tool name ending in "test" |
+
+### Matcher Values by Event
+
+| Event(s) | Matcher Matches Against |
+|----------|------------------------|
+| PreToolUse, PostToolUse, PostToolUseFailure, PermissionRequest | Tool name (e.g., `Bash`, `Edit`, `mcp__github__create_issue`) |
+| SubagentStart, SubagentStop | Agent type name |
+| SessionStart | `startup`, `resume`, `clear`, `compact` |
+| SessionEnd | `clear`, `logout`, `prompt_input_exit`, `bypass_permissions_disabled`, `other` |
+| Notification | `permission_prompt`, `idle_prompt`, `auth_success`, `elicitation_dialog` |
+| PreCompact, PostCompact | `manual`, `auto` |
+| ConfigChange | `user_settings`, `project_settings`, `local_settings`, `policy_settings`, `skills` |
+| Elicitation, ElicitationResult | MCP server name |
+| UserPromptSubmit, Stop, TeammateIdle, TaskCompleted, WorktreeCreate, WorktreeRemove, InstructionsLoaded | No matcher support |
+
+---
+
+## Exit Codes
+
+| Exit Code | Meaning | Behavior |
+|-----------|---------|----------|
+| **0** | Success | Action proceeds. Stdout parsed for JSON output. Text output shown in verbose mode (`Ctrl+O`) |
+| **2** | Blocking error | Action is blocked (if the event supports blocking). Stderr is fed back to Claude as an error message |
+| **Other** (1, 3, ...) | Non-blocking error | Execution continues. Stderr shown in verbose mode only |
+
+### Exit Code 2 Behavior by Event
+
+| Event | What Gets Blocked |
+|-------|-------------------|
+| `PreToolUse` | Tool call is blocked |
+| `PermissionRequest` | Permission is denied |
+| `UserPromptSubmit` | Prompt is blocked and erased |
+| `Stop`, `SubagentStop` | Agent is prevented from stopping |
+| `TeammateIdle` | Teammate gets feedback and continues working |
+| `TaskCompleted` | Task completion is prevented with feedback |
+| `ConfigChange` | Config change is blocked (except policy changes) |
+| `Elicitation`, `ElicitationResult` | Elicitation is denied/blocked |
+| `WorktreeCreate` | Worktree creation fails |
+| Non-blocking events | Error is shown but action proceeds |
+
+---
+
+## JSON Output Schema
+
+Hooks can return JSON on stdout to control Claude's behavior beyond simple exit codes.
+
+### Universal Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `continue` | boolean | Set `false` to stop Claude entirely |
+| `stopReason` | string | Message when `continue` is false |
+| `suppressOutput` | boolean | Suppress hook output from display |
+| `systemMessage` | string | Warning message injected into context |
+
+### Event-Specific Output
+
+| Event | Key Fields | Example |
+|-------|------------|---------|
+| PreToolUse | `hookSpecificOutput.permissionDecision` (`allow`/`deny`/`ask`), `updatedInput`, `additionalContext` | Auto-approve safe Bash commands |
+| PermissionRequest | `hookSpecificOutput.decision.behavior` (`allow`/`deny`), `updatedInput`, `message` | Programmatic permission handling |
+| PostToolUse | `hookSpecificOutput.additionalContext`, `updatedMCPToolOutput` | Inject context or replace MCP output |
+| Stop, SubagentStop | `decision` (`block`), `reason` | Force Claude to keep working |
+| UserPromptSubmit | `decision` (`block`), `reason` | Block inappropriate prompts |
+| Elicitation | `hookSpecificOutput.action` (`accept`/`decline`/`cancel`), `content` | Auto-respond to MCP input dialogs |
+
+---
+
+## HTTP Hooks
+
+HTTP hooks send a JSON POST request to a URL endpoint instead of running a shell command.
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "http",
+            "url": "http://localhost:8080/hooks/post-bash",
+            "headers": {
+              "Authorization": "Bearer $MY_TOKEN"
+            },
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### HTTP Hook Settings
+
+| Setting | Scope | Description |
+|---------|-------|-------------|
+| `allowedHttpHookUrls` | Any | URL patterns allowed for HTTP hooks (e.g., `"http://localhost:*"`) |
+| `httpHookAllowedEnvVars` | Any | Environment variable names allowed for header interpolation |
+
+Non-2xx responses are treated as non-blocking errors. The response body follows the same JSON schema as command hook stdout.
+
+---
+
+## Environment Variables
+
+### Hook-Specific Variables
+
+| Variable | Availability | Description |
+|----------|-------------|-------------|
+| `CLAUDE_ENV_FILE` | SessionStart only | File path to persist environment variables across the session |
+| `CLAUDE_PROJECT_DIR` | All command hooks | Project root path (wrap in quotes for paths with spaces) |
+| `${CLAUDE_PLUGIN_ROOT}` | Plugin hooks | Plugin root directory path |
+| `CLAUDE_CODE_REMOTE` | All hooks | Set to `"true"` in remote/web environments; not set locally |
+
+### Hook Input (JSON on stdin)
+
+All hooks receive a JSON object on stdin with these common fields:
+
+| Field | Description |
+|-------|-------------|
+| `session_id` | Current session identifier |
+| `transcript_path` | Path to the session transcript `.jsonl` file |
+| `cwd` | Current working directory |
+| `permission_mode` | Active permission mode (`default`, `plan`, `acceptEdits`, `dontAsk`, `bypassPermissions`) |
+| `hook_event_name` | The event that triggered this hook |
+| `agent_id` | Agent instance identifier |
+| `agent_type` | Agent type name |
+
+### Timeout Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CLAUDE_CODE_SESSIONEND_HOOKS_TIMEOUT_MS` | 1500ms | Timeout for SessionEnd hooks (set higher if hooks need more time) |
+
+---
+
+## Configuration Scopes
+
+Hooks can be defined at multiple levels. All levels merge at runtime; identical handlers are deduplicated.
+
+| Scope | Location | Shared? | Use Case |
+|-------|----------|---------|----------|
+| User (global) | `~/.claude/settings.json` | No | Personal hooks across all projects |
+| Project (team) | `.claude/settings.json` | Yes | Team-shared hooks |
+| Project (local) | `.claude/settings.local.json` | No (git-ignored) | Personal project-specific hooks |
+| Managed (org) | Managed settings | Yes (IT-deployed) | Organization-enforced hooks |
+| Agent frontmatter | `.claude/agents/*.md` `hooks:` field | Yes | Hooks scoped to a specific subagent |
+| Skill frontmatter | `.claude/skills/*/SKILL.md` `hooks:` field | Yes | Hooks scoped to a specific skill |
+| Plugin | Plugin `hooks/hooks.json` | Yes | Hooks bundled with a plugin |
+
+### Disabling Hooks
+
+```json
+{
+  "disableAllHooks": true
+}
+```
+
+- Respects the settings hierarchy — user/project settings cannot disable managed hooks
+- Only managed-level `disableAllHooks` disables managed hooks
+- Set `allowManagedHooksOnly` (managed settings) to ignore all non-managed hooks
+
+---
+
+## Best Practices
+
+### When to Use Hooks vs Skills vs Commands
+
+| Mechanism | Best For | Runs |
+|-----------|----------|------|
+| **Hooks** | Automated reactions to lifecycle events — validation, logging, notifications, policy enforcement | Automatically on matching events |
+| **Skills** | Reusable knowledge and workflows invoked by Claude or the user via `/slash-command` | On demand (user or model) |
+| **Commands** | User-initiated workflows with arguments — orchestration entry points | On demand (user only) |
+
+### Performance
+
+- Keep command hooks **fast** (under 1 second for blocking events). Slow hooks degrade the interactive experience
+- Use `async: true` for non-critical hooks (logging, analytics) that do not need to influence behavior
+- Set appropriate `timeout` values — do not rely on the 600-second default for hooks that should be quick
+- SessionEnd hooks have a hard 1.5-second default timeout (`CLAUDE_CODE_SESSIONEND_HOOKS_TIMEOUT_MS`)
+
+### Cross-Platform Considerations
+
+- Use Python or Node.js scripts instead of Bash for cross-platform compatibility
+- Shell profiles that print output on startup can break JSON parsing — keep hook scripts clean
+- Test hooks on all target platforms (macOS, Linux, Windows/WSL)
+- Quote `$CLAUDE_PROJECT_DIR` in shell commands for paths with spaces
+
+### Debugging
+
+- Use `Ctrl+O` (verbose mode) to see hook output in real time
+- Run Claude Code with `--debug` to see full hook execution details
+- Use `/hooks` to view all configured hooks by event and their source labels (`[User]`, `[Project]`, `[Local]`, `[Plugin]`, `[Session]`, `[Built-in]`)
+- Hook snapshots are taken at session start — external modifications trigger a review warning
+
+---
+
+## Sources
+
+- [Claude Code Hooks Documentation](https://code.claude.com/docs/en/hooks)
+- [Claude Code Voice Hooks](https://github.com/shanraisshan/claude-code-voice-hooks) — Reference implementation with sound notifications
+- [Claude Code CHANGELOG](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md)

--- a/best-practice/claude-plugins.md
+++ b/best-practice/claude-plugins.md
@@ -1,0 +1,385 @@
+# Plugins Best Practice
+
+![Last Updated](https://img.shields.io/badge/Last_Updated-Mar%2014%2C%202026-white?style=flat&labelColor=555)<br>
+
+Distributable bundles of skills, subagents, hooks, MCP servers, and LSP servers that extend Claude Code with shareable, versioned functionality.
+
+<table width="100%">
+<tr>
+<td><a href="../">← Back to Claude Code Best Practice</a></td>
+<td align="right"><img src="../!/claude-jumping.svg" alt="Claude" width="60" /></td>
+</tr>
+</table>
+
+---
+
+## What Are Plugins
+
+A **plugin** is a self-contained directory that packages one or more Claude Code components — skills, subagents, hooks, MCP servers, and LSP servers — into a single distributable unit. Plugins are namespaced (e.g., `/my-plugin:deploy`) to prevent conflicts, versioned with semver, and distributed through marketplaces.
+
+| Approach | Skill Names | Best For |
+|----------|-------------|----------|
+| **Standalone** (`.claude/` directory) | `/hello` | Personal workflows, single-project customizations, quick experiments |
+| **Plugins** (`.claude-plugin/plugin.json`) | `/plugin-name:hello` | Team sharing, community distribution, versioned releases, cross-project reuse |
+
+**Rule of thumb:** Start standalone in `.claude/` for rapid iteration, convert to a plugin when you are ready to share.
+
+---
+
+## Plugin Structure
+
+### Directory Layout
+
+```
+my-plugin/
+├── .claude-plugin/           # Metadata (only plugin.json goes here)
+│   └── plugin.json
+├── commands/                 # Slash commands (legacy; prefer skills/)
+│   └── deploy.md
+├── skills/                   # Agent Skills with SKILL.md
+│   └── code-review/
+│       └── SKILL.md
+├── agents/                   # Subagent definitions
+│   └── security-reviewer.md
+├── hooks/                    # Event handlers
+│   └── hooks.json
+├── settings.json             # Default settings (currently only "agent" key)
+├── .mcp.json                 # MCP server configurations
+├── .lsp.json                 # LSP server configurations
+├── scripts/                  # Hook and utility scripts
+│   └── format-code.sh
+├── LICENSE
+└── CHANGELOG.md
+```
+
+> **Common mistake:** Do not put `commands/`, `agents/`, `skills/`, or `hooks/` inside `.claude-plugin/`. Only `plugin.json` belongs there.
+
+### Manifest Format (`plugin.json`)
+
+The manifest is optional. If omitted, Claude Code auto-discovers components in default locations and derives the name from the directory.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | Yes (if manifest exists) | Unique identifier (kebab-case). Used as skill namespace prefix |
+| `version` | string | No | Semantic version (`MAJOR.MINOR.PATCH`) |
+| `description` | string | No | Brief explanation shown in plugin manager |
+| `author` | object | No | `{ "name", "email", "url" }` |
+| `homepage` | string | No | Documentation URL |
+| `repository` | string | No | Source code URL |
+| `license` | string | No | SPDX identifier (e.g., `MIT`) |
+| `keywords` | array | No | Discovery tags |
+| `commands` | string or array | No | Additional command files/directories |
+| `agents` | string or array | No | Additional agent files |
+| `skills` | string or array | No | Additional skill directories |
+| `hooks` | string, array, or object | No | Hook config paths or inline config |
+| `mcpServers` | string, array, or object | No | MCP config paths or inline config |
+| `lspServers` | string, array, or object | No | LSP server configs |
+| `outputStyles` | string or array | No | Output style files/directories |
+
+**Example:**
+
+```json
+{
+  "name": "deployment-tools",
+  "version": "2.1.0",
+  "description": "Deployment automation tools",
+  "author": { "name": "DevOps Team" },
+  "license": "MIT",
+  "keywords": ["deployment", "ci-cd"]
+}
+```
+
+### Environment Variable
+
+Use `${CLAUDE_PLUGIN_ROOT}` in hooks, MCP servers, and scripts to reference files relative to the plugin installation directory. Plugins are cached at `~/.claude/plugins/cache`, so absolute paths and `../` traversals will not work.
+
+---
+
+## Installation
+
+### `/plugin` Command
+
+The interactive plugin manager has four tabs: **Discover**, **Installed**, **Marketplaces**, and **Errors**. Cycle tabs with **Tab** / **Shift+Tab**.
+
+| Command | Description |
+|---------|-------------|
+| `/plugin` | Open interactive plugin manager |
+| `/plugin install <name>@<marketplace>` | Install a plugin (default: user scope) |
+| `/plugin uninstall <name>@<marketplace>` | Remove a plugin |
+| `/plugin enable <name>@<marketplace>` | Re-enable a disabled plugin |
+| `/plugin disable <name>@<marketplace>` | Disable without uninstalling |
+| `/plugin update <name>@<marketplace>` | Update to latest version |
+| `/plugin validate .` | Validate plugin/marketplace JSON |
+| `/plugin marketplace add <source>` | Register a marketplace |
+| `/plugin marketplace list` | List configured marketplaces |
+| `/plugin marketplace update <name>` | Refresh marketplace listings |
+| `/plugin marketplace remove <name>` | Remove a marketplace (uninstalls its plugins) |
+| `/reload-plugins` | Apply pending plugin changes without restarting |
+
+**Scope flag:** `--scope user|project|local` controls where the plugin is recorded.
+
+| Scope | Settings File | Purpose |
+|-------|--------------|---------|
+| `user` (default) | `~/.claude/settings.json` | Personal, all projects |
+| `project` | `.claude/settings.json` | Team-shared via version control |
+| `local` | `.claude/settings.local.json` | Personal, this project only (git-ignored) |
+| `managed` | Managed settings | Admin-enforced (read-only) |
+
+### Marketplace Installation
+
+```shell
+# Add a marketplace
+/plugin marketplace add anthropics/claude-code
+
+# Install from it
+/plugin install commit-commands@anthropics-claude-code
+```
+
+### Local Development / Manual Installation
+
+Use `--plugin-dir` to load a plugin from a local directory without installing it:
+
+```bash
+claude --plugin-dir ./my-plugin
+```
+
+Multiple plugins can be loaded simultaneously:
+
+```bash
+claude --plugin-dir ./plugin-one --plugin-dir ./plugin-two
+```
+
+A local `--plugin-dir` plugin with the same name as an installed marketplace plugin takes precedence for that session (except managed plugins).
+
+---
+
+## Marketplaces
+
+A marketplace is a catalog defined by `.claude-plugin/marketplace.json` that lists plugins and their sources. Users add the catalog, then install individual plugins from it.
+
+### Official Anthropic Marketplace
+
+The official marketplace (`claude-plugins-official`) is automatically available. Browse it from `/plugin` > **Discover** tab.
+
+### Adding Marketplaces
+
+| Source Type | Command |
+|-------------|---------|
+| GitHub | `/plugin marketplace add owner/repo` |
+| GitLab / other Git | `/plugin marketplace add https://gitlab.com/company/plugins.git` |
+| Git with branch/tag | `/plugin marketplace add https://gitlab.com/company/plugins.git#v1.0.0` |
+| Local directory | `/plugin marketplace add ./my-marketplace` |
+| Remote URL | `/plugin marketplace add https://example.com/marketplace.json` |
+
+### Team Marketplaces (`extraKnownMarketplaces`)
+
+Add to `.claude/settings.json` so team members are prompted to install when they trust the project:
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "company-tools": {
+      "source": {
+        "source": "github",
+        "repo": "your-org/claude-plugins"
+      }
+    }
+  }
+}
+```
+
+### Managed Marketplace Restrictions
+
+| Setting | Scope | Purpose |
+|---------|-------|---------|
+| `strictKnownMarketplaces` | Managed only | Allowlist of permitted marketplaces. Empty array `[]` = complete lockdown. Undefined = no restrictions |
+| `blockedMarketplaces` | Managed only | Block specific marketplaces |
+
+**Example — allow only approved sources:**
+
+```json
+{
+  "strictKnownMarketplaces": [
+    { "source": "github", "repo": "acme-corp/approved-plugins" },
+    { "source": "hostPattern", "hostPattern": "^github\\.internal\\.com$" }
+  ]
+}
+```
+
+### Auto-Updates
+
+Official marketplaces have auto-update enabled by default. Toggle per marketplace via `/plugin` > **Marketplaces** tab. Set `DISABLE_AUTOUPDATER=true` to disable all auto-updates, or pair with `FORCE_AUTOUPDATE_PLUGINS=true` to keep plugin updates while disabling Claude Code updates.
+
+---
+
+## Configuration
+
+### Plugin Settings in `settings.json`
+
+| Key | Type | Scope | Description |
+|-----|------|-------|-------------|
+| `enabledPlugins` | object | Any | Enable/disable plugins. Keys: `plugin@marketplace`, values: `true`/`false` |
+| `pluginConfigs` | object | Any | Per-plugin MCP server configs (keyed by `plugin@marketplace`) |
+| `extraKnownMarketplaces` | object | Project | Register custom marketplaces for team sharing |
+| `strictKnownMarketplaces` | array | Managed only | Allowlist of permitted marketplaces |
+| `blockedMarketplaces` | array | Managed only | Block specific marketplaces |
+| `skippedMarketplaces` | array | Any | Marketplaces user declined to install |
+| `skippedPlugins` | array | Any | Plugins user declined to install |
+| `pluginTrustMessage` | string | Managed only | Custom trust prompt message |
+
+**Example:**
+
+```json
+{
+  "enabledPlugins": {
+    "formatter@acme-tools": true,
+    "deployer@acme-tools": true,
+    "experimental@acme-tools": false
+  },
+  "pluginConfigs": {
+    "github@claude-plugins-official": {
+      "mcpServers": {
+        "github": {
+          "env": { "GITHUB_TOKEN": "${GITHUB_TOKEN}" }
+        }
+      }
+    }
+  }
+}
+```
+
+---
+
+## Official Marketplace Plugins
+
+### Code Intelligence (LSP)
+
+LSP plugins give Claude real-time diagnostics after every edit and code navigation (go-to-definition, find references, hover info). Each requires the language server binary installed on your system.
+
+| Language | Plugin | Binary Required |
+|----------|--------|-----------------|
+| C/C++ | `clangd-lsp` | `clangd` |
+| C# | `csharp-lsp` | `csharp-ls` |
+| Go | `gopls-lsp` | `gopls` |
+| Java | `jdtls-lsp` | `jdtls` |
+| Kotlin | `kotlin-lsp` | `kotlin-language-server` |
+| Lua | `lua-lsp` | `lua-language-server` |
+| PHP | `php-lsp` | `intelephense` |
+| Python | `pyright-lsp` | `pyright-langserver` |
+| Rust | `rust-analyzer-lsp` | `rust-analyzer` |
+| Swift | `swift-lsp` | `sourcekit-lsp` |
+| TypeScript | `typescript-lsp` | `typescript-language-server` |
+
+### External Integrations
+
+Pre-configured MCP server plugins for connecting Claude to external services:
+
+| Category | Plugins |
+|----------|---------|
+| Source control | `github`, `gitlab` |
+| Project management | `atlassian` (Jira/Confluence), `asana`, `linear`, `notion` |
+| Design | `figma` |
+| Infrastructure | `vercel`, `firebase`, `supabase` |
+| Communication | `slack` |
+| Monitoring | `sentry` |
+
+### Development Workflows
+
+| Plugin | Description |
+|--------|-------------|
+| `commit-commands` | Git commit workflows — commit, push, PR creation |
+| `pr-review-toolkit` | Specialized agents for reviewing pull requests |
+| `agent-sdk-dev` | Tools for building with the Claude Agent SDK |
+| `plugin-dev` | Toolkit for creating your own plugins |
+
+### Output Styles
+
+| Plugin | Description |
+|--------|-------------|
+| `explanatory-output-style` | Educational insights about implementation choices |
+| `learning-output-style` | Interactive learning mode for skill building |
+
+---
+
+## Creating Your Own Plugin
+
+### Step-by-Step
+
+1. **Create the directory:**
+   ```bash
+   mkdir -p my-plugin/.claude-plugin
+   ```
+
+2. **Create the manifest** at `my-plugin/.claude-plugin/plugin.json`:
+   ```json
+   {
+     "name": "my-plugin",
+     "description": "What this plugin does",
+     "version": "1.0.0",
+     "author": { "name": "Your Name" }
+   }
+   ```
+
+3. **Add components** — any combination of:
+   - `skills/<name>/SKILL.md` — agent skills
+   - `commands/<name>.md` — slash commands
+   - `agents/<name>.md` — subagent definitions
+   - `hooks/hooks.json` — event handlers
+   - `.mcp.json` — MCP server configs
+   - `.lsp.json` — LSP server configs
+
+4. **Test locally:**
+   ```bash
+   claude --plugin-dir ./my-plugin
+   ```
+   Use `/reload-plugins` to pick up changes without restarting.
+
+5. **Distribute** — create a `marketplace.json` or submit to the official marketplace:
+   - **Claude.ai**: [claude.ai/settings/plugins/submit](https://claude.ai/settings/plugins/submit)
+   - **Console**: [platform.claude.com/plugins/submit](https://platform.claude.com/plugins/submit)
+
+### Converting Standalone to Plugin
+
+| Standalone (`.claude/`) | Plugin |
+|-------------------------|--------|
+| `.claude/commands/` | `plugin-name/commands/` |
+| `.claude/skills/` | `plugin-name/skills/` |
+| `.claude/agents/` | `plugin-name/agents/` |
+| Hooks in `settings.json` | `plugin-name/hooks/hooks.json` |
+
+### Debugging
+
+| Issue | Solution |
+|-------|----------|
+| Plugin not loading | Validate JSON: `/plugin validate .` |
+| Commands not appearing | Ensure `commands/` is at root, not inside `.claude-plugin/` |
+| Hooks not firing | `chmod +x` on scripts, verify `${CLAUDE_PLUGIN_ROOT}` paths |
+| MCP server fails | Use `${CLAUDE_PLUGIN_ROOT}` for all paths |
+| Path errors after install | Paths cannot traverse outside plugin root (`../` fails in cache) — use symlinks instead |
+
+Run `claude --debug` to see plugin loading details, manifest errors, and component registration.
+
+---
+
+## Best Practices
+
+| Do | Avoid |
+|----|-------|
+| Start standalone, convert to plugin when sharing | Packaging single-use personal workflows as plugins |
+| Use `${CLAUDE_PLUGIN_ROOT}` for all internal paths | Absolute paths or `../` traversals |
+| Follow semver — bump version on every change | Changing code without bumping version (cache ignores unchanged versions) |
+| Keep `plugin.json` in `.claude-plugin/` only | Putting skills, hooks, or commands inside `.claude-plugin/` |
+| Pin plugin sources with `ref` or `sha` for stability | Floating references in production marketplaces |
+| Test with `--plugin-dir` before publishing | Publishing untested plugins to shared marketplaces |
+| Use `strict: true` (default) for self-contained plugins | `strict: false` unless the marketplace needs full control |
+| Scope project plugins via `enabledPlugins` in `.claude/settings.json` | Asking teammates to manually install plugins |
+
+---
+
+## Sources
+
+- [Create Plugins — Claude Code Docs](https://code.claude.com/docs/en/plugins)
+- [Discover and Install Plugins — Claude Code Docs](https://code.claude.com/docs/en/discover-plugins)
+- [Plugins Reference — Claude Code Docs](https://code.claude.com/docs/en/plugins-reference)
+- [Plugin Marketplaces — Claude Code Docs](https://code.claude.com/docs/en/plugin-marketplaces)
+- [Plugin Settings — Claude Code Docs](https://code.claude.com/docs/en/settings)

--- a/best-practice/claude-scheduled-tasks.md
+++ b/best-practice/claude-scheduled-tasks.md
@@ -1,0 +1,160 @@
+# Scheduled Tasks Best Practice
+
+![Last Updated](https://img.shields.io/badge/Last_Updated-Mar%2014%2C%202026-white?style=flat&labelColor=555)<br>
+[![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../implementation/claude-scheduled-tasks-implementation.md)
+
+Run prompts on a recurring schedule, set one-time reminders, and poll deployments and builds — all within a Claude Code session.
+
+<table width="100%">
+<tr>
+<td><a href="../">← Back to Claude Code Best Practice</a></td>
+<td align="right"><img src="../!/claude-jumping.svg" alt="Claude" width="60" /></td>
+</tr>
+</table>
+
+---
+
+## What Are Scheduled Tasks
+
+Scheduled tasks let Claude re-run a prompt automatically on an interval. Tasks are **session-scoped** — they live in the current Claude Code process and are gone when you exit. For durable scheduling that survives restarts, use Desktop scheduled tasks or GitHub Actions with a `schedule` trigger.
+
+Key characteristics:
+
+| Property | Detail |
+|----------|--------|
+| **Scope** | Current session only — closing the terminal cancels everything |
+| **Max duration** | Recurring tasks auto-expire after **3 days** |
+| **Max tasks** | Up to **50** scheduled tasks per session |
+| **Timezone** | All times interpreted in your **local timezone**, not UTC |
+| **Execution** | Fires between your turns, not mid-response. Waits if Claude is busy |
+| **Missed fires** | No catch-up — fires once when Claude becomes idle, not once per missed interval |
+| **Jitter** | Recurring tasks fire up to 10% of their period late (capped at 15 min). One-shot tasks at `:00`/`:30` fire up to 90s early |
+| **Min version** | Requires Claude Code **v2.1.72** or later |
+
+---
+
+## The /loop Command
+
+The `/loop` bundled skill is the quickest way to schedule a recurring prompt.
+
+```text
+/loop 5m check if the deployment finished and tell me what happened
+```
+
+### Interval Syntax
+
+| Form | Example | Parsed Interval |
+|------|---------|-----------------|
+| Leading token | `/loop 30m check the build` | Every 30 minutes |
+| Trailing `every` clause | `/loop check the build every 2 hours` | Every 2 hours |
+| No interval | `/loop check the build` | Defaults to every **10 minutes** |
+
+Supported units: `s` (seconds), `m` (minutes), `h` (hours), `d` (days). Seconds are rounded up to the nearest minute (cron has one-minute granularity). Odd intervals like `7m` or `90m` are rounded to the nearest clean interval.
+
+### Loop Over Another Command
+
+The scheduled prompt can itself be a slash command or skill invocation:
+
+```text
+/loop 20m /review-pr 1234
+```
+
+Each time the job fires, Claude runs `/review-pr 1234` as if you had typed it.
+
+### One-Time Reminders
+
+For one-shot reminders, use natural language instead of `/loop`:
+
+```text
+remind me at 3pm to push the release branch
+```
+
+```text
+in 45 minutes, check whether the integration tests passed
+```
+
+Claude pins the fire time to a specific minute using a cron expression, confirms when it will fire, and deletes the task after it runs.
+
+---
+
+## Cron Tools
+
+Under the hood, `/loop` and natural-language reminders use three tools:
+
+| Tool | Purpose |
+|------|---------|
+| `CronCreate` | Schedule a new task. Accepts a **5-field cron expression**, the prompt to run, and whether it recurs or fires once |
+| `CronList` | List all scheduled tasks with their IDs, schedules, and prompts |
+| `CronDelete` | Cancel a task by its **8-character ID** |
+
+You can also manage tasks in natural language:
+
+```text
+what scheduled tasks do I have?
+```
+
+```text
+cancel the deploy check job
+```
+
+### Cron Expression Reference
+
+`CronCreate` accepts standard 5-field cron: `minute hour day-of-month month day-of-week`.
+
+| Expression | Meaning |
+|------------|---------|
+| `*/5 * * * *` | Every 5 minutes |
+| `0 * * * *` | Every hour on the hour |
+| `7 * * * *` | Every hour at 7 minutes past |
+| `0 9 * * *` | Every day at 9am local |
+| `0 9 * * 1-5` | Weekdays at 9am local |
+| `30 14 15 3 *` | March 15 at 2:30pm local |
+
+All fields support wildcards (`*`), single values (`5`), steps (`*/15`), ranges (`1-5`), and comma-separated lists (`1,15,30`). Extended syntax like `L`, `W`, `?`, and name aliases (`MON`, `JAN`) is **not** supported.
+
+---
+
+## Use Cases
+
+| Use Case | Example | Suggested Interval |
+|----------|---------|-------------------|
+| **Poll deployment status** | `/loop 5m check if the staging deploy finished` | 2-5 min |
+| **Babysit a PR** | `/loop 20m /review-pr 1234` | 15-30 min |
+| **Monitor CI builds** | `/loop 10m check whether the CI build passed on main` | 5-10 min |
+| **Check test results** | `in 45 minutes, check whether the integration tests passed` | One-shot |
+| **Recurring code quality** | `/loop 1h run a quick lint check on src/` | 30-60 min |
+| **Release reminders** | `remind me at 3pm to push the release branch` | One-shot |
+| **Dependency monitoring** | `/loop 2h check if there are new security advisories for our deps` | 1-2 hr |
+
+---
+
+## Configuration
+
+| Setting | Value | Effect |
+|---------|-------|--------|
+| `CLAUDE_CODE_DISABLE_CRON` | `1` | Disables the scheduler entirely. The cron tools and `/loop` become unavailable, and any already-scheduled tasks stop firing |
+
+Set this environment variable when you want to prevent any scheduled task execution in a session.
+
+---
+
+## Best Practices
+
+| Practice | Rationale |
+|----------|-----------|
+| **Keep intervals reasonable** | Polling every 30 seconds wastes API tokens. Use 2-5 min for deployments, 15-30 min for PR reviews |
+| **Use for monitoring, not heavy compute** | Scheduled prompts share your session — heavy tasks block interactive use |
+| **Combine with notifications** | Pair scheduled checks with Slack or desktop notifications so you don't have to watch the terminal |
+| **Prefer `/loop` over manual polling** | Typing "check the build" every 5 minutes burns context; `/loop` keeps the prompt compact |
+| **Use one-shot reminders for known wait times** | If a deploy takes ~30 min, use `in 30 minutes check the deploy` instead of polling every 5 min |
+| **Cancel when done** | Forgotten loops consume tokens for up to 3 days. Cancel tasks once the job is finished |
+| **Avoid `:00` and `:30` for precise one-shot timing** | One-shot jitter applies at top/bottom of the hour. Pick an odd minute like `:07` if exact timing matters |
+| **Use Desktop or GitHub Actions for durable scheduling** | Session-scoped tasks die when you exit. For unattended cron, use persistent alternatives |
+
+---
+
+## Sources
+
+- [Scheduled Tasks — Claude Code Docs](https://code.claude.com/docs/en/scheduled-tasks)
+- [Skills Best Practice](claude-skills.md) — `/loop` is a bundled skill
+- [Claude Code CHANGELOG](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md)


### PR DESCRIPTION
## Summary

Adds best practice guides for 6 features referenced in README but lacking dedicated documentation:

- **`claude-hooks.md`** (306 lines) — 22 hook events, types, properties, matchers, exit codes, HTTP hooks, env vars
- **`claude-plugins.md`** (385 lines) — Plugin structure, manifest, marketplaces, configuration, official plugins catalog
- **`claude-agent-teams.md`** (270 lines) — Team architecture, display modes, task coordination, worktrees with teams
- **`claude-checkpointing.md`** (135 lines) — Shadow git commits, rewind methods, targeted summarization
- **`claude-git-worktrees.md`** (152 lines) — 3 ways to use worktrees, Boris's 5 patterns, cleanup behavior
- **`claude-scheduled-tasks.md`** (160 lines) — /loop command, cron tools, use cases, configuration

All documents follow existing style with badges, tables, back links, and sources. Content verified against official Claude Code docs.

## Test plan
- [ ] Verify all 6 files render correctly on GitHub
- [ ] Verify relative links resolve correctly
- [ ] Verify badge images load
- [ ] Check no broken markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)