### PR TITLE
Add recsys-pipeline-architect to SKILL COLLECTIONS

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Repos primarily known as curated libraries of `SKILL.md` files (distinct from fu
 | [awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills) | 21k | 1,100+ (curated list) |
 | [scientific-agent-skills](https://github.com/K-Dense-AI/scientific-agent-skills) | 21k | 135 |
 | [claude-skills](https://github.com/alirezarezvani/claude-skills) | 15k | 246 (across 9 domains) |
+| [recsys-pipeline-architect](https://github.com/mturac/recsys-pipeline-architect) | 0 | 1 (with 5 references + 3 runnable example scaffolds in TS/Go/Python) |
 
 <p align="center">
   <img src="!/claude-jumping.svg" alt="section divider" width="60" height="50">


### PR DESCRIPTION
Adds [recsys-pipeline-architect](https://github.com/mturac/recsys-pipeline-architect) to the *SKILL COLLECTIONS* section.

A single-skill repository for designing composable recommendation, ranking, and feed pipelines using the six-stage **Source → Hydrator → Filter → Scorer → Selector → SideEffect** framework popularized by xAI's open-sourced [For You algorithm](https://github.com/xai-org/x-algorithm).

Structure: 1 SKILL.md + 5 load-on-demand reference docs (interfaces in 4 languages, multi-action scoring, candidate isolation, filter cookbook with 12 patterns, scorer cookbook) + 3 runnable example scaffolds in different stacks (Strapi v5/TypeScript, Go with generics, Python/FastAPI — 9/9 tests passing).

MIT, independent reimplementation of the xAI pattern. v0.1.0 release tagged. Works across Claude Code, Codex, Cursor, Gemini CLI + 13 more via `npx skills add mturac/recsys-pipeline-architect`.

The repo is brand new (0 ⭐ today) — happy to be excluded if the threshold is higher; sending this in case it's a fit alongside the single-skill repos already listed (e.g., `impeccable`).