### PR TITLE
fix: add hooks log directory to .gitignore to prevent sensitive data leakage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ plan/
 # Browser-automation verification artifacts (Playwright MCP / agent screenshots)
 .playwright-mcp/
 *-check.png
+
+# Hook event logs may contain sensitive tool input data (file contents, command args)
+.claude/hooks/logs/


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Security Finding (Low severity)

`.claude/hooks/scripts/hooks.py` (lines 325–348) logs full hook event data to `.claude/hooks/logs/hooks-log.jsonl`. The logged data includes the `tool_input` field from each hook event, which can contain:

- **File contents** passed to `Write` or `Edit` tools
- **Command arguments** passed to `Bash` tool
- **File paths** and other potentially sensitive context

The `.claude/hooks/logs/` directory was not in `.gitignore`, so a `git add .` or `git commit -a` could accidentally commit this log file and leak sensitive data into the repository history.

## Fix

Added `.claude/hooks/logs/` to `.gitignore`. This matches the existing pattern used for other generated output directories (`.playwright-mcp/`, `plan/`).

```gitignore
# Hook event logs may contain sensitive tool input data (file contents, command args)
.claude/hooks/logs/
```

This is a low-risk, no-behavior-change fix — it only prevents the log file from being tracked by git. The logging behavior itself is unchanged.