### PR TITLE
fix: rename root time-agent to time-agent-pkt to resolve name collision

### DIFF
--- a/.claude/agents/time-agent.md
+++ b/.claude/agents/time-agent.md
@@ -1,6 +1,6 @@
 ---
-name: time-agent
-description: Use this agent to display the current time in Pakistan Standard Time (PKT, UTC+5).
+name: time-agent-pkt
+description: Use this agent to display the current time in Pakistan Standard Time (PKT, UTC+5). (root scope — see agent-teams for Dubai time)
 allowedTools:
   - "Bash(*)"
   - "Read"


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

Two agent files both declare `name: time-agent` but serve entirely different purposes:

| File | Scope | Timezone | Implementation |
|------|-------|----------|----------------|
| `.claude/agents/time-agent.md` | root | PKT (UTC+5) | Runs `TZ='Asia/Karachi' date` |
| `agent-teams/.claude/agents/time-agent.md` | agent-teams | Dubai GST (UTC+4) | Uses `time-fetcher` skill, returns structured data |

## Impact

When both scopes are active (e.g., running `agent-teams/time-orchestrator` from the project root), Claude Code sees two agents named `time-agent`. The resolution is non-deterministic:

- If the root PKT variant loads: `time-orchestrator` gets PKT time (UTC+5) instead of Dubai GST (UTC+4), breaking the SVG card output
- If the correct Dubai variant loads: works, but only by luck

The root agent also declares 10+ tools (`Write`, `Edit`, `Glob`, `Grep`, `WebFetch`, `WebSearch`, `Agent`, `NotebookEdit`, `mcp__*`) for a one-liner that only needs `Bash`.

## Fix

Renamed the root agent's `name` from `time-agent` to `time-agent-pkt`. The `agent-teams` variant retains `name: time-agent` since `time-orchestrator.md` explicitly invokes it by that name.

The root `.claude/commands/time-command.md` is not affected — it runs `TZ='Asia/Karachi' date` directly via bash, without invoking an agent.