### PR TITLE
feat(workflow-router): add lane selection skill

### DIFF
--- a/.claude/skills/workflow-router/SKILL.md
+++ b/.claude/skills/workflow-router/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: workflow-router
+description: "Choose the right Codex execution lane before work begins. Use when the main uncertainty is how to route the work: direct answer, solo execution, repo inspection, native subagents, planning artifact, review gate, OMX runtime, or Fusion-style judge. Also use for ambiguous, multi-track, high-risk, review-locked, or long-running tasks where the execution lane is not already obvious."
+---
+
+# Workflow Router
+
+Use this skill as a front door for execution-lane selection. It is advisory by default: pick the lane, state why, define the next action packet, and name escalation gates. Do not silently launch heavyweight runtime flows.
+
+## Quick Start
+
+1. Detect the environment lightly.
+2. Classify the task shape.
+3. Score routing pressure with `0/1/2` fields.
+4. Choose one primary lane.
+5. Emit `Routing Decision`, `Do`, `Do Not`, and `Escalation Gates`.
+
+## Lightweight Environment Detection
+
+Run environment detection only when it can change the lane decision. Skip it for obvious `direct-chat`, obvious `planning-artifact`, user-specified workflows, or small `solo-execute` tasks with no runtime coordination.
+
+Run only enough detection to route when `omx-runtime`, `native-subagents`, browser/server state, external APIs, or long-running workflows are plausible candidates:
+
+```bash
+env | sort | rg '^(OMX|TMUX|CODEX)'
+command -v omx
+omx status
+```
+
+Do not run `omx doctor` unless the task is setup/debug oriented.
+
+Classify OMX availability:
+
+- `attached`: OMX/TMUX runtime signal is present and `omx status` confirms active runtime state.
+- `cli-only`: `omx` exists, but no attached runtime signal is present.
+- `unavailable`: `omx` is missing or unusable.
+
+In `cli-only` contexts, you may recommend OMX handoff or lightweight helpers, but do not silently launch `omx team`, `omx ralph`, detached tmux sessions, or long-running runtime modes.
+
+## Scoring
+
+Score each field as `0` low, `1` medium, or `2` high:
+
+- `risk`: destructive, production, security, secrets, review-locked, or irreversible risk.
+- `ambiguity`: unclear goal, scope, architecture, or acceptance criteria.
+- `evidence_need`: need for repo, web, docs, logs, tests, or source-backed claims.
+- `artifact_need`: need for plan, brief, handoff, receipt, or reusable recipe.
+- `parallelism`: independent packets that can run concurrently.
+- `runtime_coupling`: dependence on OMX runtime, browser/server state, external API, or long-running process.
+
+## Lane Selection
+
+Use the lane taxonomy in [routing-matrix.md](references/routing-matrix.md).
+
+If the user explicitly names a workflow, skill, or tool, treat it as the primary lane hint. Add guardrails, availability checks, and fallbacks as needed, but do not override the named lane unless it is unsafe, unavailable, or contradicts explicit user constraints.
+
+Default tendencies:
+
+- Low risk, low ambiguity, low evidence need: `direct-chat` or `solo-execute`.
+- Local discovery without edits: `repo-inspection`.
+- Independent packets: `native-subagents`.
+- Durable plan before execution: `planning-artifact`.
+- Review-locked or high-risk implementation: `review-gate-loop`.
+- Attached OMX runtime plus persistent coordinated execution: `omx-runtime`.
+- Expensive, high-ambiguity decision: `fusion-style-judge`.
+
+## Output Contract
+
+Use the short format in [routing-decision.md](templates/routing-decision.md). Keep it compact. The router is not a full plan generator.
+
+## Fusion-Style Judge
+
+Use [fusion-style-review.md](references/fusion-style-review.md) when the wrong decision is expensive and independent perspectives can materially improve the outcome. Version 1 uses native Codex subagents only. OpenRouter Fusion is a future explicit backend, not the default.
+
+## Promotion Discipline
+
+Do not add new resident AGENTS rules from one routing run. Use [promotion-gates.md](references/promotion-gates.md) before promoting any router lesson into AGENTS.md.

--- a/.claude/skills/workflow-router/examples/cli-only-omx-boundary.md
+++ b/.claude/skills/workflow-router/examples/cli-only-omx-boundary.md
@@ -1,0 +1,44 @@
+# Example: CLI-Only OMX Boundary
+
+User asks:
+
+```text
+Use $team for this multi-lane implementation.
+```
+
+Observed environment:
+
+```text
+OMX availability: cli-only
+- `omx` command exists
+- no attached `OMX_*` or `TMUX` runtime signal is present
+```
+
+## Routing Decision
+
+| Field | Value |
+| --- | --- |
+| Task shape | explicit OMX/team workflow request |
+| Scores | `risk=1`, `ambiguity=1`, `evidence_need=1`, `artifact_need=1`, `parallelism=2`, `runtime_coupling=2` |
+| Environment | `OMX=cli-only`, `native_subagents=available`, `CodeGraph=available`, `web=not relevant` |
+| Recommended lane | `omx-runtime` handoff / launch decision |
+| Fallback lane | `native-subagents` for bounded read-only planning packets |
+| Why | User explicitly requested `$team`, but current session is not attached to OMX runtime. Router should preserve the request while preventing a silent runtime switch. |
+
+## Do
+
+- State that OMX is CLI-only in this context.
+- Prepare a handoff or launch recommendation for `omx team`.
+- Use native subagents only for bounded sidecar research if useful before runtime switch.
+
+## Do Not
+
+- Silently launch `omx team`, `omx ralph`, detached tmux, or long-running runtime modes.
+- Treat native subagents as team workers with OMX worker discipline.
+- Widen implementation scope while preparing the handoff.
+
+## Escalation Gates
+
+- If the user explicitly asks to launch/switch into OMX runtime, follow the runtime launch path.
+- If the task can be safely handled without persistent runtime coordination, route back to `native-subagents` or `planning-artifact`.
+- If OMX setup health is uncertain, run `omx doctor` before recommending team execution.

--- a/.claude/skills/workflow-router/examples/current-thread-routing.md
+++ b/.claude/skills/workflow-router/examples/current-thread-routing.md
@@ -1,0 +1,30 @@
+# Example: Current Thread Routing
+
+## Routing Decision
+
+| Field | Value |
+| --- | --- |
+| Task shape | multi-track research plus workflow design |
+| Scores | `risk=1`, `ambiguity=1`, `evidence_need=2`, `artifact_need=2`, `parallelism=2`, `runtime_coupling=1` |
+| Environment | `OMX=cli-only`, `native_subagents=available`, `CodeGraph=not relevant`, `web=available` |
+| Recommended lane | `native-subagents` plus `planning-artifact` |
+| Fallback lane | `repo-inspection` plus solo synthesis |
+| Why | External research, local audit, and synthesis are separable; final output should be durable. |
+
+## Do
+
+- Use bounded native subagents for independent research packets.
+- Save a workflow artifact before synthesis.
+- Write a durable plan after scope is clear.
+
+## Do Not
+
+- Launch `omx team` from a cli-only Codex App context.
+- Edit AGENTS before candidate evidence.
+- Call live OpenRouter APIs with private data.
+
+## Escalation Gates
+
+- If the implementation spans independent owners, recommend `omx-runtime`.
+- If a high-risk decision remains contested, run `fusion-style-judge`.
+- If setup health becomes the blocker, run `omx doctor`.

--- a/.claude/skills/workflow-router/examples/explicit-workflow-request.md
+++ b/.claude/skills/workflow-router/examples/explicit-workflow-request.md
@@ -1,0 +1,34 @@
+# Example: Explicit Workflow Request
+
+User asks:
+
+```text
+Use $ce-plan to turn this discussion into a plan.
+```
+
+## Routing Decision
+
+| Field | Value |
+| --- | --- |
+| Task shape | explicit planning workflow request |
+| Scores | `risk=0`, `ambiguity=1`, `evidence_need=1`, `artifact_need=2`, `parallelism=0`, `runtime_coupling=0` |
+| Environment | skipped because runtime detection cannot change the lane |
+| Recommended lane | `planning-artifact` |
+| Fallback lane | direct structured plan if skill unavailable |
+| Why | User explicitly named `$ce-plan`; router should preserve the planning boundary rather than rerouting to execution. |
+
+## Do
+
+- Load and follow `$ce-plan`.
+- Keep the output as a durable plan.
+- Preserve the no-implementation boundary.
+
+## Do Not
+
+- Start `$ce-work`, `$team`, or implementation without a new explicit request.
+- Expand scope beyond the discussion.
+
+## Escalation Gates
+
+- If planning reveals unresolved product blockers, ask or record assumptions.
+- If implementation is requested later, route again before choosing execution lane.

--- a/.claude/skills/workflow-router/references/fusion-style-review.md
+++ b/.claude/skills/workflow-router/references/fusion-style-review.md
@@ -1,0 +1,49 @@
+# Fusion-Style Review
+
+Fusion-style review is a judge contract, not a specific provider.
+
+## Trigger
+
+Use when all are true:
+
+- the decision is high-risk or high-ambiguity;
+- being wrong is expensive;
+- at least two independent perspectives can improve the result.
+
+## Backend Policy
+
+Version 1 uses native Codex subagents only.
+
+OpenRouter Fusion is deferred to a future explicit experiment and must use non-sensitive or explicitly redacted prompts.
+
+## Panel Lenses
+
+Choose two to four independent lenses:
+
+- architecture lens;
+- execution lens;
+- risk/security lens;
+- source/docs lens;
+- testing/verification lens;
+- product/scope lens.
+
+Panelists should answer independently and report:
+
+- recommendation;
+- evidence;
+- assumptions;
+- blind spots;
+- confidence.
+
+## Judge Output
+
+The leader synthesizes:
+
+- **Consensus:** what credible panels agree on.
+- **Contradictions:** where panels conflict and which source decides.
+- **Partial coverage:** which requirements or risks were missed.
+- **Unique insights:** useful one-off ideas.
+- **Blind spots:** what remains unproven.
+- **Decision:** recommended lane or action.
+
+Do not paste raw panel outputs as the final answer.

--- a/.claude/skills/workflow-router/references/output-shapes.md
+++ b/.claude/skills/workflow-router/references/output-shapes.md
@@ -1,0 +1,36 @@
+# Output Shapes
+
+The router emits a compact decision, not a full plan.
+
+## Standard Shape
+
+```markdown
+## Routing Decision
+
+| Field | Value |
+| --- | --- |
+| Task shape |  |
+| Scores | risk=?, ambiguity=?, evidence_need=?, artifact_need=?, parallelism=?, runtime_coupling=? |
+| Environment | OMX=?, native_subagents=?, CodeGraph=?, web=? |
+| Recommended lane |  |
+| Fallback lane |  |
+| Why |  |
+
+## Do
+
+-
+
+## Do Not
+
+-
+
+## Escalation Gates
+
+-
+```
+
+## Length Budget
+
+Most router outputs should fit in 20-40 lines.
+
+If a durable plan is needed, route to `planning-artifact`; do not expand the router output into a full plan.

--- a/.claude/skills/workflow-router/references/promotion-gates.md
+++ b/.claude/skills/workflow-router/references/promotion-gates.md
@@ -1,0 +1,31 @@
+# Promotion Gates
+
+Use this before promoting router lessons into AGENTS.md or global resident guidance.
+
+## Promote Only When
+
+- The pattern appears in multiple real sessions, not one anecdote.
+- The rule would prevent repeated failures or reduce repeated friction.
+- The rule is stable across projects, or clearly scoped to a project.
+- The rule can be stated briefly without duplicating full skill logic.
+- The rule does not conflict with existing slice, review, provider, or protected-file boundaries.
+
+## Keep As Candidate When
+
+- Evidence is mixed.
+- The pattern only appeared once.
+- The guidance is long, example-heavy, or better suited to the skill.
+- The rule would slow simple tasks.
+- The rule depends on a specific repo or temporary runtime state.
+
+## Thin AGENTS Block Candidate
+
+```md
+<workflow_router>
+Use `$workflow-router` before choosing an execution lane when the task is ambiguous, multi-track, high-risk, review-locked, long-running, or mainly about selecting the right agent/workflow surface.
+
+The router is a lane-selection aid. It may recommend direct chat, solo execution, repo inspection, native subagents, planning artifacts, review gates, OMX runtime, or Fusion-style judge review. It must not widen scope, bypass approval gates, or start OMX runtime flows unless the session is actually attached to OMX runtime or the user explicitly asks to launch them.
+
+In Codex App / cli-only OMX contexts, `$workflow-router` may recommend OMX commands or handoff into OMX, but it must not silently launch `omx team`, `omx ralph`, detached tmux sessions, or long-running runtime modes.
+</workflow_router>
+```

--- a/.claude/skills/workflow-router/references/routing-matrix.md
+++ b/.claude/skills/workflow-router/references/routing-matrix.md
@@ -1,0 +1,106 @@
+# Routing Matrix
+
+## Lanes
+
+### direct-chat
+
+Use for stable, low-risk answers that do not need file reads, web verification, or durable artifacts.
+
+Signals:
+
+- `risk=0`
+- `ambiguity=0`
+- `evidence_need=0`
+- `artifact_need=0`
+
+### solo-execute
+
+Use for small local work one agent can finish and verify directly.
+
+Signals:
+
+- narrow scope;
+- no independent packets;
+- tests or checks are local and obvious.
+
+### repo-inspection
+
+Use for read-only local code or project discovery.
+
+Preferred tools:
+
+- CodeGraph for symbols, call relationships, impact, and indexed files.
+- `rg` for literal text and file discovery.
+- ordinary file reads for known paths.
+- `omx sparkshell` only when an explicit read-only shell or tmux-pane summary is useful.
+
+Do not make deprecated `omx explore` the default path.
+
+### native-subagents
+
+Use when the task has independent bounded packets that can run in parallel.
+
+Examples:
+
+- external source research plus local config audit;
+- independent review lenses;
+- separate test/fixture investigation;
+- plan critique plus implementation mapping.
+
+### planning-artifact
+
+Use when the next valuable output is a durable plan, brief, handoff, or goal/spec contract.
+
+Examples:
+
+- user asks to plan;
+- long goal needs `whole_goal` and `current_session_slice`;
+- implementation should not start before scope is clarified.
+
+### review-gate-loop
+
+Use for review-locked, high-risk, governance, rewrite, or blocker-driven work.
+
+Required posture:
+
+1. targeted verification;
+2. review;
+3. fix blocker findings;
+4. rerun verification;
+5. rerun review until blockers clear.
+
+### omx-runtime
+
+Use when the task needs persistent coordinated execution and the session is attached to OMX runtime, or the user explicitly asks to launch/switch into OMX.
+
+In `cli-only` contexts, recommend a handoff rather than silently launching runtime flows.
+
+### fusion-style-judge
+
+Use when:
+
+- `risk=2` or `ambiguity=2`;
+- wrong decision is expensive;
+- independent perspectives can materially improve the decision.
+
+Version 1 backend: native Codex subagents.
+
+## Tie Breakers
+
+- Explicit workflow/tool requests win as lane hints. The router may add guardrails, but should not override a named workflow unless it is unsafe, unavailable, or contradicts explicit user constraints.
+- Prefer the lightest lane that can prove the claim.
+- Escalate only when the current lane cannot provide enough evidence or coordination.
+- Do not use router output as permission to widen scope.
+- Do not bypass provider, credential, destructive, or external-production gates.
+- Detect runtime availability only when it can change the lane decision; skip environment checks for obvious lightweight lanes.
+- Keep scoring as agent judgment in v1. Do not add a deterministic scoring helper until repeated routing examples show drift.
+
+## Explicit Request Examples
+
+| User request | Router stance |
+| --- | --- |
+| `use $ce-plan` | Choose `planning-artifact`; preserve no-implementation boundary. |
+| `use CodeGraph` | Choose `repo-inspection`; use CodeGraph for structural queries and `rg` for literal text. |
+| `use $team` | Choose `omx-runtime`; verify attached runtime or prepare handoff. |
+| `use native subagents` | Choose `native-subagents`; split bounded independent packets. |
+| `use OpenRouter Fusion` | Choose `fusion-style-judge`; enforce provider, secret, and data boundaries. |

--- a/.claude/skills/workflow-router/templates/panel-judge-report.md
+++ b/.claude/skills/workflow-router/templates/panel-judge-report.md
@@ -1,0 +1,25 @@
+## Fusion-Style Judge Report
+
+### Consensus
+
+-
+
+### Contradictions
+
+-
+
+### Partial Coverage
+
+-
+
+### Unique Insights
+
+-
+
+### Blind Spots
+
+-
+
+### Decision
+
+-

--- a/.claude/skills/workflow-router/templates/routing-decision.md
+++ b/.claude/skills/workflow-router/templates/routing-decision.md
@@ -1,0 +1,22 @@
+## Routing Decision
+
+| Field | Value |
+| --- | --- |
+| Task shape |  |
+| Scores | `risk=?`, `ambiguity=?`, `evidence_need=?`, `artifact_need=?`, `parallelism=?`, `runtime_coupling=?` |
+| Environment | `OMX=?`, `native_subagents=?`, `CodeGraph=?`, `web=?` |
+| Recommended lane |  |
+| Fallback lane |  |
+| Why |  |
+
+## Do
+
+-
+
+## Do Not
+
+-
+
+## Escalation Gates
+
+-


### PR DESCRIPTION
## Summary

Agents can now invoke a `workflow-router` Claude Code skill to choose an execution lane before acting on ambiguous, multi-track, high-risk, review-locked, or long-running work. This PR now matches the clean install package from the workflow-router draft: `SKILL.md`, the core routing references, compact output templates, and the three packaged examples.

```mermaid
flowchart TD
    A["User task arrives"] --> B{"Is lane choice obvious?"}
    B -->|"Yes"| C["Direct chat or solo execute"]
    B -->|"No"| D["Invoke workflow-router"]
    D --> E["Light environment check when it can change routing"]
    E --> F["Score risk, ambiguity, evidence, artifact, parallelism, runtime coupling"]
    F --> G{"Choose primary lane"}
    G --> H["repo-inspection"]
    G --> I["native-subagents"]
    G --> J["planning-artifact"]
    G --> K["review-gate-loop"]
    G --> L["omx-runtime"]
    G --> M["fusion-style-judge"]
    H --> N["Routing Decision packet"]
    I --> N
    J --> N
    K --> N
    L --> N
    M --> N
    N --> O["Do / Do Not / Escalation Gates"]
```

## What reviewers should look for

- The new skill is isolated under `.claude/skills/workflow-router/`; no hooks, settings, commands, agents, or resident repo guidance are changed.
- The final file list matches the draft `install-manifest.txt`; setup-hygiene-only files such as `agents-routing-contract.md` and `plain-repo-lookup.md` are intentionally excluded.
- The routing matrix keeps ordinary repo lookup lightweight with CodeGraph, `rg`, and targeted reads, while reserving OMX runtime paths for explicit or attached-runtime contexts.
- The packaged examples cover explicit workflow requests, current-thread routing, and CLI-only OMX boundaries.

## Verification

- `git diff --check origin/main...HEAD`
- Compared final PR file list against `/Users/surahli/Documents/Codex/2026-06-13/can-you-research-on-claude-fable/work/codex-workflow-router/install-manifest.txt`.
- Confirmed `SKILL.md` relative links resolve to the copied `references/` and `templates/` files.
- `rg -n "[^\\x00-\\x7F]" .claude/skills/workflow-router` returned no matches.
- Read `CLAUDE.md` and existing `.claude/skills/*/SKILL.md` examples for placement and frontmatter conventions.

Not run: Claude Code runtime invocation of the skill.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
