### PR TITLE
Daily settings drift check — 2026-06-05 (Claude Code v2.1.163)

### DIFF
--- a/best-practice/claude-settings.md
+++ b/best-practice/claude-settings.md
@@ -1,9 +1,9 @@
 # Settings Best Practice
 
-![Last Updated](https://img.shields.io/badge/Last_Updated-Jun%2004%2C%202026%2010%3A47%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.162-blue?style=flat&labelColor=555)<br>
+![Last Updated](https://img.shields.io/badge/Last_Updated-Jun%2005%2C%202026%2010%3A48%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.163-blue?style=flat&labelColor=555)<br>
 [![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../.claude/settings.json)
 
-A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.162, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
+A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.163, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
 
 <table width="100%">
 <tr>
@@ -60,6 +60,8 @@ Within the managed tier, precedence is: server-managed > MDM/OS-level policies >
 |-----|------|---------|-------------|
 | `parentSettingsBehavior` | string | `"first-wins"` | Controls whether managed settings supplied programmatically by an embedding host process (SDK parent) apply when an admin-deployed managed tier is also present. `"first-wins"`: parent-supplied settings are dropped and only the admin tier applies. `"merge"`: parent-supplied settings apply under the admin tier and are filtered so they can **tighten** policy but not loosen it. Requires v2.1.133+ |
 | `policyHelper` | object | - | Admin-deployed executable that computes managed settings dynamically at startup. Object shape: `{path: string}` pointing at the helper binary. Only honored from MDM or a system `managed-settings.json` file (never from user/project settings). Helper output is merged into the managed tier on every startup. Requires v2.1.136+ |
+| `requiredMinimumVersion` | string | - | **(Managed only)** Prevents Claude Code from starting if the installed version is below this floor. CLI exits with an error prompting the user to upgrade. Complements `minimumVersion` (which controls auto-update floor) — this one enforces at startup. Example: `"2.1.163"` *(in v2.1.163 changelog, not yet on official settings page)* |
+| `requiredMaximumVersion` | string | - | **(Managed only)** Prevents Claude Code from starting if the installed version exceeds this ceiling. CLI exits with an error if the version is too new. Use alongside `requiredMinimumVersion` to pin a specific version range in managed environments. Example: `"2.1.165"` *(in v2.1.163 changelog, not yet on official settings page)* |
 
 **Important**:
 - `deny` rules have highest safety precedence and cannot be overridden by lower-priority allow/ask rules.
@@ -84,7 +86,7 @@ Within the managed tier, precedence is: server-managed > MDM/OS-level policies >
 | `autoUpdatesChannel` | string | `"latest"` | Release channel: `"stable"` or `"latest"` |
 | `minimumVersion` | string | - | Prevent the auto-updater from downgrading below a specific version. Automatically set when switching to the stable channel and choosing to stay on the current version until stable catches up. Used with `autoUpdatesChannel` |
 | `alwaysThinkingEnabled` | boolean | `false` | Enable extended thinking by default for all sessions |
-| `skipWebFetchPreflight` | boolean | `false` | Skip WebFetch blocklist check before fetching URLs *(in JSON schema, not on official settings page)* |
+| `skipWebFetchPreflight` | boolean | `false` | Skip the WebFetch domain safety check that sends each requested hostname to `api.anthropic.com` before fetching. Set to `true` in environments that block outbound traffic to Anthropic, such as Bedrock, Vertex AI, or Foundry deployments with restrictive egress |
 | `availableModels` | array | - | Restrict which models users can select via `/model`, `--model`, Config tool, or `ANTHROPIC_MODEL`. Does not affect the Default option. Example: `["sonnet", "haiku"]` |
 | `fastModePerSessionOptIn` | boolean | `false` | Require users to opt in to fast mode each session |
 | `defaultShell` | string | `"bash"` | Default shell for input-box `!` commands. Accepts `"bash"` (default) or `"powershell"`. Setting `"powershell"` routes interactive `!` commands through PowerShell on Windows. Requires `CLAUDE_CODE_USE_POWERSHELL_TOOL=1` (v2.1.84). **v2.1.120:** When PowerShell is available, it is used as the fallback shell on Windows even without Git for Windows installed. **v2.1.126:** When PowerShell is enabled, it is treated as the *primary* shell instead of defaulting to Bash. PowerShell 7 detection now also covers Microsoft Store installs, MSI installs not on PATH, and `.NET` global tool installs |
@@ -884,7 +886,7 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_DISABLE_AGENT_VIEW` | Set to `1` to turn off background agents and agent view (`claude agents`, `--bg`, `/background`, on-demand supervisor). Env-var equivalent of the `disableAgentView` setting *(referenced on official settings page; not listed on the env-vars page)* |
 | `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` | Enable the experimental agent teams feature (`1` to enable). Allows spawning coordinated teams of subagents within a session |
 | `CLAUDE_CODE_DISABLE_WORKFLOWS` | Set to `1` to disable [dynamic workflows](https://code.claude.com/docs/en/workflows) (`/workflows`) and the bundled workflow slash commands. Env-var equivalent of the `disableWorkflows` setting |
-| `CLAUDE_CODE_ENABLE_AUTO_MODE` | Set to `1` to enable [auto mode](https://code.claude.com/docs/en/permissions#auto-mode) on Bedrock/Vertex/Foundry for Opus 4.7 and Opus 4.8 (v2.1.158). On the Anthropic API auto mode is available without this flag *(in v2.1.158 changelog, not yet on official env-vars page)* |
+| `CLAUDE_CODE_ENABLE_AUTO_MODE` | Set to `1` to make [auto mode](https://code.claude.com/docs/en/permission-modes#eliminate-prompts-with-auto-mode) available on Amazon Bedrock, Google Cloud Vertex AI, and Microsoft Foundry. Has no effect on the Anthropic API, where auto mode is available by default (v2.1.158) |
 | `ENABLE_TOOL_SEARCH` | MCP tool search threshold (e.g., `auto:5`) |
 | `ENABLE_PROMPT_CACHING_1H` | Opt into 1-hour prompt cache TTL. Replaces the deprecated `ENABLE_PROMPT_CACHING_1H_BEDROCK` *(in v2.1.108 changelog, not yet on official env-vars page)* |
 | `FORCE_PROMPT_CACHING_5M` | Force 5-minute prompt cache TTL *(in v2.1.108 changelog, not yet on official env-vars page)* |

--- a/changelog/best-practice/claude-settings/changelog.md
+++ b/changelog/best-practice/claude-settings/changelog.md
@@ -703,3 +703,16 @@
 | 1 | HIGH | Version Bump | Update report version badge from v2.1.161 → v2.1.162 and header "As of v2.1.161" → "As of v2.1.162" | ✅ COMPLETE (badge and header updated in Phase 2.6) — NEW |
 | 2 | HIGH | Changed Description | Update `bypassPermissions` description: report said protected paths (`.git`, `.claude`, `.vscode`, `.idea`, `.husky`) "still prompt" — official permissions page confirms all path-based prompts are now skipped. Added new exempt paths: `.config/git`, `.cargo`, `.devcontainer`, `.yarn`, `.mvn`. Only `rm -rf /` and `rm -rf ~` still prompt | ✅ COMPLETE (description corrected; new paths added; v2.1.121/v2.1.126 history preserved) — NEW |
 | 3 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` still changelog-only, not on official env-vars page after 24+ consecutive runs | ✋ ON HOLD (kept — recurring from 2026-04-14 v2.1.107) |
+
+---
+
+## [2026-06-05 10:48 AM PKT] Claude Code v2.1.163
+
+| # | Priority | Type | Action | Status |
+|---|----------|------|--------|--------|
+| 1 | HIGH | Version Bump | Update report version badge from v2.1.162 → v2.1.163 and header "As of v2.1.162" → "As of v2.1.163" | ✅ COMPLETE (badge and header updated in Phase 2.6) — NEW |
+| 2 | HIGH | New Setting | Add `requiredMinimumVersion` (managed-only) to Managed-only policy keys table — prevents CLI from starting below a specified version floor (v2.1.163 changelog) | ✅ COMPLETE (added to managed-only policy keys table with changelog annotation) — NEW |
+| 3 | HIGH | New Setting | Add `requiredMaximumVersion` (managed-only) to Managed-only policy keys table — prevents CLI from starting above a specified version ceiling (v2.1.163 changelog) | ✅ COMPLETE (added to managed-only policy keys table with changelog annotation) — NEW |
+| 4 | HIGH | Annotation Fix | Remove stale annotation from `skipWebFetchPreflight` — key is now confirmed on official settings page with full description (use case: Bedrock/Vertex/Foundry restrictive egress environments) | ✅ COMPLETE (stale annotation removed; description updated to match official docs) — NEW |
+| 5 | HIGH | Annotation Fix | Remove stale annotation from `CLAUDE_CODE_ENABLE_AUTO_MODE` — key is now confirmed on official env-vars page; description updated to match official wording and fix stale link | ✅ COMPLETE (stale annotation removed; description and link updated per official env-vars page) — NEW |
+| 6 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 25+ consecutive runs | ✋ ON HOLD (kept — recurring from 2026-04-14 v2.1.107) |


### PR DESCRIPTION
## Daily Settings Drift Report — 2026-06-05

**Audited version:** Claude Code v2.1.163 (one version ahead of previous report v2.1.162)
**Run timestamp:** 2026-06-05 10:48 AM PKT
**Sources checked:** [Settings docs](https://code.claude.com/docs/en/settings) · [Env-vars docs](https://code.claude.com/docs/en/env-vars) · [Raw CHANGELOG](https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md)

---

## Changes in this PR

### 1. New Managed-Only Settings (HIGH) — NEW

Two new keys introduced in v2.1.163 for version enforcement in managed environments:

| Key | Type | Default | Description |
|-----|------|---------|-------------|
| `requiredMinimumVersion` | string | - | Prevents CLI from starting below a specified version floor |
| `requiredMaximumVersion` | string | - | Prevents CLI from starting above a specified version ceiling |

Added to the **Managed-only policy keys** table with `*(in v2.1.163 changelog, not yet on official settings page)*` annotation.

### 2. Stale Annotation Removed — `skipWebFetchPreflight` (HIGH) — NEW

- **Before:** `Skip WebFetch blocklist check before fetching URLs *(in JSON schema, not on official settings page)*`
- **After:** `Skip the WebFetch domain safety check that sends each requested hostname to api.anthropic.com before fetching. Set to true in environments that block outbound traffic to Anthropic, such as Bedrock, Vertex AI, or Foundry deployments with restrictive egress`
- Key is now confirmed on the official settings page with a meaningful use-case description.

### 3. Stale Annotation Removed — `CLAUDE_CODE_ENABLE_AUTO_MODE` (HIGH) — NEW

- **Before:** `...*(in v2.1.158 changelog, not yet on official env-vars page)*` with stale link `#auto-mode`
- **After:** Description updated to match official env-vars page wording; link updated to `permission-modes#eliminate-prompts-with-auto-mode`
- Key is now confirmed on the official env-vars page.

### 4. Version Bump (HIGH) — NEW

- Badge: `v2.1.162` → `v2.1.163`
- Header text: `As of v2.1.162` → `As of v2.1.163`
- Last Updated: `Jun 04, 2026 10:47 AM PKT` → `Jun 05, 2026 10:48 AM PKT`

---

## Verification Log (Checklist Rules 1A–10C)

| Rule | Category | Depth | Result | Notes |
|------|----------|-------|--------|-------|
| 1A | Key Completeness | field-level | PASS | All known keys present; 2 new managed keys added |
| 1B | Key Types | content-match | PASS | All types match official docs |
| 1C | Key Defaults | content-match | PASS | All defaults match official docs |
| 1D | Key Descriptions | content-match | PASS (with fixes) | `skipWebFetchPreflight` and `CLAUDE_CODE_ENABLE_AUTO_MODE` descriptions updated |
| 1E | Scope Column | content-match | PASS | Managed-only scopes verified |
| 1F | Inverse Completeness | field-level | PASS | No orphaned keys found |
| 1G | Edge-Case Semantics | content-match | PASS | No new edge cases found |
| 1H | File Scope Check | content-match | PASS | All Display Settings confirmed in correct file scope |
| 1I | Skills Settings Keys | field-level | PASS | `maxSkillDescriptionChars`, `skillListingBudgetFraction`, `skillOverrides`, `disableSkillShellExecution` all present |
| 2A | Priority Levels | field-level | PASS | 5-level chain + managed policy intact |
| 2B | File Locations | content-match | PASS | All file paths match official docs |
| 2C | Merge Semantics | content-match | PASS | "concatenated and deduplicated" wording correct |
| 2D | Managed Internals | field-level | PASS | Drop-in directory, precedence order, Windows deprecation note all present |
| 3A | Permission Modes | field-level | PASS | All 6 modes documented |
| 3B | Tool Syntax Patterns | content-match | PASS | All patterns match official docs |
| 3C | Bidirectional Mode Check | field-level | PASS | All modes traceable to official docs |
| 3D | Evaluation Semantics | content-match | PASS | deny-first, path-prefix patterns documented |
| 4A | Hooks Redirect | exists | PASS | Redirect to claude-code-hooks repo is valid |
| 5A | Env Var Completeness | field-level | PASS | No missing env vars found on official page |
| 5B | Ownership Boundary | cross-file | PASS | No duplication between settings and CLI flags file |
| 5C | Env Var Descriptions | content-match | PASS (with fix) | `CLAUDE_CODE_ENABLE_AUTO_MODE` description updated |
| 5D | Inverse Env Var Check | field-level | PASS | All unverified vars annotated |
| 6A | Quick Reference Example | content-match | PASS | Example reflects current settings |
| 6B | Example URL Validation | exists | PASS | `json.schemastore.org` URL resolves (301 redirect to `www.schemastore.org`) |
| 7A | CLAUDE.md Sync | cross-file | PASS | CLAUDE.md hierarchy matches report |
| 8A | Source Credibility Guard | content-match | PASS | All findings from official sources only |
| 9A | Local File Links | exists | PASS | `../.claude/settings.json`, `../` both resolve |
| 9B | External URL Links | exists | PASS | All 6 Sources links valid; `permission-modes` and `monitoring-usage` pages confirmed |
| 9C | Anchor Links | exists | PASS | All 12 TOC anchors match headings in file |
| 10A | Version Metadata | content-match | PASS (after fix) | Badge updated to v2.1.163 |
| 10B | Suspect Key Escalation | exists | ON HOLD | `OTEL_LOG_TOOL_DETAILS` — 25th consecutive run, no resolution yet (requires maintainer decision) |
| 10C | Bidirectional Completeness | field-level | PASS | All keys traceable to official source or annotated |

---

## Hyperlink Validation Log

| # | Type | Link | Status | Notes |
|---|------|------|--------|-------|
| 1 | Local | `../.claude/settings.json` | OK | File exists |
| 2 | Local | `../` | OK | Root directory exists |
| 3 | External | `https://code.claude.com/docs/en/settings` | OK | Fetched successfully |
| 4 | External | `https://code.claude.com/docs/en/env-vars` | OK | Fetched successfully |
| 5 | External | `https://code.claude.com/docs/en/permissions` | OK | Valid page |
| 6 | External | `https://code.claude.com/docs/en/permission-modes` | OK | Confirmed — has `#eliminate-prompts-with-auto-mode` |
| 7 | External | `https://code.claude.com/docs/en/monitoring-usage` | OK | Fetched successfully |
| 8 | External | `https://json.schemastore.org/claude-code-settings.json` | OK (redirect) | 301 → `www.schemastore.org`; schema valid |
| 9 | External | `https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md` | OK | Raw version fetched |
| 10 | External | `https://github.com/feiskyer/claude-code-settings` | OK | Confirmed in research phase |
| 11 | External | `https://platform.claude.com/docs/en/manage-claude/workload-identity-federation` | OK | Confirmed in research phase |
| 12 | Anchor | `#settings-hierarchy` through `#useful-commands` (12 TOC links) | OK | All headings present |

---

## Priority Actions Summary

| # | Priority | Type | Action | Status |
|---|----------|------|--------|--------|
| 1 | HIGH | Version Bump | Update badge and header v2.1.162 → v2.1.163 | ✅ COMPLETE — NEW |
| 2 | HIGH | New Setting | Add `requiredMinimumVersion` to managed-only policy keys table | ✅ COMPLETE — NEW |
| 3 | HIGH | New Setting | Add `requiredMaximumVersion` to managed-only policy keys table | ✅ COMPLETE — NEW |
| 4 | HIGH | Annotation Fix | Remove stale annotation from `skipWebFetchPreflight`; update description | ✅ COMPLETE — NEW |
| 5 | HIGH | Annotation Fix | Remove stale annotation from `CLAUDE_CODE_ENABLE_AUTO_MODE`; update description and link | ✅ COMPLETE — NEW |
| 6 | LOW | Suspect Key | `OTEL_LOG_TOOL_DETAILS` — 25th consecutive ON HOLD run | ✋ ON HOLD — RECURRING (first seen: 2026-04-14 v2.1.107) |

## Resolved Since Last Run

All 3 items from the 2026-06-04 v2.1.162 run were already COMPLETE. No outstanding items carried forward.

---

*Generated by unattended daily drift checker — do not merge without review.*

---
_Generated by [Claude Code](https://claude.ai/code/session_01UJ3TPtzNjDfsb1z9P5iRA1)_