### PR TITLE
Daily settings drift check — 2026-06-12 (Claude Code v2.1.175)

### DIFF
--- a/best-practice/claude-settings.md
+++ b/best-practice/claude-settings.md
@@ -1,9 +1,9 @@
 # Settings Best Practice
 
-![Last Updated](https://img.shields.io/badge/Last_Updated-Jun%2011%2C%202026%2010%3A43%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.172-blue?style=flat&labelColor=555)<br>
+![Last Updated](https://img.shields.io/badge/Last_Updated-Jun%2012%2C%202026%2010%3A46%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.175-blue?style=flat&labelColor=555)<br>
 [![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../.claude/settings.json)
 
-A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.172, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
+A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.175, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
 
 <table width="100%">
 <tr>
@@ -87,7 +87,8 @@ Within the managed tier, precedence is: server-managed > MDM/OS-level policies >
 | `minimumVersion` | string | - | Prevent the auto-updater from downgrading below a specific version. Automatically set when switching to the stable channel and choosing to stay on the current version until stable catches up. Used with `autoUpdatesChannel` |
 | `alwaysThinkingEnabled` | boolean | `false` | Enable extended thinking by default for all sessions |
 | `skipWebFetchPreflight` | boolean | `false` | Skip the WebFetch domain safety check that sends each requested hostname to `api.anthropic.com` before fetching. Set to `true` in environments that block outbound traffic to Anthropic, such as Bedrock, Vertex AI, or Foundry deployments with restrictive egress |
-| `availableModels` | array | - | Restrict which models users can select via `/model`, `--model`, Config tool, or `ANTHROPIC_MODEL`. Does not affect the Default option. Example: `["sonnet", "haiku"]` |
+| `availableModels` | array | - | Restrict which models users can select via `/model`, `--model`, Config tool, or `ANTHROPIC_MODEL`. Does not affect the Default option. As of v2.1.172, also constrains the model picker for subagent dispatching and the `advisorModel` picker. Use `enforceAvailableModels: true` to additionally constrain the Default model option. Example: `["sonnet", "haiku"]` |
+| `enforceAvailableModels` | boolean | `false` | **(Managed only)** When `true`, the `availableModels` allowlist also constrains the Default model option — users cannot select a model outside the allowlist even via the Default slot. Without this flag, `availableModels` leaves the Default option unrestricted. Pair with `availableModels` for full model lockdown (v2.1.175) |
 | `fastModePerSessionOptIn` | boolean | `false` | Require users to opt in to fast mode each session |
 | `defaultShell` | string | `"bash"` | Default shell for input-box `!` commands. Accepts `"bash"` (default) or `"powershell"`. Setting `"powershell"` routes interactive `!` commands through PowerShell on Windows. Requires `CLAUDE_CODE_USE_POWERSHELL_TOOL=1` (v2.1.84). **v2.1.120:** When PowerShell is available, it is used as the fallback shell on Windows even without Git for Windows installed. **v2.1.126:** When PowerShell is enabled, it is treated as the *primary* shell instead of defaulting to Bash. PowerShell 7 detection now also covers Microsoft Store installs, MSI installs not on PATH, and `.NET` global tool installs |
 | `includeGitInstructions` | boolean | `true` | Include built-in commit and PR workflow instructions and the git status snapshot in Claude's system prompt. The `CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS` environment variable takes precedence over this setting when set |
@@ -638,6 +639,7 @@ Configure via `env` key:
 | `teammateMode` | string | `"auto"` | How [agent team](https://code.claude.com/docs/en/agent-teams) teammates display: `"auto"` (picks split panes in tmux or iTerm2, in-process otherwise), `"in-process"`, or `"tmux"`. See [choose a display mode](https://code.claude.com/docs/en/agent-teams#choose-a-display-mode). Versions before v2.1.119 stored this in `~/.claude.json` |
 | `terminalProgressBarEnabled` | boolean | `true` | Show the terminal progress bar in supported terminals (ConEmu, Ghostty 1.2.0+, and iTerm2 3.6.6+). Appears in `/config` as **Terminal progress bar**. Versions before v2.1.119 stored this in `~/.claude.json` |
 | `preferredNotifChannel` | string | `"auto"` | Method for task-complete and permission-prompt notifications. Values: `"auto"`, `"terminal_bell"`, `"iterm2"`, `"iterm2_with_bell"`, `"kitty"`, `"ghostty"`, `"notifications_disabled"`. Default `"auto"` sends a desktop notification in iTerm2, Ghostty, and Kitty and does nothing in other terminals. Set `"terminal_bell"` to ring the bell character in any terminal. Appears in `/config` as **Notifications**. See [Get a terminal bell or notification](https://code.claude.com/docs/en/terminal-config#get-a-terminal-bell-or-notification) |
+| `wheelScrollAccelerationEnabled` | boolean | `true` | Disable mouse-wheel scroll acceleration in fullscreen mode. Set to `false` to use fixed per-tick scroll steps instead of the OS-level acceleration curve (v2.1.174) |
 
 ### Global Config Settings (`~/.claude.json`)
 
@@ -886,12 +888,14 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_MCP_ALLOWLIST_ENV` | Spawn stdio MCP servers with a safe baseline environment only, stripping most inherited env vars to prevent credential leakage into untrusted server processes |
 | `MAX_MCP_OUTPUT_TOKENS` | Max MCP output tokens (default: 25000). Warning displayed when output exceeds 10,000 tokens |
 | `API_TIMEOUT_MS` | Timeout in ms for API requests (default: 600000) |
+| `API_FORCE_IDLE_TIMEOUT` | Override the 5-minute idle timeout for streaming connections. Set to `0` to disable the idle timeout entirely, `1` to enforce it on all connections, or leave unset for the default (auto-enabled on slow or unreliable gateways that frequently stall). Useful for slow API gateways (v2.1.169) |
 | `BASH_MAX_TIMEOUT_MS` | Bash command timeout |
 | `BASH_MAX_OUTPUT_LENGTH` | Max bash output length |
 | `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` | Auto-compact threshold percentage (1-100). Default is ~95%. Set lower (e.g., `50`) to trigger compaction earlier. Values above 95% have no effect. Use `/context` to monitor current usage. Example: `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=50 claude` |
 | `CLAUDE_CODE_MAX_CONTEXT_TOKENS` | Override the context window size Claude Code assumes for the active model. Only takes effect when `DISABLE_COMPACT` is also set. Use when routing to a model through `ANTHROPIC_BASE_URL` whose context window does not match the built-in size for its name |
 | `CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR` | Keep cwd between bash calls (`1` to enable) |
 | `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS` | Disable background tasks (`1` to disable) |
+| `CLAUDE_CODE_DISABLE_ADVISOR_TOOL` | Set to `1` to disable the advisor tool and the `/advisor` command. Env-var equivalent of omitting advisor usage. Pair with `advisorModel` for advisor configuration (min v2.1.98) |
 | `CLAUDE_CODE_DISABLE_AGENT_VIEW` | Set to `1` to turn off background agents and agent view (`claude agents`, `--bg`, `/background`, on-demand supervisor). Env-var equivalent of the `disableAgentView` setting *(referenced on official settings page; not listed on the env-vars page)* |
 | `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` | Enable the experimental agent teams feature (`1` to enable). Allows spawning coordinated teams of subagents within a session |
 | `CLAUDE_CODE_DISABLE_WORKFLOWS` | Set to `1` to disable [dynamic workflows](https://code.claude.com/docs/en/workflows) (`/workflows`) and the bundled workflow slash commands. Env-var equivalent of the `disableWorkflows` setting |
@@ -925,7 +929,7 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_NEW_INIT` | Set to `true` to make `/init` run an interactive setup flow. Asks which files to generate (CLAUDE.md, skills, hooks) before exploring the codebase. Without this, `/init` generates a CLAUDE.md automatically |
 | `CLAUDE_CODE_PLUGIN_SEED_DIR` | Path to one or more read-only plugin seed directories, separated by `:` on Unix or `;` on Windows. Bundle pre-populated plugins into a container image. Claude Code registers marketplaces from these directories at startup and uses pre-cached plugins without re-cloning |
 | `ENABLE_CLAUDEAI_MCP_SERVERS` | Enable Claude.ai MCP servers |
-| `CLAUDE_CODE_EFFORT_LEVEL` | Set effort level: `low`, `medium`, `high`, `xhigh` (Opus 4.7 only, v2.1.111), `max` (Opus 4.6 only), or `auto` (use model default). Takes precedence over `/effort` and the `effortLevel` setting. Also configurable as a startup-only var — see [CLI Startup Flags](./claude-cli-startup-flags.md#environment-variables) |
+| `CLAUDE_CODE_EFFORT_LEVEL` | Set effort level: `low`, `medium`, `high`, `xhigh` (Opus 4.7 and 4.8, v2.1.111), `max` (Opus 4.6 only), or `auto` (use model default). Takes precedence over `/effort` and the `effortLevel` setting. Also configurable as a startup-only var — see [CLI Startup Flags](./claude-cli-startup-flags.md#environment-variables) |
 | `CLAUDE_EFFORT` | Read-only. Injected into Bash tool subprocesses and hook handlers with the active effort level so shell scripts and hooks can adapt to the current tier (companion to `CLAUDE_CODE_EFFORT_LEVEL`; v2.1.133). Inside skill files use `${CLAUDE_EFFORT}` *(in changelog, not on official env-vars page — read-only, not user-configurable)* |
 | `CLAUDE_CODE_ALWAYS_ENABLE_EFFORT` | Set to `1` to force-enable the effort parameter on all models, even those that do not normally support effort-level selection. Allows `/effort` and the `effortLevel` setting to take effect on models outside the standard effort-capable set (v2.1.154) *(in v2.1.154 changelog, not yet on official env-vars page)* |
 | `CLAUDE_CODE_MAX_TURNS` | Maximum agentic turns before stopping *(not in official docs — unverified)* |

--- a/changelog/best-practice/claude-settings/changelog.md
+++ b/changelog/best-practice/claude-settings/changelog.md
@@ -804,3 +804,18 @@
 | 6 | HIGH | Example Update | Update Quick Reference example: add `advisorModel` field to showcase v2.1.172 feature | ✅ COMPLETE (updated example) — NEW |
 | 7 | INVALID | Rule 8A Rejection | `DISABLE_PROMPT_CACHING_FABLE` — pattern-implied from Haiku/Sonnet/Opus siblings but NOT explicitly listed on official /en/env-vars page. Per Rule 8A, pattern inference is insufficient — not added | ❌ INVALID (not on official env-vars page; pattern only — Rule 8A) — NEW |
 | 8 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 31+ consecutive runs | ✋ ON HOLD (kept — recurring from 2026-04-14 v2.1.107) |
+
+---
+
+## [2026-06-12 10:46 AM PKT] Claude Code v2.1.175
+
+| # | Priority | Type | Action | Status |
+|---|----------|------|--------|--------|
+| 1 | HIGH | New Setting | Add `enforceAvailableModels` (managed-only boolean, v2.1.175) to General Settings after `availableModels` — enforces the `availableModels` allowlist on the Default model option | ✅ COMPLETE (added after `availableModels` row) — NEW |
+| 2 | HIGH | New Setting | Add `wheelScrollAccelerationEnabled` (boolean, v2.1.174) to Display Settings table — disables mouse-wheel scroll acceleration in fullscreen mode | ✅ COMPLETE (added after `preferredNotifChannel` row) — NEW |
+| 3 | HIGH | Version Bump | Update report version badge from v2.1.172 → v2.1.175 and header "As of v2.1.172" → "As of v2.1.175" | ✅ COMPLETE (badge and header updated in Phase 2.6) — NEW |
+| 4 | MED | Missing Env Var | Add `API_FORCE_IDLE_TIMEOUT` to env vars table near `API_TIMEOUT_MS` — override 5-minute idle timeout for streaming; confirmed on official /en/env-vars page (v2.1.169) | ✅ COMPLETE (added after `API_TIMEOUT_MS` row) — NEW |
+| 5 | MED | Missing Env Var | Add `CLAUDE_CODE_DISABLE_ADVISOR_TOOL` to env vars table near other DISABLE_ vars — disable the advisor tool and `/advisor` command; confirmed on official /en/env-vars page (min v2.1.98) | ✅ COMPLETE (added after `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS` row) — NEW |
+| 6 | MED | Changed Description | Update `availableModels` — add v2.1.172 note that it also constrains subagent model picker and `advisorModel` picker; add `enforceAvailableModels` cross-reference | ✅ COMPLETE (description updated in General Settings table) — NEW |
+| 7 | LOW | Changed Description | Fix `CLAUDE_CODE_EFFORT_LEVEL` — "xhigh (Opus 4.7 only, v2.1.111)" → "xhigh (Opus 4.7 and 4.8, v2.1.111)" | ✅ COMPLETE (updated in env vars table) — NEW |
+| 8 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 32+ consecutive runs | ✋ ON HOLD (kept — recurring from 2026-04-14 v2.1.107) |


### PR DESCRIPTION
## Summary

Automated daily drift check for `best-practice/claude-settings.md` against Claude Code v2.1.175 official docs. Report is 3 versions behind (v2.1.172 → v2.1.175). Two new settings keys and two missing env vars confirmed on official sources.

## Drift Report — Claude Code v2.1.175

**Agents run:** `workflow-claude-settings-agent` + `claude-code-guide` (parallel)  
**Sources:** [Settings docs](https://code.claude.com/docs/en/settings), [Env vars docs](https://code.claude.com/docs/en/env-vars), [GitHub CHANGELOG](https://raw.githubusercontent.com/anthropics/claude-code/refs/heads/main/CHANGELOG.md)

---

### Changes Applied

| # | Priority | Type | Action | Status |
|---|----------|------|--------|--------|
| 1 | HIGH | New Setting | Add `enforceAvailableModels` (managed-only boolean, v2.1.175) after `availableModels` in General Settings | NEW |
| 2 | HIGH | New Setting | Add `wheelScrollAccelerationEnabled` (boolean, v2.1.174) to Display Settings table | NEW |
| 3 | HIGH | Version Bump | Badge + header: v2.1.172 → v2.1.175, date Jun 11 → Jun 12 | NEW |
| 4 | MED | Missing Env Var | Add `API_FORCE_IDLE_TIMEOUT` near `API_TIMEOUT_MS` — official /en/env-vars page, v2.1.169 | NEW |
| 5 | MED | Missing Env Var | Add `CLAUDE_CODE_DISABLE_ADVISOR_TOOL` near DISABLE_ vars — official /en/env-vars page, min v2.1.98 | NEW |
| 6 | MED | Changed Description | Update `availableModels`: add v2.1.172 subagent/advisor restriction note + `enforceAvailableModels` cross-ref | NEW |
| 7 | LOW | Changed Description | Fix `CLAUDE_CODE_EFFORT_LEVEL`: "xhigh (Opus 4.7 only)" → "(Opus 4.7 and 4.8)" | NEW |
| 8 | LOW | Suspect Key | `OTEL_LOG_TOOL_DETAILS` still not on official env-vars page (32+ consecutive runs) | ON HOLD |

---

### Verification Log (all 30 checklist rules executed)

| Rule | Category | Depth | Result | Notes |
|------|----------|-------|--------|-------|
| 1A | Key Completeness | field-level | FAIL→FIXED | `enforceAvailableModels`, `wheelScrollAccelerationEnabled` missing — added |
| 1B | Key Types | content-match | PASS | All types match official docs |
| 1C | Key Defaults | content-match | PASS | All defaults match |
| 1D | Key Descriptions | content-match | FAIL→FIXED | `availableModels` description stale — updated |
| 1E | Scope Column | content-match | PASS | Managed-only scopes verified |
| 1F | Inverse Completeness | field-level | PASS | No orphaned keys found |
| 1G | Edge-Case Semantics | content-match | PASS | Boundary values documented |
| 1H | File Scope Check | content-match | PASS | No settings.json/~/.claude.json scope confusion |
| 1I | Skills Settings Keys | field-level | PASS | `maxSkillDescriptionChars`, `skillListingBudgetFraction` present |
| 2A | Priority Levels | field-level | PASS | 5-level chain + managed policy intact |
| 2B | File Locations | content-match | PASS | All paths correct |
| 2C | Merge Semantics | content-match | PASS | "concatenated and deduplicated" wording matches |
| 2D | Managed Internals | field-level | PASS | Delivery methods and precedence documented |
| 3A | Permission Modes | field-level | PASS | All modes present |
| 3B | Tool Syntax Patterns | content-match | PASS | All patterns verified |
| 3C | Bidirectional Mode Check | field-level | PASS | No orphaned/undocumented modes |
| 3D | Evaluation Semantics | content-match | PASS | Deny-first, path-prefix patterns documented |
| 4A | Hooks Redirect | exists | PASS | Redirect link to claude-code-hooks valid |
| 5A | Env Var Completeness | field-level | FAIL→FIXED | `API_FORCE_IDLE_TIMEOUT`, `CLAUDE_CODE_DISABLE_ADVISOR_TOOL` missing — added |
| 5B | Ownership Boundary | cross-file | PASS | No cross-file env var duplication |
| 5C | Env Var Descriptions | content-match | FAIL→FIXED | `CLAUDE_CODE_EFFORT_LEVEL` Opus 4.8 note missing — fixed |
| 5D | Inverse Env Var Check | field-level | PASS | All report vars traceable to official source or annotated |
| 6A | Quick Reference Example | content-match | PASS | Example uses valid current settings |
| 6B | Example URL Validation | exists | PASS | `$schema` URL functional (301 redirect to www.schemastore.org — known, intentional) |
| 7A | CLAUDE.md Sync | cross-file | PASS | Configuration hierarchy consistent |
| 8A | Source Credibility Guard | content-match | PASS | All findings verified against official docs only |
| 9A | Local File Links | exists | PASS | All relative links resolve |
| 9B | External URL Links | exists | PASS | All external URLs return valid pages |
| 9C | Anchor Links | exists | PASS | All ToC anchor links resolve to headings |
| 10A | Version Metadata | content-match | FAIL→FIXED | Badge/header v2.1.172 → v2.1.175 — updated |
| 10B | Suspect Key Escalation | exists | PASS | `OTEL_LOG_TOOL_DETAILS` at 32+ runs — ON HOLD per prior decision |
| 10C | Bidirectional Completeness | field-level | PASS | All report keys traceable to official sources |

---

### Resolved Since Last Run

No items from the v2.1.172 run (2026-06-11) required follow-up — all were marked COMPLETE.

### Hyperlink Validation

All links PASS. `json.schemastore.org` 301-redirect is intentional (per v2.1.119 #8 decision).

---

## Commits

1. `changelog: append v2.1.175 settings drift run (2026-06-12)` — Phase 2.5
2. `settings: add enforceAvailableModels, wheelScrollAccelerationEnabled, 2 env vars; bump to v2.1.175` — Phases 2.6 + 3

---
_Generated by [Claude Code](https://claude.ai/code/session_01DFFEQ7x7XXZv1WzKfrfdrU)_