### PR TITLE
Daily settings drift check — 2026-06-03 (Claude Code v2.1.161)

### DIFF
--- a/best-practice/claude-cli-startup-flags.md
+++ b/best-practice/claude-cli-startup-flags.md
@@ -208,7 +208,7 @@ These startup-only environment variables are set in your shell before launching 
 
 | Variable | Description |
 |----------|-------------|
-| `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` | Enable experimental agent teams |
+| `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` | Enable experimental agent teams. Also env-configurable — see [Settings Reference](./claude-settings.md#environment-variables) |
 | `CLAUDE_CODE_TMPDIR` | Override temp directory for internal files. Also configurable via `env` key — see [Settings Reference](./claude-settings.md#environment-variables-via-env) |
 | `CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD=1` | Enable additional directory CLAUDE.md loading |
 | `DISABLE_AUTOUPDATER=1` | Disable auto-updates. Also configurable via `env` key — see [Settings Reference](./claude-settings.md#environment-variables-via-env) |

--- a/best-practice/claude-settings.md
+++ b/best-practice/claude-settings.md
@@ -1,9 +1,9 @@
 # Settings Best Practice
 
-![Last Updated](https://img.shields.io/badge/Last_Updated-Jun%2002%2C%202026%2010%3A48%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.160-blue?style=flat&labelColor=555)<br>
+![Last Updated](https://img.shields.io/badge/Last_Updated-Jun%2003%2C%202026%2010%3A48%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.161-blue?style=flat&labelColor=555)<br>
 [![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../.claude/settings.json)
 
-A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.160, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
+A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.161, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
 
 <table width="100%">
 <tr>
@@ -851,7 +851,7 @@ Set environment variables for all Claude Code sessions.
 | `ANTHROPIC_DEFAULT_HAIKU_MODEL_DESCRIPTION` | Customize the Haiku entry description in the `/model` picker. Defaults to `Custom model (<model-id>)` |
 | `ANTHROPIC_DEFAULT_HAIKU_MODEL_SUPPORTED_CAPABILITIES` | Override capability detection for a pinned Haiku model. Comma-separated values (e.g., `effort,thinking`). Required when the pinned model supports features the auto-detection cannot confirm |
 | `CLAUDECODE` | Set to `1` in shell environments Claude Code spawns (Bash tool, tmux sessions). Not set in hooks or status line commands. Use to detect when a script is running inside a Claude Code shell |
-| `CLAUDE_CODE_SESSION_ID` | Read-only. Set automatically in Bash and PowerShell tool subprocesses to the current session ID. Matches the `session_id` field passed to hooks. Updated on `/clear`. Use to correlate scripts and external tools with the Claude Code session that launched them (v2.1.132) |
+| `CLAUDE_CODE_SESSION_ID` | Read-only. Set automatically in Bash and PowerShell tool subprocesses to the current session ID. Matches the `session_id` field passed to hooks. Updated on `/clear`. Use to correlate scripts and external tools with the Claude Code session that launched them (v2.1.132) *(not in official docs — unverified; read-only, injected into subprocess env)* |
 | `AI_AGENT` | Set automatically by Claude Code in subprocess environments (Bash tool, hooks, MCP stdio servers). Generic flag identifying the parent process as an AI agent — useful for tools that adapt behavior when invoked from any AI agent rather than checking each agent-specific variable like `CLAUDECODE` *(in v2.1.120 changelog, not yet on official env-vars page)* |
 | `CLAUDE_CODE_SKIP_FAST_MODE_NETWORK_ERRORS` | Set to `1` to allow fast mode when the organization status check fails due to a network error. Useful when a corporate proxy blocks the status endpoint |
 | `CLAUDE_CODE_USE_BEDROCK` | Use AWS Bedrock (`1` to enable) |
@@ -900,7 +900,7 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_GLOB_HIDDEN` | Set to `false` to exclude dotfiles from results when Claude invokes the Glob tool. Included by default. Does not affect `@` file autocomplete, `ls`, Grep, or Read |
 | `CLAUDE_CODE_GLOB_NO_IGNORE` | Set to `false` to make the Glob tool respect `.gitignore` patterns. By default, Glob returns all matching files including gitignored ones. Does not affect `@` file autocomplete, which has its own `respectGitignore` setting |
 | `CLAUDE_CODE_GLOB_TIMEOUT_SECONDS` | Timeout in seconds for Glob file discovery |
-| `CLAUDE_CODE_ENABLE_TASKS` | Set to `true` to enable task tracking in non-interactive mode (`-p` flag). Tasks are on by default in interactive mode |
+| `CLAUDE_CODE_ENABLE_TASKS` | Controls whether sessions use the structured Task tools (`TaskCreate`, `TaskUpdate`, `TaskGet`, `TaskList`) or the legacy `TodoWrite` tool. As of v2.1.142, Task tools are the default in all modes. Set to `0` to revert to `TodoWrite` |
 | `CLAUDE_CODE_SIMPLE` | Set to `1` to run with a minimal system prompt and only the Bash, file read, and file edit tools. Also configurable as a startup-only var — see [CLI Startup Flags](./claude-cli-startup-flags.md#environment-variables) |
 | `CLAUDE_CODE_EXIT_AFTER_STOP_DELAY` | Auto-exit SDK mode after idle duration (ms) |
 | `CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING` | Disable adaptive thinking (`1` to disable) |
@@ -926,7 +926,7 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_OPUS_4_6_FAST_MODE_OVERRIDE` | **REMOVED in v2.1.160** — the environment variable is now a no-op. Fast mode runs on the default model regardless of this variable. Previously pinned [fast mode](https://code.claude.com/docs/en/fast-mode) to Claude Opus 4.6 instead of the default (v2.1.142–v2.1.159) |
 | `CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK` | Set to `1` to disable the non-streaming fallback when a streaming request fails mid-stream. Streaming errors propagate to the retry layer instead. Useful when a proxy or gateway causes the fallback to produce duplicate tool execution (v2.1.83) |
 | `CLAUDE_ENABLE_STREAM_WATCHDOG` | Abort stalled streams (`1` to enable) |
-| `CLAUDE_CODE_ENABLE_FINE_GRAINED_TOOL_STREAMING` | Enable fine-grained tool streaming (`1` to enable) |
+| `CLAUDE_CODE_ENABLE_FINE_GRAINED_TOOL_STREAMING` | Enabled by default on the Anthropic API (v2.1.139+); set to `0` to opt out |
 | `CLAUDE_CODE_DISABLE_AUTO_MEMORY` | Disable auto memory (`1` to disable) |
 | `CLAUDE_CODE_DISABLE_FILE_CHECKPOINTING` | Disable file checkpointing for `/rewind` (`1` to disable) |
 | `CLAUDE_CODE_DISABLE_ATTACHMENTS` | Disable attachment processing (`1` to disable) |

--- a/changelog/best-practice/claude-settings/changelog.md
+++ b/changelog/best-practice/claude-settings/changelog.md
@@ -680,3 +680,16 @@
 | 3 | HIGH | Removed Env Var | Mark `CLAUDE_CODE_OPUS_4_6_FAST_MODE_OVERRIDE` as REMOVED in v2.1.160 — "the environment variable is now a no-op" per changelog | ✅ COMPLETE (marked REMOVED with no-op annotation; v2.1.160 attribution added) — RESOLVED (from 2026-06-01 v2.1.159, where it was INVALID per Rule 8A; v2.1.160 changelog now explicitly states "now a no-op") |
 | 4 | MED | Changed Description | Update `workflowKeywordTriggerEnabled` description: trigger keyword renamed from "workflow" to "ultracode" in v2.1.160 per official changelog | ✅ COMPLETE (description updated; "ultracode" keyword noted with v2.1.160 attribution) — NEW |
 | 5 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 20+ consecutive runs | ✋ ON HOLD (kept — recurring from 2026-04-14 v2.1.107) |
+
+---
+
+## [2026-06-03 10:48 AM PKT] Claude Code v2.1.161
+
+| # | Priority | Type | Action | Status |
+|---|----------|------|--------|--------|
+| 1 | HIGH | Version Bump | Update report version badge from v2.1.160 → v2.1.161 and header "As of v2.1.160" → "As of v2.1.161" | ✅ COMPLETE (badge and header updated in Phase 2.6) — NEW |
+| 2 | HIGH | Changed Description | Update `CLAUDE_CODE_ENABLE_TASKS` — official env-vars page now describes it as controlling Task tools vs legacy TodoWrite (default Task tools since v2.1.142; set to `0` to revert). Prior description referred to non-interactive mode task tracking | ✅ COMPLETE (description updated per official env-vars page) — NEW |
+| 3 | HIGH | Changed Description | Update `CLAUDE_CODE_ENABLE_FINE_GRAINED_TOOL_STREAMING` — enabled by default on Anthropic API; set to `0` to opt out. Prior description said "`1` to enable" (inverted behavior) | ✅ COMPLETE (description updated per official env-vars page) — NEW |
+| 4 | MED | Annotation Fix | Add "not in official docs — unverified" annotation to `CLAUDE_CODE_SESSION_ID` — confirmed NOT on official /en/env-vars page per Rule 5D | ✅ COMPLETE (annotation added) — NEW |
+| 5 | LOW | Ownership Boundary | `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` in both files; `claude-cli-startup-flags.md` lacks cross-reference note | ✅ COMPLETE (cross-reference note added to CLI flags file) — NEW |
+| 6 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` still changelog-only, not on official env-vars page after 23+ consecutive runs | ✋ ON HOLD (kept — recurring from 2026-04-14 v2.1.107) |


### PR DESCRIPTION
## Summary

Automated daily drift check against official Claude Code docs for **v2.1.161**. Three files changed across 3 separate commits.

v2.1.161 contains no new settings keys — only bug fixes and display improvements. All fixes in this PR are env var description corrections and metadata updates.

---

## Verification Log

| Rule | Category | Depth | Result | Notes |
|------|----------|-------|--------|-------|
| 1A | Key Completeness | field-level | PASS | All keys present |
| 1B | Key Types | content-match | PASS | All types match |
| 1C | Key Defaults | content-match | PASS | All defaults match |
| 1D | Key Descriptions | content-match | FAIL | 2 env var descriptions stale (fixed) |
| 1E | Scope Column | content-match | PASS | |
| 1F | Inverse Completeness | field-level | PASS | |
| 1G | Edge-Case Semantics | content-match | PASS | |
| 1H | File Scope Check | content-match | PASS | |
| 1I | Skills Settings Keys | field-level | PASS | |
| 2A–2D | Settings Hierarchy | field-level | PASS | |
| 3A–3D | Permissions | field-level | PASS | |
| 4A | Hooks Redirect | exists | PASS | |
| 5A | Env Var Completeness | field-level | PASS | |
| 5B | Ownership Boundary | cross-file | PARTIAL FAIL | `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` lacked cross-ref in CLI flags file (fixed) |
| 5C | Env Var Descriptions | content-match | FAIL | 2 descriptions stale (fixed) |
| 5D | Inverse Env Var Check | field-level | FAIL | `CLAUDE_CODE_SESSION_ID` missing unverified annotation (fixed) |
| 6A | Quick Reference | content-match | PASS | |
| 6B | Example URL Validation | exists | PASS | `$schema` 301 redirect working (known; leave as-is per v2.1.119 decision) |
| 7A | CLAUDE.md Sync | cross-file | PASS | |
| 8A | Source Credibility Guard | content-match | Applied throughout | 1 hallucinated key rejected (`autoMemoryClearMessageLimitPerTurn`) |
| 9A–9C | Hyperlinks | exists | PASS | All local and external links valid |
| 10A | Version Metadata | content-match | FAIL | Badge/header said v2.1.160 (fixed → v2.1.161) |
| 10B | Suspect Key Escalation | exists | ON HOLD | `OTEL_LOG_TOOL_DETAILS` — 23+ consecutive runs; no schema confirmation yet |
| 10C | Bidirectional Completeness | field-level | PARTIAL FAIL | `SESSION_ID` annotation fixed |

---

## Action Items

| # | Priority | Type | Action | Status |
|---|----------|------|--------|--------|
| 1 | HIGH | Version Bump | Update badge v2.1.160 → v2.1.161 and header text | ✅ COMPLETE — NEW |
| 2 | HIGH | Changed Description | `CLAUDE_CODE_ENABLE_TASKS` — now describes Task tools vs TodoWrite toggle (v2.1.142+) | ✅ COMPLETE — NEW |
| 3 | HIGH | Changed Description | `CLAUDE_CODE_ENABLE_FINE_GRAINED_TOOL_STREAMING` — enabled by default; set `0` to opt out | ✅ COMPLETE — NEW |
| 4 | MED | Annotation Fix | `CLAUDE_CODE_SESSION_ID` — add "not in official docs — unverified" per Rule 5D | ✅ COMPLETE — NEW |
| 5 | LOW | Ownership Boundary | `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` CLI flags entry — add cross-reference to Settings Reference | ✅ COMPLETE — NEW |
| 6 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — 23+ runs on-hold, not on official env-vars page | ✋ ON HOLD (recurring from 2026-04-14 v2.1.107) |

## Resolved Since Last Run

All 4 action items from the 2026-06-02 v2.1.160 run are confirmed resolved (badge updated, `acceptEdits` description updated, `CLAUDE_CODE_OPUS_4_6_FAST_MODE_OVERRIDE` marked REMOVED, `workflowKeywordTriggerEnabled` updated for "ultracode" keyword).

---

## Files Changed

| File | Change |
|------|--------|
| `best-practice/claude-settings.md` | Badge/header v2.1.161; `ENABLE_TASKS` description; `FINE_GRAINED_TOOL_STREAMING` description; `SESSION_ID` unverified annotation |
| `best-practice/claude-cli-startup-flags.md` | Cross-reference note on `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` |
| `changelog/best-practice/claude-settings/changelog.md` | Append 2026-06-03 v2.1.161 entry (6 items) |

---

Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_018eMtsYbMfEMpsWt5PpytxY)_