### PR TITLE
Daily settings drift check — 2026-06-10 (Claude Code v2.1.170)

### DIFF
--- a/best-practice/claude-settings.md
+++ b/best-practice/claude-settings.md
@@ -1,9 +1,9 @@
 # Settings Best Practice
 
-![Last Updated](https://img.shields.io/badge/Last_Updated-Jun%2009%2C%202026%2010%3A40%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.169-blue?style=flat&labelColor=555)<br>
+![Last Updated](https://img.shields.io/badge/Last_Updated-Jun%2010%2C%202026%2010%3A43%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.170-blue?style=flat&labelColor=555)<br>
 [![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../.claude/settings.json)
 
-A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.169, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
+A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.170, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
 
 <table width="100%">
 <tr>
@@ -110,7 +110,7 @@ Within the managed tier, precedence is: server-managed > MDM/OS-level policies >
 | `disableWorkflows` | boolean | `false` | Set to `true` to disable [dynamic workflows](https://code.claude.com/docs/en/workflows) (`/workflows`) and the bundled workflow slash commands. Can be set at any scope. Equivalent to the `CLAUDE_CODE_DISABLE_WORKFLOWS` env var. Workflows were introduced in v2.1.154 |
 | `workflowKeywordTriggerEnabled` | boolean | `true` | Whether typing the word "ultracode" in a prompt triggers a [dynamic workflow](https://code.claude.com/docs/en/workflows). Set to `false` to require explicit `/workflows` invocation. Ultracode, `/workflows`, and saved workflow commands are unaffected by this setting. Appears in `/config` as **Workflow keyword trigger** (v2.1.157; trigger keyword renamed workflow→ultracode in v2.1.160) |
 | `ultracode` | boolean | - | **(Session-only — not persisted)** When `true`, the harness authors and runs a workflow for every substantive task by default, maximizing thoroughness regardless of token cost. Appears in the official "Available settings" list but is session-scoped: set via `/effort ultracode`, `--settings`, or the SDK rather than written to `settings.json` (v2.1.154) |
-| `disableBundledSkills` | boolean | `false` | Conceal Claude Code's built-in capabilities (bundled skills) from the model. When `true`, the model cannot invoke built-in skills. Paired with the `CLAUDE_CODE_DISABLE_BUNDLED_SKILLS` env var. Useful when strict plugin-only customization is required *(in v2.1.169 changelog, not yet on official settings page)* |
+| `disableBundledSkills` | boolean | `false` | Conceal Claude Code's built-in capabilities (bundled skills) from the model. When `true`, the model cannot invoke built-in skills. Paired with the `CLAUDE_CODE_DISABLE_BUNDLED_SKILLS` env var. Useful when strict plugin-only customization is required (v2.1.169) |
 | `feedbackSurveyRate` | number | - | Probability (0–1) that the session quality survey appears when eligible. Enterprise admins can control how often the survey is shown. Example: `0.05` = 5% of eligible sessions |
 
 **Example:**
@@ -544,6 +544,7 @@ Configure Claude Code plugins and marketplaces.
 | `"sonnet[1m]"` | Sonnet with 1M token context |
 | `"opus[1m]"` | Opus with 1M token context (default on Max, Team, and Enterprise since v2.1.75) |
 | `"opusplan"` | Opus for planning, Sonnet for execution |
+| `"fable"` | Latest Fable model (Claude Fable 5, v2.1.170) |
 
 **Example:**
 ```json
@@ -562,6 +563,7 @@ Map Anthropic model IDs to provider-specific model IDs for Bedrock, Vertex, or F
 |-----|------|---------|-------------|
 | `effortLevel` | string | - | Persist the effort level across sessions. Accepts `"low"`, `"medium"`, `"high"`, or `"xhigh"` (Opus 4.7 and 4.8, v2.1.111). Written automatically when you run `/effort low`, `/effort medium`, `/effort high`, or `/effort xhigh`. Supported on Opus 4.6, Sonnet 4.6, Opus 4.7, and Opus 4.8 (defaults to `high`). Unsupported levels fall back to the highest supported level on the active model |
 | `fallbackModel` | array | - | Up to 3 fallback model IDs tried sequentially when the primary model is unavailable (e.g., rate-limited or capacity issue). Each entry is a model ID or alias. Claude Code attempts the primary model first; if it fails, each fallback is tried in order. Stops at the first successful response (v2.1.166) |
+| `advisorModel` | string | - | Persist the model used for `/advisor` sessions across restarts. Accepts an alias (`"opus"`, `"sonnet"`, `"fable"`) or a full model ID. Written automatically when you run `/advisor` and select a model. Companion env var: `CLAUDE_CODE_DISABLE_ADVISOR_TOOL` (v2.1.98) |
 | `modelOverrides` | object | - | Map model picker entries to provider-specific IDs (e.g., Bedrock inference profile ARNs). Each key is a model picker entry name, each value is the provider model ID |
 
 **Example:**
@@ -883,6 +885,7 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_MCP_ALLOWLIST_ENV` | Spawn stdio MCP servers with a safe baseline environment only, stripping most inherited env vars to prevent credential leakage into untrusted server processes |
 | `MAX_MCP_OUTPUT_TOKENS` | Max MCP output tokens (default: 25000). Warning displayed when output exceeds 10,000 tokens |
 | `API_TIMEOUT_MS` | Timeout in ms for API requests (default: 600000) |
+| `API_FORCE_IDLE_TIMEOUT` | Force an idle timeout for API requests (ms). Use when a proxy drops idle connections before the standard `API_TIMEOUT_MS` fires |
 | `BASH_MAX_TIMEOUT_MS` | Bash command timeout |
 | `BASH_MAX_OUTPUT_LENGTH` | Max bash output length |
 | `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` | Auto-compact threshold percentage (1-100). Default is ~95%. Set lower (e.g., `50`) to trigger compaction earlier. Values above 95% have no effect. Use `/context` to monitor current usage. Example: `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=50 claude` |
@@ -893,7 +896,9 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` | Enable the experimental agent teams feature (`1` to enable). Allows spawning coordinated teams of subagents within a session |
 | `CLAUDE_CODE_DISABLE_WORKFLOWS` | Set to `1` to disable [dynamic workflows](https://code.claude.com/docs/en/workflows) (`/workflows`) and the bundled workflow slash commands. Env-var equivalent of the `disableWorkflows` setting |
 | `CLAUDE_CODE_ENABLE_AUTO_MODE` | Set to `1` to make [auto mode](https://code.claude.com/docs/en/permission-modes#eliminate-prompts-with-auto-mode) available on Amazon Bedrock, Google Cloud Vertex AI, and Microsoft Foundry. Has no effect on the Anthropic API, where auto mode is available by default (v2.1.158) |
-| `CLAUDE_CODE_DISABLE_BUNDLED_SKILLS` | Set to `1` to conceal Claude Code's built-in capabilities (bundled skills) from the model. Env-var equivalent of the `disableBundledSkills` setting *(in v2.1.169 changelog, not yet on official env-vars page)* |
+| `CLAUDE_CODE_SAFE_MODE` | Set to `1` to disable all user-level customizations (CLAUDE.md files, skills, plugins, hooks, custom commands) for troubleshooting. Useful for diagnosing issues caused by project configuration. Companion to the `--safe-mode` startup flag *(in v2.1.170 changelog, not yet on official env-vars page)* |
+| `CLAUDE_CODE_DISABLE_BUNDLED_SKILLS` | Set to `1` to conceal Claude Code's built-in capabilities (bundled skills) from the model. Env-var equivalent of the `disableBundledSkills` setting (v2.1.169) |
+| `CLAUDE_CODE_DISABLE_ADVISOR_TOOL` | Set to `1` to disable the `/advisor` command and the advisor model context switching. Companion to the `advisorModel` setting (v2.1.98) |
 | `ENABLE_TOOL_SEARCH` | MCP tool search threshold (e.g., `auto:5`) |
 | `ENABLE_PROMPT_CACHING_1H` | Opt into 1-hour prompt cache TTL. Replaces the deprecated `ENABLE_PROMPT_CACHING_1H_BEDROCK` *(in v2.1.108 changelog, not yet on official env-vars page)* |
 | `FORCE_PROMPT_CACHING_5M` | Force 5-minute prompt cache TTL *(in v2.1.108 changelog, not yet on official env-vars page)* |
@@ -1053,6 +1058,10 @@ Set environment variables for all Claude Code sessions.
 | `ANTHROPIC_DEFAULT_SONNET_MODEL_NAME` | Customize the Sonnet entry label in the `/model` picker when using a pinned model on Bedrock/Vertex/Foundry. Defaults to the model ID |
 | `ANTHROPIC_DEFAULT_SONNET_MODEL_DESCRIPTION` | Customize the Sonnet entry description in the `/model` picker. Defaults to `Custom model (<model-id>)` |
 | `ANTHROPIC_DEFAULT_SONNET_MODEL_SUPPORTED_CAPABILITIES` | Override capability detection for a pinned Sonnet model. Comma-separated values (e.g., `effort,thinking`). Required when the pinned model supports features the auto-detection cannot confirm |
+| `ANTHROPIC_DEFAULT_FABLE_MODEL` | Override the Fable model alias with a custom model ID (e.g., for third-party deployments) |
+| `ANTHROPIC_DEFAULT_FABLE_MODEL_NAME` | Customize the Fable entry label in the `/model` picker when using a pinned model on Bedrock/Vertex/Foundry. Defaults to the model ID |
+| `ANTHROPIC_DEFAULT_FABLE_MODEL_DESCRIPTION` | Customize the Fable entry description in the `/model` picker. Defaults to `Custom model (<model-id>)` |
+| `ANTHROPIC_DEFAULT_FABLE_MODEL_SUPPORTED_CAPABILITIES` | Override capability detection for a pinned Fable model. Comma-separated values (e.g., `effort,thinking`). Required when the pinned model supports features the auto-detection cannot confirm |
 | `MAX_THINKING_TOKENS` | Maximum extended thinking tokens per response. Set to `0` to disable extended thinking entirely on the Anthropic API (equivalent to `--thinking disabled`). Applies only when using a fixed thinking budget — on adaptive thinking models (Opus 4.7+), the effort level controls thinking depth instead |
 | `CLAUDE_CODE_AUTO_COMPACT_WINDOW` | Set the context capacity in tokens used for auto-compaction calculations. Defaults to the model's context window (200K standard, 1M for extended context models). Use a lower value (e.g., `500000`) on a 1M model to treat it as 500K for compaction. Capped at actual context window. `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` is applied as a percentage of this value. Setting this decouples the compaction threshold from the status line's `used_percentage` |
 | `DISABLE_AUTO_COMPACT` | Disable automatic context compaction (`1` to disable). Manual `/compact` still works *(not in official docs — unverified)* |
@@ -1097,6 +1106,7 @@ Set environment variables for all Claude Code sessions.
 | `/keybindings` | Configure custom keyboard shortcuts |
 | `/skills` | View and manage skills |
 | `/permissions` | View and manage permission rules |
+| `/cd <path>` | Relocate session to a new working directory without breaking the prompt cache. Useful for switching between project roots within a single session (v2.1.170) |
 | `/usage-credits` | View remaining usage credits and limits. Renamed from `/extra-usage` in v2.1.144 (the old name still works) |
 | `--doctor` | Diagnose configuration issues |
 | `--debug` | Debug mode with hook execution details |
@@ -1123,6 +1133,7 @@ Set environment variables for all Claude Code sessions.
   "plansDirectory": "./plans",
   "claudeMdExcludes": ["**/vendor/**/CLAUDE.md"],
   "effortLevel": "high",
+  "advisorModel": "opus",
   "maxSkillDescriptionChars": 1536,
   "skillListingBudgetFraction": 0.01,
   "disableAgentView": false,

--- a/changelog/best-practice/claude-settings/changelog.md
+++ b/changelog/best-practice/claude-settings/changelog.md
@@ -789,3 +789,22 @@
 | 3 | MED | New Env Var | Add `CLAUDE_CODE_DISABLE_BUNDLED_SKILLS` to Common Environment Variables table — env-var equivalent of `disableBundledSkills` setting. Changelog-only per Rule 5D/8A (v2.1.169) | ✅ COMPLETE (added after `CLAUDE_CODE_ENABLE_AUTO_MODE` with changelog-only annotation) — NEW |
 | 4 | MED | Ownership Question | `CLAUDE_CODE_SAFE_MODE` (v2.1.169, paired with `--safe-mode` startup flag) — determined to be a startup-only variable; belongs in `claude-cli-startup-flags.md`, not in `claude-settings.md`. Per Rule 13 (env vars split across two files) | ✋ ON HOLD (out of scope for this report — add to `claude-cli-startup-flags.md` in a separate run) — NEW |
 | 5 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 30+ consecutive runs | ✋ ON HOLD (kept — recurring from 2026-04-14 v2.1.107) |
+
+---
+
+## [2026-06-10 10:43 AM PKT] Claude Code v2.1.170
+
+| # | Priority | Type | Action | Status |
+|---|----------|------|--------|--------|
+| 1 | HIGH | Missing Setting | Add `advisorModel` to Model Configuration section (string, any scope, v2.1.98+; accepts alias "opus"/"sonnet"/"fable" or full model ID; write with `/advisor`; companion env var `CLAUDE_CODE_DISABLE_ADVISOR_TOOL`) | ✅ COMPLETE (added to Model Overrides table after `fallbackModel`) — NEW |
+| 2 | HIGH | Version Bump | Update report version badge from v2.1.169 → v2.1.170 and header "As of v2.1.169" → "As of v2.1.170" | ✅ COMPLETE (badge and header updated in Phase 2.6) — NEW |
+| 3 | HIGH | Stale Annotation | Remove stale annotation from `disableBundledSkills` — now on official settings page; update description per official docs | ✅ COMPLETE (annotation removed, version note added) — NEW |
+| 4 | HIGH | Missing Env Var | Add `CLAUDE_CODE_SAFE_MODE` to env vars table (v2.1.170 changelog; disables customizations for troubleshooting; changelog-only annotation) | ✅ COMPLETE (added after `CLAUDE_CODE_ENABLE_AUTO_MODE` with changelog-only annotation) — NEW |
+| 5 | HIGH | Missing Env Vars | Add `ANTHROPIC_DEFAULT_FABLE_MODEL` (+ `_NAME`, `_DESCRIPTION`, `_SUPPORTED_CAPABILITIES` companions) to env vars table — confirmed on official /en/env-vars page | ✅ COMPLETE (added as a group after `ANTHROPIC_DEFAULT_SONNET_MODEL_SUPPORTED_CAPABILITIES`) — NEW |
+| 6 | HIGH | Missing Env Var | Add `CLAUDE_CODE_DISABLE_ADVISOR_TOOL` to env vars table — confirmed on official /en/env-vars page | ✅ COMPLETE (added after `CLAUDE_CODE_DISABLE_BUNDLED_SKILLS`) — NEW |
+| 7 | MED | New Model Alias | Add `"fable"` to Model Aliases table (Claude Fable 5, v2.1.170) | ✅ COMPLETE (added after `"opusplan"`) — NEW |
+| 8 | MED | Stale Annotation | Remove stale "changelog-only" annotation from `CLAUDE_CODE_DISABLE_BUNDLED_SKILLS` — now confirmed on official /en/env-vars page | ✅ COMPLETE (annotation replaced with version note) — NEW |
+| 9 | MED | New Useful Command | Add `/cd` to Useful Commands table (relocate session to new working directory without breaking prompt cache, v2.1.170) | ✅ COMPLETE (added after `/permissions`) — NEW |
+| 10 | MED | Missing Env Var | Add `API_FORCE_IDLE_TIMEOUT` to env vars table — confirmed on official /en/env-vars page | ✅ COMPLETE (added after `API_TIMEOUT_MS`) — NEW |
+| 11 | LOW | Example Update | Add `advisorModel` to Quick Reference example | ✅ COMPLETE (added `"advisorModel": "opus"` after `effortLevel`) — NEW |
+| 12 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 30+ consecutive runs | ✋ ON HOLD (kept — recurring from 2026-04-14 v2.1.107) |


### PR DESCRIPTION
## Daily Settings Drift Check — 2026-06-10

**Claude Code version audited:** v2.1.170 (one version ahead of previous report at v2.1.169)
**Sources checked:** [Settings docs](https://code.claude.com/docs/en/settings) · [CLI Reference](https://code.claude.com/docs/en/cli-reference) · [Env Vars](https://code.claude.com/docs/en/env-vars) · [CHANGELOG.md](https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md)

---

## Priority Actions Applied

| # | Priority | Type | Action | Status |
|---|----------|------|--------|--------|
| 1 | HIGH | Missing Setting | Added `advisorModel` to Model Overrides table | ✅ COMPLETE |
| 2 | HIGH | Version Bump | Badge + header: v2.1.169 → v2.1.170 | ✅ COMPLETE |
| 3 | HIGH | Stale Annotation | Removed stale `*(in v2.1.169 changelog, not yet on official settings page)*` from `disableBundledSkills` | ✅ COMPLETE |
| 4 | HIGH | Missing Env Var | Added `CLAUDE_CODE_SAFE_MODE` (changelog-only annotation, v2.1.170) | ✅ COMPLETE |
| 5 | HIGH | Missing Env Vars | Added `ANTHROPIC_DEFAULT_FABLE_MODEL` + `_NAME` + `_DESCRIPTION` + `_SUPPORTED_CAPABILITIES` | ✅ COMPLETE |
| 6 | HIGH | Missing Env Var | Added `CLAUDE_CODE_DISABLE_ADVISOR_TOOL` | ✅ COMPLETE |
| 7 | MED | New Model Alias | Added `"fable"` to Model Aliases table (Claude Fable 5, v2.1.170) | ✅ COMPLETE |
| 8 | MED | Stale Annotation | Removed stale `*(in v2.1.169 changelog, not yet on official env-vars page)*` from `CLAUDE_CODE_DISABLE_BUNDLED_SKILLS` | ✅ COMPLETE |
| 9 | MED | New Useful Command | Added `/cd <path>` to Useful Commands table (v2.1.170) | ✅ COMPLETE |
| 10 | MED | Missing Env Var | Added `API_FORCE_IDLE_TIMEOUT` after `API_TIMEOUT_MS` | ✅ COMPLETE |
| 11 | LOW | Example Update | Added `"advisorModel": "opus"` to Quick Reference example | ✅ COMPLETE |
| 12 | LOW | Suspect Key | `OTEL_LOG_TOOL_DETAILS` — still not on official /en/env-vars page after 30+ runs | ✋ ON HOLD |

---

## Verification Log (all 25 checklist rules)

| Rule | Category | Depth | Result | Notes |
|------|----------|-------|--------|-------|
| 1A | Key Completeness | field-level | PASS | All keys present; `advisorModel` was the only gap |
| 1B | Key Types | content-match | PASS | All types match official docs |
| 1C | Key Defaults | content-match | PASS | All defaults match |
| 1D | Key Descriptions | content-match | PASS | `disableBundledSkills` annotation updated |
| 1E | Scope Column | content-match | PASS | No scope mismatches found |
| 1F | Inverse Completeness | field-level | PASS | All unverified keys properly annotated |
| 1G | Edge-Case Semantics | content-match | PASS | No new edge-case behaviors found |
| 1H | File Scope Check | content-match | PASS | All keys in correct settings.json vs ~/.claude.json sections |
| 1I | Skills Settings Keys | field-level | PASS | `skillOverrides`, `disableSkillShellExecution`, `maxSkillDescriptionChars`, `skillListingBudgetFraction` all present |
| 2A | Priority Levels | field-level | PASS | 5-level chain + managed policy intact |
| 2B | File Locations | content-match | PASS | All paths correct |
| 2C | Merge Semantics | content-match | PASS | "concatenated and deduplicated" wording correct |
| 2D | Managed Internals | field-level | PASS | Delivery methods and platform paths correct |
| 3A | Permission Modes | field-level | PASS | All modes present |
| 3B | Tool Syntax Patterns | content-match | PASS | No changes to permission syntax in v2.1.170 |
| 3C | Bidirectional Mode Check | field-level | PASS | No unverified modes found |
| 3D | Evaluation Semantics | content-match | PASS | Deny-first order and path-prefix patterns correct |
| 4A | Hooks Redirect | exists | PASS | Redirect link to claude-code-hooks repo present |
| 5A | Env Var Completeness | field-level | PASS (after fixes) | 6 new vars added |
| 5B | Ownership Boundary | cross-file | PASS | No duplication with `claude-cli-startup-flags.md` |
| 5C | Env Var Descriptions | content-match | PASS | All descriptions match official docs |
| 5D | Inverse Env Var Check | field-level | PASS | All unverified vars annotated; `OTEL_LOG_TOOL_DETAILS` kept ON HOLD |
| 6A | Quick Reference Example | content-match | PASS (after fix) | `advisorModel` added; 40-key example now valid |
| 6B | Example URL Validation | exists | PASS | `$schema` URL resolves correctly |
| 7A | CLAUDE.md Sync | cross-file | PASS | Configuration hierarchy consistent |
| 8A | Source Credibility Guard | content-match | PASS | All changes traced to official sources only |
| 9A | Local File Links | exists | PASS | All relative links resolve |
| 9B | External URL Links | exists | PASS | All external URLs return valid pages |
| 9C | Anchor Links | exists | PASS | All anchor links point to existing headings |
| 10A | Version Metadata | content-match | PASS | Badge, header, and table counts consistent after bump |
| 10B | Suspect Key Escalation | exists | PASS | `OTEL_LOG_TOOL_DETAILS` at 30+ runs but kept; no new 5-run threshold breaches |
| 10C | Bidirectional Completeness | field-level | PASS | All report entries traceable to official sources or annotated |

---

## Resolved Since Last Run

| Item | First Seen | Resolution |
|------|-----------|------------|
| `disableBundledSkills` — changelog-only annotation | v2.1.169 (2026-06-09) | Now on official settings page; annotation removed |
| `CLAUDE_CODE_DISABLE_BUNDLED_SKILLS` — changelog-only annotation | v2.1.169 (2026-06-09) | Now on official env-vars page; annotation removed |
| `CLAUDE_CODE_SAFE_MODE` — previous run deferred as startup-only | v2.1.169 (2026-06-09) | v2.1.170 confirms it as a real env var; added with changelog-only annotation |

---

## Hyperlink Validation Log

| # | Type | Link | Status |
|---|------|------|--------|
| 1 | External | https://code.claude.com/docs/en/settings | OK |
| 2 | External | https://code.claude.com/docs/en/cli-reference | OK |
| 3 | External | https://code.claude.com/docs/en/env-vars | OK |
| 4 | External | https://json.schemastore.org/claude-code-settings.json | OK |
| 5 | Local | ../.claude/settings.json | OK |
| 6 | Local | ../README.md | OK |
| 7–20 | External | All remaining doc links | OK |

---

## Commits

- `changelog: append v2.1.170 settings drift entry (2026-06-10)`
- `settings: apply v2.1.170 drift fixes — advisorModel, fable alias, new env vars`

> **Do not self-merge** — leave open for human review.

---
_Generated by [Claude Code](https://claude.ai/code/session_014kwe3qjbMBjSagfD8AJ7cv)_