### PR TITLE
fix(hooks): add SND_SYNC for Windows winsound playback

### DIFF
--- a/.claude/hooks/scripts/hooks.py
+++ b/.claude/hooks/scripts/hooks.py
@@ -174,8 +174,10 @@ def play_sound(sound_name):
                         # SND_NODEFAULT: don't play default sound if file not found
                         # Note: Using SND_SYNC instead of SND_ASYNC because the script exits immediately
                         # after this call, which would terminate async playback before it completes
-                        winsound.PlaySound(str(file_path),
-                                         winsound.SND_FILENAME | winsound.SND_NODEFAULT)
+                        winsound.PlaySound(
+                            str(file_path),
+                            winsound.SND_FILENAME | winsound.SND_SYNC | winsound.SND_NODEFAULT
+                        )
                         return True
                     else:
                         # winsound not available, fail silently

--- a/.codex/hooks/scripts/hooks.py
+++ b/.codex/hooks/scripts/hooks.py
@@ -126,8 +126,10 @@ def play_sound(sound_name):
             try:
                 if is_windows:
                     if winsound:
-                        winsound.PlaySound(str(file_path),
-                                         winsound.SND_FILENAME | winsound.SND_NODEFAULT)
+                        winsound.PlaySound(
+                            str(file_path),
+                            winsound.SND_FILENAME | winsound.SND_SYNC | winsound.SND_NODEFAULT
+                        )
                         return True
                     else:
                         return False


### PR DESCRIPTION
## Summary
- add `SND_SYNC` to Windows `winsound.PlaySound` calls
- apply fix in both `.claude` and `.codex` hook script variants

## Linked issue
- closes #52