### PR TITLE
Add block-no-verify as a blocking Bash PreToolUse hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,372 +1,389 @@
 {
     "permissions": {
-    "allow": [
-      "Edit(*)",
-      "Write(*)",
-      "NotebookEdit(*)",
-      "Bash",
-      "WebFetch(domain:*)",
-      "WebSearch",
-      "mcp__*",
-      "mcp__ide__*",
-      "mcp__chrome-devtools__*",
-      "mcp__claude-in-chrome__*",
-      "mcp__playwright__*",
-      "mcp__tavily-web-search__tavily_search",
-      "mcp__tavily-web-search__tavily_extract",
-      "WebFetch(domain:api.open-meteo.com)",
-      "WebFetch(domain:raw.githubusercontent.com)",
-      "WebFetch(domain:docs.anthropic.com)",
-      "WebFetch(domain:support.claude.com)"
-    ],
-    "deny": [],
-    "ask": [
-      "Bash(rm *)",
-      "Bash(rmdir *)",
-      "Bash(shred *)",
-      "Bash(unlink *)",
-      "Bash(dd *)",
-      "Bash(mkfs *)",
-      "Bash(fdisk *)",
-      "Bash(chmod *)",
-      "Bash(chown *)",
-      "Bash(git *)",
-      "Bash(gh *)",
-      "Bash(npm *)",
-      "Bash(pip *)",
-      "Bash(pip3 *)",
-      "Bash(yarn *)",
-      "Bash(pnpm *)",
-      "Bash(docker *)",
-      "Bash(kubectl *)",
-      "Bash(firebase *)",
-      "Bash(gcloud *)",
-      "Bash(curl *)",
-      "Bash(wget *)",
-      "Bash(kill *)",
-      "Bash(killall *)",
-      "Bash(pkill *)"
-    ]
-  },
-  "spinnerVerbs": {
-    "mode": "replace",
-    "verbs": ["Admiring Shayan's code", "Learning from Shayan", "Studying Shayan's patterns", "Copying Shayan's genius", "Thanking Shayan deeply", "Absorbing Shayan's wisdom", "Following Shayan's lead", "Praising Shayan's repo"]
-  },
-  "spinnerTipsOverride": {
-    "tips": [
-      "This is shayan custom tip#1",
-      "This is shayan custom tip#2"
-    ],
-    "excludeDefault": true
-  },
-  
-  "plansDirectory": "./reports",
-  "outputStyle": "Explanatory",
-  "statusLine": {
-    "type": "command",
-    "command": "echo \"shayan's best practice status line\"",
-    "padding": 0
-  },
-  "attribution": {
-    "commit": "Co-Authored-By: Claude <noreply@anthropic.com>",
-    "pr": "Generated with [Claude Code](https://claude.ai/code)"
-  },
-  "spinnerTipsEnabled": true,
-  "respectGitignore": true,
-  "env": {
-    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "80"
-  },
-  "enableAllProjectMcpServers": true,
-  "disableAllHooks": false,
-"hooks": {
-    "PreToolUse": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/hooks.py",
-            "timeout": 5000,
-            "async": true,
-            "statusMessage": "PreToolUse"
-          }
+        "allow": [
+            "Edit(*)",
+            "Write(*)",
+            "NotebookEdit(*)",
+            "Bash",
+            "WebFetch(domain:*)",
+            "WebSearch",
+            "mcp__*",
+            "mcp__ide__*",
+            "mcp__chrome-devtools__*",
+            "mcp__claude-in-chrome__*",
+            "mcp__playwright__*",
+            "mcp__tavily-web-search__tavily_search",
+            "mcp__tavily-web-search__tavily_extract",
+            "WebFetch(domain:api.open-meteo.com)",
+            "WebFetch(domain:raw.githubusercontent.com)",
+            "WebFetch(domain:docs.anthropic.com)",
+            "WebFetch(domain:support.claude.com)"
+        ],
+        "deny": [],
+        "ask": [
+            "Bash(rm *)",
+            "Bash(rmdir *)",
+            "Bash(shred *)",
+            "Bash(unlink *)",
+            "Bash(dd *)",
+            "Bash(mkfs *)",
+            "Bash(fdisk *)",
+            "Bash(chmod *)",
+            "Bash(chown *)",
+            "Bash(git *)",
+            "Bash(gh *)",
+            "Bash(npm *)",
+            "Bash(pip *)",
+            "Bash(pip3 *)",
+            "Bash(yarn *)",
+            "Bash(pnpm *)",
+            "Bash(docker *)",
+            "Bash(kubectl *)",
+            "Bash(firebase *)",
+            "Bash(gcloud *)",
+            "Bash(curl *)",
+            "Bash(wget *)",
+            "Bash(kill *)",
+            "Bash(killall *)",
+            "Bash(pkill *)"
         ]
-      }
-    ],
-    "PermissionRequest": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/hooks.py",
-            "timeout": 5000,
-            "async": true,
-            "statusMessage": "PermissionRequest"
-          }
+    },
+    "spinnerVerbs": {
+        "mode": "replace",
+        "verbs": [
+            "Admiring Shayan's code",
+            "Learning from Shayan",
+            "Studying Shayan's patterns",
+            "Copying Shayan's genius",
+            "Thanking Shayan deeply",
+            "Absorbing Shayan's wisdom",
+            "Following Shayan's lead",
+            "Praising Shayan's repo"
         ]
-      }
-    ],
-    "PostToolUse": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/hooks.py",
-            "timeout": 5000,
-            "async": true,
-            "statusMessage": "PostToolUse"
-          }
+    },
+    "spinnerTipsOverride": {
+        "tips": [
+            "This is shayan custom tip#1",
+            "This is shayan custom tip#2"
+        ],
+        "excludeDefault": true
+    },
+    "plansDirectory": "./reports",
+    "outputStyle": "Explanatory",
+    "statusLine": {
+        "type": "command",
+        "command": "echo \"shayan's best practice status line\"",
+        "padding": 0
+    },
+    "attribution": {
+        "commit": "Co-Authored-By: Claude <noreply@anthropic.com>",
+        "pr": "Generated with [Claude Code](https://claude.ai/code)"
+    },
+    "spinnerTipsEnabled": true,
+    "respectGitignore": true,
+    "env": {
+        "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "80"
+    },
+    "enableAllProjectMcpServers": true,
+    "disableAllHooks": false,
+    "hooks": {
+        "PreToolUse": [
+            {
+                "matcher": "Bash",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "npx block-no-verify@1.1.2"
+                    }
+                ]
+            },
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/hooks.py",
+                        "timeout": 5000,
+                        "async": true,
+                        "statusMessage": "PreToolUse"
+                    }
+                ]
+            }
+        ],
+        "PermissionRequest": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/hooks.py",
+                        "timeout": 5000,
+                        "async": true,
+                        "statusMessage": "PermissionRequest"
+                    }
+                ]
+            }
+        ],
+        "PostToolUse": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/hooks.py",
+                        "timeout": 5000,
+                        "async": true,
+                        "statusMessage": "PostToolUse"
+                    }
+                ]
+            }
+        ],
+        "PostToolUseFailure": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/hooks.py",
+                        "timeout": 5000,
+                        "async": true,
+                        "statusMessage": "PostToolUseFailure"
+                    }
+                ]
+            }
+        ],
+        "UserPromptSubmit": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/hooks.py",
+                        "timeout": 5000,
+                        "async": true,
+                        "statusMessage": "UserPromptSubmit"
+                    }
+                ]
+            }
+        ],
+        "Notification": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/hooks.py",
+                        "timeout": 5000,
+                        "async": true,
+                        "statusMessage": "Notification"
+                    }
+                ]
+            }
+        ],
+        "Stop": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/hooks.py",
+                        "timeout": 5000,
+                        "async": true,
+                        "statusMessage": "Stop"
+                    }
+                ]
+            }
+        ],
+        "SubagentStart": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/hooks.py",
+                        "timeout": 5000,
+                        "async": true,
+                        "statusMessage": "SubagentStart"
+                    }
+                ]
+            }
+        ],
+        "SubagentStop": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/hooks.py",
+                        "timeout": 5000,
+                        "async": true,
+                        "statusMessage": "SubagentStop"
+                    }
+                ]
+            }
+        ],
+        "PreCompact": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/hooks.py",
+                        "timeout": 5000,
+                        "async": true,
+                        "once": true,
+                        "statusMessage": "PreCompact"
+                    }
+                ]
+            }
+        ],
+        "PostCompact": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/hooks.py",
+                        "timeout": 5000,
+                        "async": true,
+                        "statusMessage": "PostCompact"
+                    }
+                ]
+            }
+        ],
+        "SessionStart": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/hooks.py",
+                        "timeout": 5000,
+                        "async": true,
+                        "once": true,
+                        "statusMessage": "SessionStart"
+                    }
+                ]
+            }
+        ],
+        "SessionEnd": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/hooks.py",
+                        "timeout": 5000,
+                        "async": true,
+                        "once": true,
+                        "statusMessage": "SessionEnd"
+                    }
+                ]
+            }
+        ],
+        "Setup": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/hooks.py",
+                        "timeout": 30000,
+                        "async": true,
+                        "statusMessage": "Setup"
+                    }
+                ]
+            }
+        ],
+        "TeammateIdle": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/hooks.py",
+                        "timeout": 5000,
+                        "async": true,
+                        "statusMessage": "TeammateIdle"
+                    }
+                ]
+            }
+        ],
+        "TaskCompleted": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/hooks.py",
+                        "timeout": 5000,
+                        "async": true,
+                        "statusMessage": "TaskCompleted"
+                    }
+                ]
+            }
+        ],
+        "ConfigChange": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/hooks.py",
+                        "timeout": 5000,
+                        "async": true,
+                        "statusMessage": "ConfigChange"
+                    }
+                ]
+            }
+        ],
+        "WorktreeCreate": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/hooks.py",
+                        "timeout": 5000,
+                        "async": true,
+                        "statusMessage": "WorktreeCreate"
+                    }
+                ]
+            }
+        ],
+        "WorktreeRemove": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/hooks.py",
+                        "timeout": 5000,
+                        "async": true,
+                        "statusMessage": "WorktreeRemove"
+                    }
+                ]
+            }
+        ],
+        "InstructionsLoaded": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/hooks.py",
+                        "timeout": 5000,
+                        "async": true,
+                        "statusMessage": "InstructionsLoaded"
+                    }
+                ]
+            }
+        ],
+        "Elicitation": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/hooks.py",
+                        "timeout": 5000,
+                        "async": true,
+                        "statusMessage": "Elicitation"
+                    }
+                ]
+            }
+        ],
+        "ElicitationResult": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/hooks.py",
+                        "timeout": 5000,
+                        "async": true,
+                        "statusMessage": "ElicitationResult"
+                    }
+                ]
+            }
         ]
-      }
-    ],
-    "PostToolUseFailure": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/hooks.py",
-            "timeout": 5000,
-            "async": true,
-            "statusMessage": "PostToolUseFailure"
-          }
-        ]
-      }
-    ],
-    "UserPromptSubmit": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/hooks.py",
-            "timeout": 5000,
-            "async": true,
-            "statusMessage": "UserPromptSubmit"
-          }
-        ]
-      }
-    ],
-    "Notification": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/hooks.py",
-            "timeout": 5000,
-            "async": true,
-            "statusMessage": "Notification"
-          }
-        ]
-      }
-    ],
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/hooks.py",
-            "timeout": 5000,
-            "async": true,
-            "statusMessage": "Stop"
-          }
-        ]
-      }
-    ],
-    "SubagentStart": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/hooks.py",
-            "timeout": 5000,
-            "async": true,
-            "statusMessage": "SubagentStart"
-          }
-        ]
-      }
-    ],
-    "SubagentStop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/hooks.py",
-            "timeout": 5000,
-            "async": true,
-            "statusMessage": "SubagentStop"
-          }
-        ]
-      }
-    ],
-    "PreCompact": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/hooks.py",
-            "timeout": 5000,
-            "async": true,
-            "once": true,
-            "statusMessage": "PreCompact"
-          }
-        ]
-      }
-    ],
-    "PostCompact": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/hooks.py",
-            "timeout": 5000,
-            "async": true,
-            "statusMessage": "PostCompact"
-          }
-        ]
-      }
-    ],
-    "SessionStart": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/hooks.py",
-            "timeout": 5000,
-            "async": true,
-            "once": true,
-            "statusMessage": "SessionStart"
-          }
-        ]
-      }
-    ],
-    "SessionEnd": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/hooks.py",
-            "timeout": 5000,
-            "async": true,
-            "once": true,
-            "statusMessage": "SessionEnd"
-          }
-        ]
-      }
-    ],
-    "Setup": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/hooks.py",
-            "timeout": 30000,
-            "async": true,
-            "statusMessage": "Setup"
-          }
-        ]
-      }
-    ],
-    "TeammateIdle": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/hooks.py",
-            "timeout": 5000,
-            "async": true,
-            "statusMessage": "TeammateIdle"
-          }
-        ]
-      }
-    ],
-    "TaskCompleted": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/hooks.py",
-            "timeout": 5000,
-            "async": true,
-            "statusMessage": "TaskCompleted"
-          }
-        ]
-      }
-    ],
-    "ConfigChange": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/hooks.py",
-            "timeout": 5000,
-            "async": true,
-            "statusMessage": "ConfigChange"
-          }
-        ]
-      }
-    ],
-    "WorktreeCreate": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/hooks.py",
-            "timeout": 5000,
-            "async": true,
-            "statusMessage": "WorktreeCreate"
-          }
-        ]
-      }
-    ],
-    "WorktreeRemove": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/hooks.py",
-            "timeout": 5000,
-            "async": true,
-            "statusMessage": "WorktreeRemove"
-          }
-        ]
-      }
-    ],
-    "InstructionsLoaded": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/hooks.py",
-            "timeout": 5000,
-            "async": true,
-            "statusMessage": "InstructionsLoaded"
-          }
-        ]
-      }
-    ],
-    "Elicitation": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/hooks.py",
-            "timeout": 5000,
-            "async": true,
-            "statusMessage": "Elicitation"
-          }
-        ]
-      }
-    ],
-    "ElicitationResult": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/hooks.py",
-            "timeout": 5000,
-            "async": true,
-            "statusMessage": "ElicitationResult"
-          }
-        ]
-      }
-    ]
-  }
+    }
 }


### PR DESCRIPTION
## Summary

Adds `block-no-verify@1.1.2` as the first entry in the `PreToolUse` array with a `Bash` matcher, running synchronously before the existing async `hooks.py`.

## Details

The current `PreToolUse` wildcard hook runs with `"async": true` — it cannot block a command. When an agent runs `git commit` or `git push` with the hook-bypass flag, it silently skips pre-commit hooks, commit-msg validation, and pre-push test suites.

The new entry runs synchronously (no `async` flag), reads `tool_input.command` from the Claude Code hook stdin, detects the hook-bypass flag across all git subcommands, and exits 2 to block. The existing `hooks.py` chain is preserved unchanged.

Closes #22

---

_Disclosure: I am the author and maintainer of `block-no-verify`._
