### PR TITLE
fix: pin MCP server package versions to prevent supply-chain drift

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,15 +2,24 @@
   "mcpServers": {
     "playwright": {
       "command": "npx",
-      "args": ["-y", "@playwright/mcp"]
+      "args": [
+        "-y",
+        "@playwright/mcp@0.0.70"
+      ]
     },
     "context7": {
       "command": "npx",
-      "args": ["-y", "@upstash/context7-mcp"]
+      "args": [
+        "-y",
+        "@upstash/context7-mcp@2.1.8"
+      ]
     },
     "deepwiki": {
       "command": "npx",
-      "args": ["-y", "deepwiki-mcp"]
+      "args": [
+        "-y",
+        "deepwiki-mcp@0.0.6"
+      ]
     }
   }
 }


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Security Finding (Medium severity)

`.mcp.json` configures three MCP servers using `npx -y <package>` without any version pin:

```json
"args": ["-y", "@playwright/mcp"]
"args": ["-y", "@upstash/context7-mcp"]
"args": ["-y", "deepwiki-mcp"]
```

The `-y` flag tells npx to auto-install without prompting. Without a version pin, npx installs the **latest published version** on every invocation. This means:

- A compromised package release (supply-chain attack) would auto-install silently
- A breaking API change in any of these packages would break Claude Code sessions without warning
- The environment is non-reproducible — different machines may run different versions

`deepwiki-mcp` is a lesser-known package with lower visibility, making it a higher relative supply-chain risk.

## Fix

Pinned all three packages to the current stable versions as verified against the npm registry today (2026-04-22):

| Package | Before | After |
|---------|--------|-------|
| `@playwright/mcp` | unpinned | `@playwright/mcp@0.0.70` |
| `@upstash/context7-mcp` | unpinned | `@upstash/context7-mcp@2.1.8` |
| `deepwiki-mcp` | unpinned | `deepwiki-mcp@0.0.6` |

When you want to upgrade any of these, update the pin deliberately after reviewing the changelog. This gives you control over when and what you update, rather than silently pulling in changes on every Claude Code session start.