### PR TITLE
fix: rename root research agent to resolve name collision with workflows variant

### DIFF
--- a/.claude/agents/development-workflows-research-agent.md
+++ b/.claude/agents/development-workflows-research-agent.md
@@ -1,5 +1,5 @@
 ---
-name: development-workflows-research-agent
+name: development-workflows-research-agent-root
 description: Research agent that fetches GitHub repos, counts agents/skills/commands, gets star counts, and analyzes Claude Code workflow repositories
 model: sonnet
 color: cyan


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

Two agent files declare the same `name: development-workflows-research-agent`:

| File | Scope | Tools |
|------|-------|-------|
| `.claude/agents/development-workflows-research-agent.md` | root | `Bash`, `Read`, `Write`, `Edit`, `Glob`, `Grep`, `WebFetch`, `WebSearch`, `Agent`, `NotebookEdit`, `mcp__*` |
| `.claude/agents/workflows/development-workflows-research-agent.md` | workflows | `Bash`, `Read`, `Glob`, `Grep`, `WebFetch`, `WebSearch` |

## Impact

When both scopes are active simultaneously (e.g., when running commands from the project root), Claude Code sees two agents with the same name. Whichever variant gets loaded, the outcome is wrong:

- If the root variant loads: a read-only research task gains `Write`, `Edit`, `Agent`, `NotebookEdit`, and `mcp__*` — tools the agent's own body says **must not** be used ("Do NOT modify any local files")
- If the workflows variant loads: correct behavior, but non-deterministic resolution is a latent bug

## Fix

Renamed the root agent's `name` field from `development-workflows-research-agent` to `development-workflows-research-agent-root`. This resolves the collision so that the `.claude/commands/workflows/development-workflows.md` command — which invokes `subagent_type: "development-workflows-research-agent"` — deterministically resolves to the correctly-scoped, read-only workflows variant.

The root variant still exists for direct invocation if needed, just under a distinct name.