### PR TITLE
fix: add missing SND_SYNC flag to winsound.PlaySound to prevent sounds being cut off on Windows

### DIFF
--- a/.claude/hooks/scripts/hooks.py
+++ b/.claude/hooks/scripts/hooks.py
@@ -175,7 +175,7 @@ def play_sound(sound_name):
                         # Note: Using SND_SYNC instead of SND_ASYNC because the script exits immediately
                         # after this call, which would terminate async playback before it completes
                         winsound.PlaySound(str(file_path),
-                                         winsound.SND_FILENAME | winsound.SND_NODEFAULT)
+                                         winsound.SND_FILENAME | winsound.SND_NODEFAULT | winsound.SND_SYNC)
                         return True
                     else:
                         # winsound not available, fail silently


### PR DESCRIPTION
Closes #52

## Problem

In `.claude/hooks/scripts/hooks.py`, the `play_sound()` function calls `winsound.PlaySound` without `SND_SYNC`. The code comment explicitly states `SND_SYNC` should be used to ensure synchronous playback, but the flag is missing. Without it, `winsound.PlaySound` defaults to async mode and the sound is cut off when the script exits.

## Fix

Add `winsound.SND_SYNC` to the flags passed to `winsound.PlaySound`:

```python
winsound.PlaySound(str(file_path),
                 winsound.SND_FILENAME | winsound.SND_NODEFAULT | winsound.SND_SYNC)
```

Signed-off-by: cocoon <54054995+kuishou68@users.noreply.github.com>