### PR TITLE
add /_learn command and learning-tour skill (MVP)

### DIFF
--- a/.claude/commands/_learn.md
+++ b/.claude/commands/_learn.md
@@ -20,7 +20,11 @@ Read the full `README.md` now. You'll need the CONCEPTS table and the Hot Featur
 
 ---
 
-## Step 2: Branch Setup
+## Step 2: Orientation + Branch Setup
+
+Output this orientation paragraph before running any git commands:
+
+> "This is a hands-on tour of the Claude Code best-practices repo. One heads-up: this repo's permission settings require confirmation for git commands — you'll see a few prompts during setup and progress tracking, just approve them. I'll run live demos with you, not just explain concepts. To personalize the tour, I have a quick 3-question survey. Your answers tell me which stops to include and how deep to go — concepts you've already used get skipped or condensed; gaps get full treatment."
 
 Run these checks in order:
 

--- a/.claude/commands/_learn.md
+++ b/.claude/commands/_learn.md
@@ -1,0 +1,53 @@
+---
+description: Start or resume a personalized learning tour of this Claude Code best-practices repo
+---
+
+# Learning Tour Entry Point
+
+Personalized, interactive tour of this Claude Code best-practices repository.
+
+## What This Command Does
+
+1. Read `README.md` — always; live source of truth for concepts and hot features
+2. Set up the `_learning-tour` branch (underscore = infrastructure branch, not a workflow)
+3. Hand off to the `learning-tour` skill with branch context
+
+---
+
+## Step 1: Read README.md
+
+Read the full `README.md` now. You'll need the CONCEPTS table and the Hot Features section (🔥) to drive the survey and stop list. Do not proceed without reading it.
+
+---
+
+## Step 2: Branch Setup
+
+Run these checks in order:
+
+```bash
+git branch --list _learning-tour
+```
+
+**If the branch does NOT exist:**
+- Run: `git checkout -b _learning-tour main`
+- Tell the user: "Created a new `_learning-tour` branch to track your progress."
+- Pass `branch_status=new` to the skill.
+
+**If the branch already exists:**
+- Run: `git checkout _learning-tour`
+- Tell the user: "Switched to your `_learning-tour` branch."
+- Pass `branch_status=existing` to the skill.
+
+---
+
+## Step 3: Invoke the Skill
+
+Use the `Skill` tool:
+
+```
+Skill("learning-tour", args: "branch_status=<new|existing> $ARGUMENTS")
+```
+
+Pass `$ARGUMENTS` through unchanged — the user may have typed `resume`, `revisit`, or nothing.
+
+The skill handles all mode detection, survey, stop sequencing, and progress tracking from here.

--- a/.claude/commands/_learn.md
+++ b/.claude/commands/_learn.md
@@ -29,7 +29,7 @@ git branch --list _learning-tour
 ```
 
 **If the branch does NOT exist:**
-- Run: `git checkout -b _learning-tour main`
+- Run: `git checkout -b _learning-tour` (branches from HEAD — preserves any in-progress work on the current branch)
 - Tell the user: "Created a new `_learning-tour` branch to track your progress."
 - Pass `branch_status=new` to the skill.
 

--- a/.claude/skills/learning-tour/SKILL.md
+++ b/.claude/skills/learning-tour/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: learning-tour
+description: Use when /_learn is invoked — personalized Claude Code best-practices tour that surveys the user's experience level, computes a stop list, runs live demos, and tracks progress on a dedicated branch.
+user-invocable: false
+allowed-tools: WebFetch, Read, Write, Edit, Bash, AskUserQuestion
+model: sonnet
+---
+
+# Learning Tour Skill
+
+Personalized tour of this Claude Code best-practices repository. Survey-first, live-demo-driven, doc-citation-disciplined.
+
+---
+
+## Source Rules (apply at every stop — read this before anything else)
+
+Training knowledge about Claude Code features can be months out of date. Fetch official docs before each stop so you're teaching from ground truth, not memory. See [`references/doc-surprises.md`](references/doc-surprises.md) for concrete examples of where training knowledge has diverged from the actual docs.
+
+**Source labeling — use one of these on every factual claim:**
+- `Per the official docs [URL]: ...`
+- `Per this repo: ...`
+- `The docs don't address this, but per this repo: ...`
+
+**WebFetch fallback:** If WebFetch fails or returns no relevant content for a concept, tell the user: "I couldn't reach the official docs for [concept] — I'll use this repo's implementation as the primary source and flag anything I'm uncertain about." Continue the stop using repo artifacts + training knowledge with explicit source labels.
+
+---
+
+## How the Tour Works
+
+The tour has 4 phases. Read [`references/phase-details.md`](references/phase-details.md) for the full instructions for each phase. This file gives you the overview.
+
+### Phase 1 — Detect Mode, Survey if New
+
+**Read `learning-tour-progress.md`** (if it exists) to determine mode:
+- No file → **init**: run survey, build stop list
+- File exists, no `completed:` date → **resume**: skip survey, go to Phase 3
+- File exists, `readme_version` ≠ current main HEAD → **refresh**: run Refresh Logic, then Phase 3
+- File exists, `readme_version` matches, `completed:` date present → **revisit**: inform user, offer to reset
+
+See [`references/phase-details.md`](references/phase-details.md) → "Phase 1" for the survey questions and `branch_status` handling.
+
+### Phase 2 — Build Stop List (init only)
+
+Compute stop order, initialize `learning-tour-progress.md`, commit to `_learning-tour` branch.
+
+See [`references/phase-details.md`](references/phase-details.md) → "Phase 2".
+
+### Phase 3 — Visit Each Stop
+
+For each pending stop (checkbox not checked):
+1. Fetch official doc via WebFetch (Source Rules above)
+2. Read the demo file from [`demos/`](demos/) — load only the file for the current stop
+3. Present the concept (familiarity: what it is + where in repo; mastery: + gotchas + when NOT to use)
+4. Run the designated live demo from the demo file — required action, not optional pointer
+5. Mastery only: ask "What would you change about this design? What are its limits?"
+6. Mark stop complete in progress file → commit → ask "next stop or go deeper?"
+
+**Available demo files:** `checkpointing.md`, `commands-skills.md`, `subagents.md`
+For stops without a demo file yet, present the concept from docs + repo artifacts and note that a demo file hasn't been written yet.
+
+See [`references/phase-details.md`](references/phase-details.md) → "Phase 3" for per-stop depth guidance.
+
+### Phase 4 — Completion
+
+Write completion date, commit, show gap map.
+
+See [`references/phase-details.md`](references/phase-details.md) → "Phase 4".
+
+---
+
+## Progress File
+
+The progress file lives at `learning-tour-progress.md` in the repo root (not in `.claude/` — that would trigger permission prompts). It is committed to `_learning-tour` branch only.
+
+See [`references/progress-schema.md`](references/progress-schema.md) for the full schema, stop list, and refresh logic.

--- a/.claude/skills/learning-tour/demos/checkpointing.md
+++ b/.claude/skills/learning-tour/demos/checkpointing.md
@@ -1,0 +1,29 @@
+# Demo: Checkpointing
+
+## Repo Artifact
+
+No specific file to open — checkpointing is a runtime feature of the Claude Code session itself. The demo is interactive.
+
+## Steps
+
+1. Make a small, visible edit to any file (e.g., add a comment to `README.md`)
+2. Press `Esc Esc` to open the checkpoint menu
+3. Walk through all 5 rewind actions with the user:
+   - **Restore previous checkpoint** — undoes the last Claude turn
+   - **Fork from here** — creates a new conversation branch from this point
+   - **Summarize from here** — targeted `/compact` that preserves early context intact (this one surprises people)
+   - **Branch to new task** — starts a parallel track without losing current context
+   - **Compare checkpoints** — shows a diff between two points in time
+4. Undo the edit you made in step 1 (restore or manually revert)
+
+## Expected "Why Does This Exist?" Question
+
+**"What doesn't get tracked?"**
+
+Answer: Only Claude's file-editing tools (Write, Edit, NotebookEdit) are tracked. Bash commands — `rm`, `mv`, `cp`, package installs, database migrations — are **not** tracked. If you run `rm -rf dist/` via Bash, checkpointing cannot rewind that. This is why the docs recommend keeping destructive Bash operations minimal and preferring Claude's file tools where possible.
+
+## Mastery Follow-up
+
+"If checkpointing only tracks file edits, not Bash side-effects, what kinds of tasks are risky to run without a manual git commit first?"
+
+Good answers: database schema changes, package installs that modify `node_modules`, build artifacts written via shell scripts. The broader insight: checkpointing is a conversation-level undo, not a full system snapshot.

--- a/.claude/skills/learning-tour/demos/commands-skills.md
+++ b/.claude/skills/learning-tour/demos/commands-skills.md
@@ -1,0 +1,32 @@
+# Demo: Commands + Skills
+
+## Repo Artifact
+
+`.claude/commands/weather-orchestrator.md` + run the command live.
+
+## Steps
+
+1. Open `.claude/commands/weather-orchestrator.md` and read it together with the user. Point out:
+   - The command is only 46 lines and does zero logic — it asks a question, calls an agent, calls a skill
+   - The `model: haiku` frontmatter — commands can specify which model runs them
+   - The `Skill("weather-svg-creator")` invocation — this is how commands hand off to skills
+
+2. Run `/weather-orchestrator` live. Let it complete fully.
+
+3. After it finishes, open `.claude/skills/weather-svg-creator/SKILL.md`. Ask: "What did the command do that the skill couldn't do for itself?"
+
+   The answer: the command owns the *workflow* (ask → fetch → create). The skill owns *one step* (create the SVG given a temperature). The skill is reusable by anything that needs an SVG card; the command is the opinionated end-to-end entry point.
+
+4. Show `.claude/skills/learning-tour/SKILL.md` as a contrast: this skill is much larger and uses reference files. Point out the `references/` directory pattern — same progressive disclosure, different scale.
+
+## Expected "Why Does This Exist?" Question
+
+**"Why does the weather agent need to exist at all? Why not just have the command fetch the weather directly?"**
+
+Answer: The agent has capabilities the command doesn't — it has a preloaded skill (`weather-fetcher`) embedded in its context via the `skills:` frontmatter field, its own `model`, `maxTurns`, `permissionMode`, and `memory`. An agent has **persistent identity** across its turns; a command just runs instructions in the current session. When you need isolated execution with its own tools and context, you need an agent.
+
+## Mastery Follow-up
+
+"The official docs say 'custom commands have been merged into skills.' Given that, when would you still choose a command over a skill as your entry point?"
+
+Good answer: Commands appear in the `/` autocomplete menu as first-class entry points and are designed to be user-invoked directly. Skills can be `user-invocable: false` (background knowledge, not exposed in the menu). Use a command when the thing is a workflow entry point; use a skill when it's reusable logic invoked by other things.

--- a/.claude/skills/learning-tour/demos/subagents.md
+++ b/.claude/skills/learning-tour/demos/subagents.md
@@ -1,0 +1,34 @@
+# Demo: Subagents
+
+## Repo Artifact
+
+`.claude/agents/weather-agent.md` — read while the weather-orchestrator output from the commands-skills demo is still visible (or re-run `/weather-orchestrator` first if needed).
+
+## Steps
+
+1. Open `.claude/agents/weather-agent.md`. Walk through the frontmatter fields:
+   - `skills: [weather-fetcher]` — the `weather-fetcher` skill is *preloaded* into this agent's context. The agent doesn't need to invoke it explicitly; the instructions are already there.
+   - `model: sonnet` — agents can run on a different model than the parent session
+   - `maxTurns: 5` — caps agentic loops; prevents runaway agents
+   - `permissionMode: acceptEdits` — agents can be granted different permissions than the session
+   - `memory: project` — agents can have their own persistent memory scope
+
+2. Compare with how the command invokes it:
+   ```
+   Task(subagent_type="weather-agent", ...)
+   ```
+   Point out: the `Task` tool (also called `Agent` in newer versions) is the only way to spawn a subagent. Bash commands cannot launch agents — this is a critical constraint documented in CLAUDE.md.
+
+3. Open `.claude/agents/presentation-curator.md` as a more complex example. Show the `hooks:` field and the self-evolution pattern where the agent updates its own skills after execution.
+
+## Expected "Why Does This Exist?" Question
+
+**"What does the agent have that a command doesn't?"**
+
+Answer: Persistent identity within its execution. The agent has its own model, its own permission mode, its own preloaded skills, its own memory scope, and a capped turn budget. It's an isolated subprocess with a defined contract — the parent command knows what it asked for, but the agent figures out how. This separation is what makes agents composable: you can swap the weather-agent for a different implementation without changing the command.
+
+## Mastery Follow-up
+
+"Given that agents have `maxTurns`, `permissionMode`, and `model` — when would you NOT use an agent and just put the logic directly in a command or skill?"
+
+Good answer: When the task is deterministic and single-step. Agents add overhead (spawning, context isolation) that isn't worth it for simple lookups or transformations. The weather-fetcher skill is a good example of something that doesn't need an agent — it's a single API call with no iteration. The weather-agent exists because the *orchestration* pattern (agent with preloaded skill) is being demonstrated, not because fetching weather requires an agent.

--- a/.claude/skills/learning-tour/references/doc-surprises.md
+++ b/.claude/skills/learning-tour/references/doc-surprises.md
@@ -1,0 +1,26 @@
+# Why Fetch Docs Before Each Stop
+
+This file explains why the Source Rules require fetching official docs rather than relying on training knowledge. It's context for contributors and for the model when reasoning about whether to apply the rule.
+
+## The Problem
+
+Claude's training knowledge about Claude Code features can lag the actual product by several months. A model that "knows" how checkpointing works may have learned from documentation that predates significant changes. This is especially true for:
+
+- Feature counts and option names (these change in minor releases)
+- Deprecated patterns that have been superseded
+- Newly announced conventions that postdate training
+
+## Concrete Examples
+
+These are cases where fetching docs revealed the training-knowledge answer would have been wrong:
+
+| Concept | Training-knowledge answer | What the docs actually say |
+|---------|--------------------------|---------------------------|
+| Checkpointing | "Rewind to a previous state" | 5 distinct rewind actions, including "Summarize from here" (targeted /compact that preserves early context) |
+| Checkpointing scope | (not well-specified) | Bash side-effects (rm, mv, cp) are NOT tracked — only Claude's file-editing tools (Write, Edit, NotebookEdit) |
+| Commands vs Skills | Commands are the primary extension point | "Custom commands have been merged into skills" — officially announced; commands remain as first-class menu entry points, but skills are the underlying mechanism |
+| `context: fork` | Runs skill in isolated context | Warning: only valid for skills with explicit task instructions; reference-content skills return nothing useful |
+
+## For Contributors
+
+When writing a new demo file, run `/_learn` first and note any place where the official doc differs from what you expected. Add the discrepancy to the table above — it helps calibrate future model invocations.

--- a/.claude/skills/learning-tour/references/phase-details.md
+++ b/.claude/skills/learning-tour/references/phase-details.md
@@ -27,13 +27,21 @@ Get current main HEAD hash: `git log main --oneline -1 | awk '{print $1}'`
 
 ---
 
+### Init: Orientation (output before any question)
+
+**Before asking anything**, output a short orientation paragraph — this is required, not optional:
+
+> "This is a hands-on tour of the Claude Code best-practices repo. One heads-up: this repo's permission settings require confirmation for git commands — you'll see a few prompts during setup and progress tracking, just approve them. I'll run live demos with you, not just explain concepts. To personalize the tour, I have a quick 3-question survey. Your answers tell me which stops to include and how deep to go — concepts you've already used get skipped or condensed; gaps get full treatment."
+
+---
+
 ### Init: Pre-survey (1 AskUserQuestion call)
 
 Ask the user their goal:
 
-> "What's your goal for this tour?"
-> - **Familiarity** — understand what exists, get hands-on with each concept
-> - **Mastery** — go deep on things you've only surface-level tried; focus on gotchas and design decisions
+> "First: what's your goal for this tour?
+> - **Familiarity** — understand what exists, get hands-on with each concept (recommended for most)
+> - **Mastery** — go deep on things you've surface-level tried; adds design-critique prompts after each demo and focuses on gotchas and when NOT to use each pattern"
 
 ---
 
@@ -43,12 +51,13 @@ Both questions are driven by the README.md content you already read in the comma
 
 **Q1 — CONCEPTS checklist** (present rows from README.md CONCEPTS table):
 
-- Familiarity wording: "Which of these have you tried or configured before?"
-- Mastery wording: "Which of these have you created yourself and then had to fix or extend?"
+- Familiarity wording: "Checking a concept means you've already used it — I'll skip or condense that stop. Which of these have you tried or configured before? (check all that apply · use ← → to navigate pages · ignore 'Type something')"
+- Mastery wording: "Checking a concept means you've already extended or debugged it — I'll skip or cover it briefly. Which of these have you created yourself and then had to fix or extend? (check all that apply · use ← → to navigate pages · ignore 'Type something')"
+- **Limit to 8 rows max per message.** If the CONCEPTS table has more than 8 rows, split into two AskUserQuestion calls, grouping by theme (e.g., "core config" then "workflow / orchestration"). Label each group clearly.
 
 **Q2 — Hot Features checklist** (present rows from README.md 🔥 Hot section):
 
-"Which of these have you tried?"
+"Checked = tried, unchecked = we'll demo it. Which of these have you tried? (check all that apply · use ← → to navigate pages · ignore 'Type something')"
 
 Record answers as concept levels and hot feature tried/no status. These drive skip thresholds in Phase 2.
 
@@ -74,7 +83,7 @@ Iterate through stops in file order. For each stop where the top-level checkbox 
 
 **1. Fetch official docs**
 
-WebFetch from `https://code.claude.ai/docs/` — search for the concept page. If that root doesn't work, try `https://docs.anthropic.com/en/docs/claude-code/`. Apply WebFetch fallback rule from SKILL.md Source Rules if fetch fails.
+WebFetch from `https://code.claude.com/docs/en/` — the canonical Claude Code docs domain. Construct URLs as `https://code.claude.com/docs/en/<concept-slug>` (e.g., `https://code.claude.com/docs/en/sub-agents`). Apply WebFetch fallback rule from SKILL.md Source Rules if fetch fails.
 
 **2. Load demo file**
 

--- a/.claude/skills/learning-tour/references/phase-details.md
+++ b/.claude/skills/learning-tour/references/phase-details.md
@@ -1,0 +1,127 @@
+# Phase Details
+
+Full instructions for each phase of the learning tour. Read from SKILL.md as needed — no need to load this file upfront.
+
+---
+
+## Phase 1 — Detect Mode and Survey
+
+### Mode Detection
+
+Read `learning-tour-progress.md` (if it exists):
+
+| Condition | Mode |
+|-----------|------|
+| File does not exist | **init** |
+| File exists, no `completed:` date | **resume** |
+| File exists, `readme_version` ≠ current main HEAD | **refresh** |
+| File exists, `completed:` date present, readme current | **revisit** |
+
+Get current main HEAD hash: `git log main --oneline -1 | awk '{print $1}'`
+
+**If mode is resume or refresh:** skip survey; go to Phase 3 (after running Refresh Logic if refresh).
+
+**If mode is revisit:** tell the user their tour is already complete, show the gap map from Phase 4, and offer to reset a specific stop by editing its checkbox back to `[ ]`.
+
+**If branch_status=new was passed from the command:** mode must be init; no need to check.
+
+---
+
+### Init: Pre-survey (1 AskUserQuestion call)
+
+Ask the user their goal:
+
+> "What's your goal for this tour?"
+> - **Familiarity** — understand what exists, get hands-on with each concept
+> - **Mastery** — go deep on things you've only surface-level tried; focus on gotchas and design decisions
+
+---
+
+### Init: Survey (2 AskUserQuestion calls)
+
+Both questions are driven by the README.md content you already read in the command — do not hardcode topic lists.
+
+**Q1 — CONCEPTS checklist** (present rows from README.md CONCEPTS table):
+
+- Familiarity wording: "Which of these have you tried or configured before?"
+- Mastery wording: "Which of these have you created yourself and then had to fix or extend?"
+
+**Q2 — Hot Features checklist** (present rows from README.md 🔥 Hot section):
+
+"Which of these have you tried?"
+
+Record answers as concept levels and hot feature tried/no status. These drive skip thresholds in Phase 2.
+
+---
+
+## Phase 2 — Build Stop List (init only)
+
+1. For each CONCEPTS row not meeting skip threshold: add as a stop
+2. Append Hot Features as the final stop (always; scope to untried rows from Q2)
+3. Order stops respecting `recommended_first` — encode inline on each stop entry (see progress-schema.md)
+4. If mastery goal: add sub-bullet milestones to each stop
+5. Get `readme_version`: `git log main --oneline -1 | awk '{print $1}'`
+6. Write `learning-tour-progress.md` to repo root with full schema (see progress-schema.md)
+7. Stage and commit: `git add learning-tour-progress.md && git commit -m "learning-tour: initialize progress"`
+
+---
+
+## Phase 3 — Visit Each Stop
+
+Iterate through stops in file order. For each stop where the top-level checkbox is `[ ]`:
+
+### Per-stop sequence
+
+**1. Fetch official docs**
+
+WebFetch from `https://code.claude.ai/docs/` — search for the concept page. If that root doesn't work, try `https://docs.anthropic.com/en/docs/claude-code/`. Apply WebFetch fallback rule from SKILL.md Source Rules if fetch fails.
+
+**2. Load demo file**
+
+Read the corresponding file from `demos/` for the current stop. Only read the file you need — progressive disclosure means not loading all demos upfront.
+
+| Stop | Demo file |
+|------|-----------|
+| Checkpointing | `demos/checkpointing.md` |
+| Commands + Skills | `demos/commands-skills.md` |
+| Subagents | `demos/subagents.md` |
+| All others | _(no demo file yet — see note below)_ |
+
+If no demo file exists for a stop, present the concept from docs + repo artifacts. Note at the end: "A hands-on demo file for this stop hasn't been written yet — if you want to contribute one, see `demos/commands-skills.md` as a template."
+
+**3. Present concept**
+
+- **Familiarity depth**: what it is, where it lives in the repo, one concrete example
+- **Mastery depth**: everything above + gotchas + when NOT to use it + non-obvious design decisions
+
+**4. Run the live demo**
+
+Follow the demo file's Steps section exactly. The demo is a required action — not an optional "you could also try..." pointer. The live demo is where the best learning moments come from.
+
+**5. Mastery follow-up** (mastery mode only)
+
+After the demo: "What would you change about this design? What are its limits?"
+
+Let the user answer before moving on. This surfaces design intuitions the demo alone can't teach.
+
+**6. Mark progress and commit**
+
+Update the checkbox in `learning-tour-progress.md`:
+- Familiarity: change `[ ]` to `[x]` on the stop line
+- Mastery: change sub-bullet checkboxes as each milestone completes; check stop line when all sub-bullets done
+
+Commit: `git add learning-tour-progress.md && git commit -m "learning-tour: complete [Stop Name]"`
+
+Ask: "Ready for the next stop, or want to go deeper on this one?"
+
+---
+
+## Phase 4 — Completion
+
+1. Write to progress file: `completed: YYYY-MM-DD` (use today's date)
+2. Commit: `git add learning-tour-progress.md && git commit -m "learning-tour: complete"`
+3. Show gap map — full Concepts table with current levels:
+   - Toured stops (with `[x]`)
+   - Skipped stops and why (level was already high enough)
+   - Stops available to revisit
+4. Tell the user how to revisit a skipped stop: edit `learning-tour-progress.md`, change `[x]` back to `[ ]` on the desired stop, then run `/_learn`.

--- a/.claude/skills/learning-tour/references/phase-details.md
+++ b/.claude/skills/learning-tour/references/phase-details.md
@@ -27,14 +27,6 @@ Get current main HEAD hash: `git log main --oneline -1 | awk '{print $1}'`
 
 ---
 
-### Init: Orientation (output before any question)
-
-**Before asking anything**, output a short orientation paragraph — this is required, not optional:
-
-> "This is a hands-on tour of the Claude Code best-practices repo. One heads-up: this repo's permission settings require confirmation for git commands — you'll see a few prompts during setup and progress tracking, just approve them. I'll run live demos with you, not just explain concepts. To personalize the tour, I have a quick 3-question survey. Your answers tell me which stops to include and how deep to go — concepts you've already used get skipped or condensed; gaps get full treatment."
-
----
-
 ### Init: Pre-survey (1 AskUserQuestion call)
 
 Ask the user their goal:

--- a/.claude/skills/learning-tour/references/progress-schema.md
+++ b/.claude/skills/learning-tour/references/progress-schema.md
@@ -1,0 +1,98 @@
+# Progress File Schema
+
+File location: `learning-tour-progress.md` at repo root (NOT inside `.claude/`).
+Branch: `_learning-tour` only. Never commit this file to `main`.
+
+---
+
+## Full Schema
+
+```markdown
+# Learning Tour Progress
+
+## Session
+started: YYYY-MM-DD
+completed:                           ← blank until Phase 4
+readme_version: <git commit hash>    ← hash of main HEAD when README was last read
+
+## Goal
+familiarity                          ← or: mastery
+
+## Concepts
+<!-- Cached from README.md CONCEPTS table at readme_version -->
+<!-- Refresh rules below apply when readme_version ≠ current main HEAD -->
+| Concept           | Level                             |
+|-------------------|-----------------------------------|
+| Subagents         | unfamiliar / familiar / mastery   |
+| Commands          | unfamiliar / familiar / mastery   |
+| Skills            | unfamiliar / familiar / mastery   |
+| ...               | ...                               |
+
+## Hot Features
+<!-- Cached from README.md 🔥 Hot section at readme_version -->
+| Feature     | Tried     |
+|-------------|-----------|
+| Auto Mode   | yes / no  |
+| ...         | ...       |
+
+## Stops
+<!-- Order computed once at Phase 2 of first run; this file is the order authority on resume -->
+<!-- recommended_first encoded inline; command/skill follow file order, never recompute -->
+- [ ] Checkpointing
+- [ ] Memory / CLAUDE.md
+- [ ] Commands + Skills                recommended_first: none
+- [ ] Subagents                        recommended_first: Commands + Skills
+- [ ] context: fork                    recommended_first: Commands + Skills, Subagents
+- [ ] MCP Servers
+- [ ] Hooks
+- [ ] Plugins                          recommended_first: Commands + Skills, Subagents, MCP Servers
+- [ ] Hot Features                     ← always last; scoped to untried rows from Hot table
+```
+
+---
+
+## Skip Threshold
+
+**Mode is NOT a stored field.** Derive it from stop structure:
+- Stops with only top-level checkboxes → familiarity pass
+- Stops with sub-bullet milestones → mastery pass
+
+**Skip rules:**
+- Familiarity pass: skip a stop if concept `level ≥ familiar`
+- Mastery pass: skip only if `level = mastery`
+
+---
+
+## Mastery Sub-bullet Format
+
+When goal is mastery, stops include sub-bullet milestones to enable partial-stop resume:
+
+```markdown
+- [ ] Commands + Skills                recommended_first: none
+  - [ ] concept explained
+  - [ ] live demo completed
+  - [ ] gotcha discussed
+  - [ ] user articulated a design decision
+```
+
+---
+
+## Refresh Logic
+
+Run when `readme_version` ≠ `git log main --oneline -1 | awk '{print $1}'`.
+
+1. Re-read `README.md`; diff CONCEPTS and Hot rows against cached rows in progress file
+2. **New CONCEPTS row**: fetch its official doc via WebFetch; infer `recommended_first` from dependencies; insert stop at correct position; `level = unfamiliar`
+3. **Removed CONCEPTS row**: mark stop `deprecated`; drop from pending stops
+4. **Hot feature graduated to CONCEPTS**: carry `tried: yes` → `level: familiar`
+5. Update `readme_version` to current main HEAD; commit progress file
+6. Tell the user: "README has changed since your last session — N new concepts, stop list updated"
+
+---
+
+## Git Commit Messages
+
+- Initialize: `git commit -m "learning-tour: initialize progress"`
+- Per stop: `git commit -m "learning-tour: complete [Stop Name]"`
+- Refresh: `git commit -m "learning-tour: refresh stop list (readme updated)"`
+- Complete: `git commit -m "learning-tour: complete"`


### PR DESCRIPTION
This repo's README.md is a great comprehensive guide, but so full of information that I wasn't sure how to get started.

This PR adds a meta command+skill to take a user on a personalized tour through its concepts, to build familiarity (and optionally mastery).

## Summary

- Adds `/_learn` command as a thin entry point: reads README, sets up `_learning-tour` branch, invokes skill
- Adds `learning-tour` skill with survey-first personalization (familiarity vs mastery modes), progress tracking, and live demos
- MVP scope: 3 demo files written (checkpointing, commands+skills, subagents); remaining stops degrade gracefully with a contributor note

## Design decisions

- **`_` prefix convention**: `/_learn` is an infrastructure/meta command, not a workflow command like `/weather-orchestrator`
- **`_learning-tour` branch isolation**: progress file committed to a separate branch so users can `git pull` main without losing tour state
- **Progress file at repo root** (not `.claude/`): avoids permission prompts
- **Skill splits into `references/`**: SKILL.md is a ~75-line routing doc; phase logic, progress schema, and doc-surprise examples are in reference files loaded on demand
- **Mode detection in the skill, not the command**: command stays thin (~40 lines); all conditional logic lives where it can be iterated

## File layout

```
.claude/commands/_learn.md
.claude/skills/learning-tour/
  SKILL.md
  references/phase-details.md
  references/progress-schema.md
  references/doc-surprises.md
  demos/checkpointing.md
  demos/commands-skills.md
  demos/subagents.md
```

## Adding more demo files

Each demo file follows the template in `demos/commands-skills.md`: repo artifact, steps, expected question, mastery follow-up. Stops without a demo file are handled gracefully — the skill presents the concept from docs + repo artifacts and notes the gap.

Generated with [Claude Code](https://claude.ai/code)