### PR TITLE
fix: add missing description frontmatter to time-orchestrator command

### DIFF
--- a/agent-teams/.claude/commands/time-orchestrator.md
+++ b/agent-teams/.claude/commands/time-orchestrator.md
@@ -1,4 +1,5 @@
 ---
+description: Fetch the current time for Dubai (GST, UTC+4) and create a visual SVG time card
 model: haiku
 ---
 


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

`agent-teams/.claude/commands/time-orchestrator.md` is missing its `description` field in the YAML frontmatter. The file currently only has:

```yaml
---
model: haiku
---
```

## Impact

Without a `description` field, Claude Code cannot surface this command in the `/` slash-command menu. The command is completely non-discoverable — users would need to know the exact name to invoke it. This is a hard requirement for all slash commands: the `description` field is what populates the command picker UI.

## Fix

Added a one-line `description` matching the command's stated purpose:

```yaml
---
description: Fetch the current time for Dubai (GST, UTC+4) and create a visual SVG time card
model: haiku
---
```

The description text is derived directly from the command body's opening sentence, so it accurately reflects what the command does.