### PR TITLE
Daily settings drift check — 2026-06-11 (Claude Code v2.1.172)

### DIFF
--- a/best-practice/claude-settings.md
+++ b/best-practice/claude-settings.md
@@ -1,9 +1,9 @@
 # Settings Best Practice
 
-![Last Updated](https://img.shields.io/badge/Last_Updated-Jun%2009%2C%202026%2010%3A40%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.169-blue?style=flat&labelColor=555)<br>
+![Last Updated](https://img.shields.io/badge/Last_Updated-Jun%2011%2C%202026%2010%3A43%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.172-blue?style=flat&labelColor=555)<br>
 [![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../.claude/settings.json)
 
-A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.169, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
+A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.172, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
 
 <table width="100%">
 <tr>
@@ -112,6 +112,7 @@ Within the managed tier, precedence is: server-managed > MDM/OS-level policies >
 | `ultracode` | boolean | - | **(Session-only — not persisted)** When `true`, the harness authors and runs a workflow for every substantive task by default, maximizing thoroughness regardless of token cost. Appears in the official "Available settings" list but is session-scoped: set via `/effort ultracode`, `--settings`, or the SDK rather than written to `settings.json` (v2.1.154) |
 | `disableBundledSkills` | boolean | `false` | Conceal Claude Code's built-in capabilities (bundled skills) from the model. When `true`, the model cannot invoke built-in skills. Paired with the `CLAUDE_CODE_DISABLE_BUNDLED_SKILLS` env var. Useful when strict plugin-only customization is required *(in v2.1.169 changelog, not yet on official settings page)* |
 | `feedbackSurveyRate` | number | - | Probability (0–1) that the session quality survey appears when eligible. Enterprise admins can control how often the survey is shown. Example: `0.05` = 5% of eligible sessions |
+| `advisorModel` | string | - | Model for the server-side advisor tool. Accepts a model alias (`opus`, `sonnet`, `fable`) or a full model ID. When unset, the advisor uses the session model. Requires v2.1.98+ |
 
 **Example:**
 ```json
@@ -291,6 +292,7 @@ Control what tools and operations Claude can perform.
 | `Agent` | `Agent(name)` | `Agent(researcher)`, `Agent(*)` — permission scoped to subagent spawning |
 | `Skill` | `Skill(skill-name)` or `Skill(prefix *)` | `Skill(weather-fetcher)`, `Skill(weather *)` matches `weather-fetcher`/`weather-svg-creator` (v2.1.139) |
 | `MCP` | `mcp__server__tool` or `MCP(server:tool)` | `mcp__memory__*`, `MCP(github:*)` |
+| `Cd` | `Cd(path pattern)` | `Cd(/home/*)`, `Cd(~/projects/*)` — controls which directories the `/cd` command may navigate to |
 
 **Evaluation order:** Rules are evaluated in order: deny rules first, then ask, then allow. The first matching rule wins.
 
@@ -544,6 +546,7 @@ Configure Claude Code plugins and marketplaces.
 | `"sonnet[1m]"` | Sonnet with 1M token context |
 | `"opus[1m]"` | Opus with 1M token context (default on Max, Team, and Enterprise since v2.1.75) |
 | `"opusplan"` | Opus for planning, Sonnet for execution |
+| `"fable"` | Claude Fable 5 — long-horizon reasoning model. Anthropic API only (v2.1.170+) |
 
 **Example:**
 ```json
@@ -1053,6 +1056,10 @@ Set environment variables for all Claude Code sessions.
 | `ANTHROPIC_DEFAULT_SONNET_MODEL_NAME` | Customize the Sonnet entry label in the `/model` picker when using a pinned model on Bedrock/Vertex/Foundry. Defaults to the model ID |
 | `ANTHROPIC_DEFAULT_SONNET_MODEL_DESCRIPTION` | Customize the Sonnet entry description in the `/model` picker. Defaults to `Custom model (<model-id>)` |
 | `ANTHROPIC_DEFAULT_SONNET_MODEL_SUPPORTED_CAPABILITIES` | Override capability detection for a pinned Sonnet model. Comma-separated values (e.g., `effort,thinking`). Required when the pinned model supports features the auto-detection cannot confirm |
+| `ANTHROPIC_DEFAULT_FABLE_MODEL` | Override Fable model alias (e.g., `claude-fable-5`) |
+| `ANTHROPIC_DEFAULT_FABLE_MODEL_NAME` | Customize the Fable entry label in the `/model` picker when using a pinned model on Bedrock/Vertex/Foundry. Defaults to the model ID |
+| `ANTHROPIC_DEFAULT_FABLE_MODEL_DESCRIPTION` | Customize the Fable entry description in the `/model` picker. Defaults to `Custom model (<model-id>)` |
+| `ANTHROPIC_DEFAULT_FABLE_MODEL_SUPPORTED_CAPABILITIES` | Override capability detection for a pinned Fable model. Comma-separated values (e.g., `effort,thinking`). Required when the pinned model supports features the auto-detection cannot confirm |
 | `MAX_THINKING_TOKENS` | Maximum extended thinking tokens per response. Set to `0` to disable extended thinking entirely on the Anthropic API (equivalent to `--thinking disabled`). Applies only when using a fixed thinking budget — on adaptive thinking models (Opus 4.7+), the effort level controls thinking depth instead |
 | `CLAUDE_CODE_AUTO_COMPACT_WINDOW` | Set the context capacity in tokens used for auto-compaction calculations. Defaults to the model's context window (200K standard, 1M for extended context models). Use a lower value (e.g., `500000`) on a 1M model to treat it as 500K for compaction. Capped at actual context window. `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` is applied as a percentage of this value. Setting this decouples the compaction threshold from the status line's `used_percentage` |
 | `DISABLE_AUTO_COMPACT` | Disable automatic context compaction (`1` to disable). Manual `/compact` still works *(not in official docs — unverified)* |
@@ -1109,6 +1116,7 @@ Set environment variables for all Claude Code sessions.
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "model": "sonnet",
+  "advisorModel": "fable",
   "agent": "code-reviewer",
   "language": "english",
   "cleanupPeriodDays": 30,

--- a/changelog/best-practice/claude-settings/changelog.md
+++ b/changelog/best-practice/claude-settings/changelog.md
@@ -789,3 +789,18 @@
 | 3 | MED | New Env Var | Add `CLAUDE_CODE_DISABLE_BUNDLED_SKILLS` to Common Environment Variables table — env-var equivalent of `disableBundledSkills` setting. Changelog-only per Rule 5D/8A (v2.1.169) | ✅ COMPLETE (added after `CLAUDE_CODE_ENABLE_AUTO_MODE` with changelog-only annotation) — NEW |
 | 4 | MED | Ownership Question | `CLAUDE_CODE_SAFE_MODE` (v2.1.169, paired with `--safe-mode` startup flag) — determined to be a startup-only variable; belongs in `claude-cli-startup-flags.md`, not in `claude-settings.md`. Per Rule 13 (env vars split across two files) | ✋ ON HOLD (out of scope for this report — add to `claude-cli-startup-flags.md` in a separate run) — NEW |
 | 5 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 30+ consecutive runs | ✋ ON HOLD (kept — recurring from 2026-04-14 v2.1.107) |
+
+---
+
+## [2026-06-11 10:43 AM PKT] Claude Code v2.1.172
+
+| # | Priority | Type | Action | Status |
+|---|----------|------|--------|--------|
+| 1 | HIGH | New Setting | Add `advisorModel` (string, unset, any scope) to General Settings table — model for server-side advisor tool; accepts alias (opus, sonnet, fable) or full model ID. Confirmed on official settings page (min v2.1.98) | ✅ COMPLETE (added after `feedbackSurveyRate` row) — NEW |
+| 2 | HIGH | Version Bump | Update report version badge from v2.1.169 → v2.1.172 and header "As of v2.1.169" → "As of v2.1.172" | ✅ COMPLETE (badge and header updated in Phase 2.6) — NEW |
+| 3 | HIGH | New Permission Rule | Add `Cd` to Tool Permission Syntax table — controls `/cd` command directory access; confirmed on official permissions page (v2.1.169+) | ✅ COMPLETE (added after `MCP` row) — NEW |
+| 4 | HIGH | New Env Vars | Add 4 `ANTHROPIC_DEFAULT_FABLE_MODEL*` vars (override, name, description, supported capabilities) for Fable 5 model pinning on Bedrock/Vertex/Foundry; confirmed on official env-vars page (v2.1.170) | ✅ COMPLETE (added after `ANTHROPIC_DEFAULT_SONNET_MODEL_SUPPORTED_CAPABILITIES`) — NEW |
+| 5 | HIGH | Model Alias | Add `fable` to Model Aliases table — Claude Fable 5, Anthropic API only (v2.1.170+); confirmed on official settings page | ✅ COMPLETE (added after `opusplan` row) — NEW |
+| 6 | HIGH | Example Update | Update Quick Reference example: add `advisorModel` field to showcase v2.1.172 feature | ✅ COMPLETE (updated example) — NEW |
+| 7 | INVALID | Rule 8A Rejection | `DISABLE_PROMPT_CACHING_FABLE` — pattern-implied from Haiku/Sonnet/Opus siblings but NOT explicitly listed on official /en/env-vars page. Per Rule 8A, pattern inference is insufficient — not added | ❌ INVALID (not on official env-vars page; pattern only — Rule 8A) — NEW |
+| 8 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 31+ consecutive runs | ✋ ON HOLD (kept — recurring from 2026-04-14 v2.1.107) |


### PR DESCRIPTION
## Settings Drift Report — v2.1.169 → v2.1.172

**Run date:** 2026-06-11 10:43 AM PKT  
**Previous version:** v2.1.169  
**Current version:** v2.1.172  
**Versions checked:** 10 (v2.1.163–v2.1.172)

---

## Summary of Changes

6 HIGH-priority items applied, 1 INVALID (Rule 8A), 1 LOW ongoing ON HOLD.

### Priority Actions

| # | Priority | Type | Action | Status |
|---|----------|------|--------|--------|
| 1 | HIGH | New Setting | Added `advisorModel` to General Settings table — model for server-side advisor tool; accepts alias (opus, sonnet, fable) or full model ID (official settings page, min v2.1.98) | ✅ COMPLETE |
| 2 | HIGH | Version Bump | Updated badge/header from v2.1.169 → v2.1.172 | ✅ COMPLETE |
| 3 | HIGH | New Permission Rule | Added `Cd` to Tool Permission Syntax table — controls `/cd` command directory access (official permissions page, v2.1.169+) | ✅ COMPLETE |
| 4 | HIGH | New Env Vars | Added 4 `ANTHROPIC_DEFAULT_FABLE_MODEL*` vars for Fable 5 model pinning on Bedrock/Vertex/Foundry (official env-vars page, v2.1.170) | ✅ COMPLETE |
| 5 | HIGH | Model Alias | Added `"fable"` to Model Aliases table — Claude Fable 5, Anthropic API only (v2.1.170+) | ✅ COMPLETE |
| 6 | HIGH | Example Update | Added `advisorModel: "fable"` to Quick Reference complete example | ✅ COMPLETE |
| 7 | INVALID | Rule 8A Rejection | `DISABLE_PROMPT_CACHING_FABLE` — pattern-implied from Haiku/Sonnet/Opus siblings but NOT on official /en/env-vars page; not added per Rule 8A | ❌ INVALID |
| 8 | LOW | Suspect Key | `OTEL_LOG_TOOL_DETAILS` — 31+ consecutive ON HOLD runs; still changelog-only | ✋ ON HOLD |

---

## Resolved Since Last Run

No items from the v2.1.169 run were resolved.

---

## Verification Log

| Rule | Category | Depth | Result | Notes |
|------|----------|-------|--------|-------|
| 1A | Key Completeness | field-level | FAIL→FIXED | `advisorModel` was missing; added |
| 1B | Key Types | content-match | PASS | All key types accurate |
| 1C | Key Defaults | content-match | PASS | All defaults accurate |
| 1D | Key Descriptions | content-match | PASS | All descriptions accurate |
| 1E | Scope Column | content-match | PASS | All scope values verified |
| 1F | Inverse Completeness | field-level | PASS | All report keys traceable to official source or annotated |
| 1G | Edge-Case Semantics | content-match | PASS | Boundary behaviors documented |
| 1H | File Scope Check | content-match | PASS | Display settings correctly in `~/.claude.json` scope |
| 1I | Skills Settings Keys | field-level | PASS | `maxSkillDescriptionChars`, `skillListingBudgetFraction` present |
| 2A | Priority Levels | field-level | PASS | 5-level hierarchy accurate |
| 2B | File Locations | content-match | PASS | All paths accurate |
| 2C | Merge Semantics | content-match | PASS | "concatenated and deduplicated" wording correct |
| 2D | Managed Internals | field-level | PASS | Managed tier delivery methods accurate |
| 3A | Permission Modes | field-level | PASS | All modes present |
| 3B | Tool Syntax Patterns | content-match | FAIL→FIXED | `Cd` rule type was missing; added |
| 3C | Bidirectional Mode Check | field-level | PASS | All modes verified bidirectionally |
| 3D | Evaluation Semantics | content-match | PASS | Deny-first order, path prefixes documented |
| 4A | Hooks Redirect | exists | PASS | Redirect link valid |
| 5A | Env Var Completeness | field-level | FAIL→FIXED | 4 `ANTHROPIC_DEFAULT_FABLE_MODEL*` vars added |
| 5B | Ownership Boundary | cross-file | PASS | No cross-file duplication |
| 5C | Env Var Descriptions | content-match | PASS | All descriptions match official page |
| 5D | Inverse Env Var Check | field-level | PASS | All report vars traceable or annotated |
| 6A | Quick Reference Example | content-match | FAIL→FIXED | Added `advisorModel` field |
| 6B | Example URL Validation | exists | PASS | Schema URL redirects (301) but resolves; established behavior |
| 7A | CLAUDE.md Sync | cross-file | PASS | Hierarchy consistent |
| 8A | Source Credibility Guard | content-match | PASS | `DISABLE_PROMPT_CACHING_FABLE` rejected — not on official page |
| 9A | Local File Links | exists | PASS | All relative links resolve |
| 9B | External URL Links | exists | PASS | All 6 source URLs return valid pages |
| 9C | Anchor Links | exists | PASS | All anchor links resolve |
| 10A | Version Metadata | content-match | FAIL→FIXED | Badge/header bumped to v2.1.172 |
| 10B | Suspect Key Escalation | exists | ONGOING | `OTEL_LOG_TOOL_DETAILS` — 31+ runs |
| 10C | Bidirectional Completeness | field-level | PASS | All keys traceable bidirectionally |

---

## Hyperlink Validation Log

| # | Type | Link | Status |
|---|------|------|--------|
| 1 | Local | `../` | OK |
| 2 | Local | `../.claude/settings.json` | OK |
| 3 | Local | `../!/claude-jumping.svg` | OK |
| 4 | External | `https://code.claude.com/docs/en/settings` | OK |
| 5 | External | `https://json.schemastore.org/claude-code-settings.json` | OK (301→resolved) |
| 6 | External | `https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md` | OK |
| 7 | External | `https://github.com/feiskyer/claude-code-settings` | OK |
| 8 | External | `https://code.claude.com/docs/en/env-vars` | OK |
| 9 | External | `https://code.claude.com/docs/en/permissions` | OK |

---

## Files Changed

- `best-practice/claude-settings.md` — badge bump, 6 content additions
- `changelog/best-practice/claude-settings/changelog.md` — new v2.1.172 entry appended

https://claude.ai/code/session_018uKhLv77W1wr5PvymBhzuE

---
_Generated by [Claude Code](https://claude.ai/code/session_018uKhLv77W1wr5PvymBhzuE)_