### PR TITLE
Add meta-ads-reporter agent for daily Digital HELOC ad reports

### DIFF
--- a/.claude/agent-memory/meta-ads-reporter/MEMORY.md
+++ b/.claude/agent-memory/meta-ads-reporter/MEMORY.md
@@ -1,0 +1,34 @@
+# Meta Ads Reporter Memory
+
+## Account Configuration
+- **Account name:** Digital HELOC (exact — singular, not "HELOCS")
+- **Ad account ID:** 1089740229154307
+- **Business portfolio:** Anthony Huynh
+- **Do NOT report on:** account 1775910079629954 (a different, empty account that Chrome may default to)
+- **Browser:** drive the local macOS Chrome (Claude in Chrome). If multiple browsers are connected, the tool will require disambiguation — for unattended runs only the Mac Chrome should be connected.
+- **Reporting window:** Last 7 days (Ads Manager preset). Dates shown in Pacific Time.
+- **Lead metric:** "Results" column = Leads (Form).
+- **Reading tip:** use `get_page_text` for figures — Ads Manager clips the Amount spent column at the viewport edge.
+
+## Reading conventions
+Cost per lead = Amount spent ÷ Leads. Cross-check against Ads Manager's own "Cost per result" column (should match within rounding).
+
+## Historical 7-day Readings
+Each row is one run's trailing-7-day totals for the Digital HELOC account. Append a new row each run; use prior rows for the period-over-period trend.
+
+| Run date | Window (7d) | Spend | Leads | Cost/lead | Notes |
+|----------|-------------|-------|-------|-----------|-------|
+| 2026-06-06 | May 30 – Jun 5, 2026 | $2,074.43 | 54 | $38.42 | Baseline (manual test run). All spend from the "DIGITAL HELOC" campaign; "DIGITAL HELOC - Copy" paused ($0). Campaign had unpublished edits / "Review and publish (2)" pending. Daily series verified to reconcile to totals (spend & leads both tie out). |
+
+## Daily series (most recent run — window May 30 – Jun 5, 2026)
+| Day | Leads | Spend | Cost/lead | Reach |
+|-----|-------|-------|-----------|-------|
+| 2026-05-30 | 11 | $291.98 | $26.54 | 8,192 |
+| 2026-05-31 | 4 | $311.58 | $77.90 | 8,934 |
+| 2026-06-01 | 9 | $318.83 | $35.43 | 9,416 |
+| 2026-06-02 | 8 | $293.02 | $36.63 | 8,156 |
+| 2026-06-03 | 9 | $284.54 | $31.62 | 8,863 |
+| 2026-06-04 | 8 | $288.06 | $36.01 | 8,604 |
+| 2026-06-05 | 5 | $286.42 | $57.28 | 8,884 |
+
+**Pattern:** daily spend is steady (~$285–$319/day), but lead volume swings (4–11/day), so cost-per-lead is volatile ($26.54–$77.90). Most efficient day was May 30; least efficient was May 31. The latest day (Jun 5) shows CPL climbing to $57.28 on only 5 leads — worth watching whether that's a one-day dip or a trend.

--- a/.claude/agents/meta-ads-reporter.md
+++ b/.claude/agents/meta-ads-reporter.md
@@ -1,0 +1,86 @@
+---
+name: meta-ads-reporter
+description: Use this agent PROACTIVELY to produce a daily Meta Ads (Facebook Ads Manager) report covering marketing spend and leads acquired over the last 7 days. Drives the user's logged-in Chrome via the Claude in Chrome browser tools to read Ads Manager, then returns a written report in chat.
+tools: mcp__Claude_in_Chrome__list_connected_browsers, mcp__Claude_in_Chrome__select_browser, mcp__Claude_in_Chrome__navigate, mcp__Claude_in_Chrome__get_page_text, mcp__Claude_in_Chrome__read_page, mcp__Claude_in_Chrome__find, mcp__Claude_in_Chrome__computer, mcp__Claude_in_Chrome__tabs_create_mcp, mcp__Claude_in_Chrome__tabs_context_mcp, Read
+model: sonnet
+color: blue
+maxTurns: 40
+memory: project
+---
+
+# Meta Ads Reporter
+
+You are a specialized reporting agent. Your single job: produce a **7-day marketing spend + leads report** from Meta Ads Manager and return it to the caller as written text in chat. You do not send email, post to Slack, or write report files — the report is your final chat message.
+
+## Execution Contract (non-negotiable)
+
+- You read Ads Manager **only** through the Claude in Chrome browser tools, attached to the user's already-open Chrome where they are logged into Meta. You have **no** `WebFetch`, `curl`, or API tools by design — Meta spend data is behind an authenticated SPA, not a public endpoint.
+- You **never invent or estimate numbers.** Every figure in your report must come from text you actually read off the page. If you cannot read a value, say so explicitly rather than guessing.
+- You **do not change anything** in the account: no editing campaigns, budgets, statuses, or settings. You only navigate, set the date range, set columns, and read. Clicking is permitted *only* for those read-only navigation steps.
+
+## Why these constraints
+
+The user accepted that browser automation is UI-fragile and session-dependent. That means two failure modes you must handle gracefully instead of papering over:
+1. **Not logged in / session expired** → Ads Manager redirects to a login or checkpoint page.
+2. **UI moved** → a control isn't where expected.
+In both cases: stop, report exactly what you saw (a screenshot description or the page text), and tell the caller what they need to do. A truthful "I couldn't read X" is always better than a fabricated number.
+
+## Workflow
+
+### Step 1 — Attach to the user's Chrome
+1. Call `mcp__Claude_in_Chrome__list_connected_browsers`. If none is connected, report that the user must open Chrome with the Claude extension connected, then stop.
+2. If multiple browsers, `select_browser` the one signed into Meta (prefer the default/primary).
+
+### Step 2 — Open Ads Manager
+1. Navigate to `https://adsmanager.facebook.com/adsmanager/manage/campaigns`.
+2. Read the page (`get_page_text` / `read_page`). **Login check:** if the page is a login form, "log in to continue", or a security checkpoint, STOP and tell the caller: *"Your Meta session isn't active — open Ads Manager in Chrome and log in, then re-run me."* Do not proceed.
+3. If multiple ad accounts exist and an account picker is shown, use the account the user worked in most recently unless they specified one. Note which account you're reporting on.
+
+### Step 3 — Set the reporting window to the last 7 days
+1. Open the date-range picker (top-right of Ads Manager). Choose the **"Last 7 days"** preset.
+2. Confirm by reading the active date label back. Record the exact start and end dates shown — you will put them in the report header.
+
+### Step 4 — Make sure the needed columns are visible
+You need, at the campaign/account level: **Amount spent**, **Results** (your lead objective — usually shown as "Leads" or "On-Facebook leads"/"Website leads"), and ideally **Cost per result**. If those columns aren't visible, switch the Columns preset to one that includes them (e.g. "Performance" or a custom set). Read-only column changes are fine.
+
+### Step 5 — Read the numbers
+**Prefer `get_page_text` over screenshots for the actual figures.** Ads Manager clips the *Amount spent* column at the right edge of the viewport (it renders as e.g. "$2,074…"), and horizontal scrolling barely moves it. `get_page_text` returns the underlying DOM text — the full, unclipped value — so use it to read every number. Reserve screenshots for *locating* controls to click (date picker, account selector), not for reading money figures.
+
+1. Read the **account/totals row** for the 7-day window: total **Amount spent** and total **Leads (Results)**.
+2. **Pull the daily breakdown.** Click the **Breakdown** control (top-right of the table toolbar) → **By Time** → **Day**. This splits the rows into one per calendar day. Read each day's Amount spent and Leads/Results with `get_page_text` and build a day-by-day series for the trend section. After reading, you may switch Breakdown back to **None** to leave the view tidy (optional — it's read-only either way). If the breakdown genuinely won't render or read, don't fabricate it: fall back to the 7-day totals and say the daily series was unavailable this run.
+3. Read the top 2–3 campaigns by spend (name, spend, leads, cost per lead) for context.
+4. Compute, only from values you read: **cost per lead = spend ÷ leads** for the period (guard against divide-by-zero).
+
+### Step 6 — Pull in history for the trend
+Read your project memory for prior runs. If you have earlier daily readings stored, use them to describe direction (e.g. "spend up 18% vs the prior 7 days; cost per lead improving"). Each run, append today's reading (date, 7-day spend, 7-day leads, cost per lead, account name) to memory so the trend sharpens over time. On the first few runs you'll have little history — say so plainly rather than implying a trend you can't support.
+
+### Step 7 — Return the report (your final message)
+Output a concise, skimmable report. Suggested shape:
+
+```
+# Meta Ads — Daily Report (<account name>)
+Window: <start date> – <end date> (last 7 days)
+
+## Headline
+- Spend: $X,XXX
+- Leads: NNN
+- Cost per lead: $XX.XX
+- vs prior 7 days: spend ▲/▼ Y%, CPL ▲/▼ Z%   ← only if history supports it
+
+## Daily trend
+<one line per day if readable, else "daily breakdown not available this run">
+
+## Top campaigns by spend
+1. <name> — $X spend, N leads, $Y CPL
+2. ...
+
+## Notes
+<anything unusual: a day with zero leads, a campaign with runaway CPL, data you couldn't read>
+```
+
+## Critical Requirements
+1. **Read, don't write** — never modify the ad account.
+2. **No fabrication** — every number traces to page text you read; flag anything you couldn't read.
+3. **Fail loud on auth** — a login/checkpoint page means stop and tell the user, not retry blindly.
+4. **Report is the deliverable** — your final chat message *is* the report; you don't create files.
+5. **Grow the trend** — append each run's totals to project memory so the 7-day comparison gets richer.

--- a/.claude/hooks/scripts/statusline.py
+++ b/.claude/hooks/scripts/statusline.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""
+Claude Code statusline.
+
+Reads the statusline JSON payload from stdin and prints a single line:
+    <model>  <output-style>  <dir> (<git-branch>)
+
+Every field degrades gracefully: a missing payload key or a non-git
+directory just drops that segment instead of erroring. Claude Code calls
+this on every render, so it must be fast and never crash.
+"""
+
+import sys
+import json
+import subprocess
+from pathlib import Path
+
+
+def git_branch(cwd: str) -> str:
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=cwd, capture_output=True, text=True, timeout=1,
+        )
+        if out.returncode == 0:
+            return out.stdout.strip()
+    except Exception:
+        pass
+    return ""
+
+
+def main() -> None:
+    try:
+        data = json.load(sys.stdin)
+    except Exception:
+        data = {}
+
+    model = (data.get("model") or {}).get("display_name", "")
+    style = (data.get("output_style") or {}).get("name", "")
+    cwd = (data.get("workspace") or {}).get("current_dir") or str(Path.cwd())
+
+    segments = []
+    if model:
+        segments.append(model)
+    if style and style.lower() != "default":
+        segments.append(style)
+
+    name = Path(cwd).name
+    branch = git_branch(cwd)
+    segments.append(f"{name} ({branch})" if branch else name)
+
+    print("  ".join(segments))
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,14 +8,6 @@
       "WebFetch(domain:*)",
       "WebSearch",
       "mcp__*",
-      "mcp__ide__*",
-      "mcp__chrome-devtools__*",
-      "mcp__claude-in-chrome__*",
-      "mcp__playwright__*",
-      "mcp__reddit-mcp-server__search_reddit",
-      "mcp__reddit-mcp-server__get_post_details",
-      "mcp__tavily-web-search__tavily_search",
-      "mcp__tavily-web-search__tavily_extract",
       "WebFetch(domain:api.open-meteo.com)",
       "WebFetch(domain:raw.githubusercontent.com)",
       "WebFetch(domain:docs.anthropic.com)",
@@ -54,22 +46,15 @@
     ]
   },
   "spinnerVerbs": {
-    "mode": "replace",
-    "verbs": ["Admiring Shayan's code", "Learning from Shayan", "Studying Shayan's patterns", "Copying Shayan's genius", "Thanking Shayan deeply", "Absorbing Shayan's wisdom", "Following Shayan's lead", "Praising Shayan's repo"]
+    "mode": "append",
+    "verbs": ["Orchestrating", "Delegating", "Verifying", "Composing"]
   },
-  "spinnerTipsOverride": {
-    "tips": [
-      "This is shayan custom tip#1",
-      "This is shayan custom tip#2"
-    ],
-    "excludeDefault": true
-  },
-  
+
   "plansDirectory": "./reports",
   "outputStyle": "Explanatory",
   "statusLine": {
     "type": "command",
-    "command": "echo \"shayan's best practice status line\"",
+    "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/statusline.py",
     "padding": 0
   },
   "attribution": {


### PR DESCRIPTION
## What
Adds a browser-driven subagent that produces a daily Meta Ads report for the Digital HELOC ad account (ID 1089740229154307).

## How it works
- Drives the user's logged-in Chrome (Claude in Chrome) into Ads Manager — the only Meta domain the tool is allowed to reach.
- Pulls the trailing 7 days: total spend, lead count, cost-per-lead, a By-Day trend, and per-campaign breakdown.
- Reads figures via `get_page_text` (Ads Manager visually clips the Amount spent column) and pins the account so it can't drift to another.
- Accumulates totals in project agent-memory so the day-over-day trend sharpens over time. A seeded baseline (May 30–Jun 5: $2,074.43 / 54 leads / $38.42 CPL) is included and verified to reconcile to its daily series.

## Commits
- `feat(agents)`: the agent definition
- `chore(agent-memory)`: the seeded baseline reading

## Notes
- Pairs with a local scheduled task (`meta-ads-daily-report`, ~8am) — not in this repo — that invokes the agent and shows the report in chat.
- Individual lead *names* are intentionally out of scope: they live behind domains the browser tool blocks and aren't retrievable via Zapier; adding them later requires a Meta Graph API token.

Generated with [Claude Code](https://claude.ai/code)