### PR TITLE
fix: correct CLAUDE.md tip count (7→8) and total tips count (69→70)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ All major workflows converge on the same architectural pattern: **Research → P
   <img src="!/claude-jumping.svg" alt="section divider" width="60" height="50">
 </p>
 
-## 💡 TIPS AND TRICKS (69)
+## 💡 TIPS AND TRICKS (70)
 
 🚫👶 = do not babysit
 
@@ -145,7 +145,7 @@ All major workflows converge on the same architectural pattern: **Research → P
 | write detailed specs and reduce ambiguity before handing work off — the more specific you are, the better the output | [![Boris](!/tags/boris-cherny.svg)](https://x.com/bcherny/status/2017742752566632544) |
 | prototype > PRD — build 20-30 versions instead of writing specs, the cost of building is low so take many shots | [![Boris](!/tags/boris-cherny.svg)](https://youtu.be/julbw1JuAz0?t=3630) [![Video](!/tags/video.svg)](https://youtu.be/julbw1JuAz0?t=3630) |
 
-<a id="tips-claudemd"></a>■ **CLAUDE.md (7)**
+<a id="tips-claudemd"></a>■ **CLAUDE.md (8)**
 
 | Tip | Source |
 |-----|--------|


### PR DESCRIPTION
## Problem

The CLAUDE.md tips section header shows `(7)` but contains 8 tips, and the overall tip counter shows `(69)` instead of `(70)`.

This discrepancy was introduced in commit `c451a72` ("added tip related to settings.json"), which added a new tip about using `settings.json` for harness-enforced behavior (attributed to davila7) to the CLAUDE.md section, but did not update either the section count or the total count.

## Solution

- Updated `■ **CLAUDE.md (7)**` → `■ **CLAUDE.md (8)**`
- Updated `## 💡 TIPS AND TRICKS (69)` → `## 💡 TIPS AND TRICKS (70)**

## Testing

Verified by manually counting all tips in every section:

| Section | Declared | Actual |
|---------|----------|--------|
| Prompting | 3 | 3 ✓ |
| Planning/Specs | 6 | 6 ✓ |
| CLAUDE.md | 7 | **8** ← was wrong |
| Agents | 4 | 4 ✓ |
| Commands | 3 | 3 ✓ |
| Skills | 9 | 9 ✓ |
| Hooks | 5 | 5 ✓ |
| Workflows | 7 | 7 ✓ |
| Workflows Advanced | 6 | 6 ✓ |
| Git / PR | 5 | 5 ✓ |
| Debugging | 7 | 7 ✓ |
| Utilities | 5 | 5 ✓ |
| Daily | 2 | 2 ✓ |
| **Total** | **69** | **70** ← was wrong |