### PR TITLE
Daily settings drift check — 2026-06-15 (Claude Code v2.1.176)

### DIFF
--- a/best-practice/claude-settings.md
+++ b/best-practice/claude-settings.md
@@ -1,6 +1,6 @@
 # Settings Best Practice
 
-![Last Updated](https://img.shields.io/badge/Last_Updated-Jun%2014%2C%202026%2010%3A49%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.176-blue?style=flat&labelColor=555)<br>
+![Last Updated](https://img.shields.io/badge/Last_Updated-Jun%2015%2C%202026%2010%3A45%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.176-blue?style=flat&labelColor=555)<br>
 [![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../.claude/settings.json)
 
 A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.176, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).

--- a/changelog/best-practice/claude-settings/changelog.md
+++ b/changelog/best-practice/claude-settings/changelog.md
@@ -841,3 +841,14 @@
 |---|----------|------|--------|--------|
 | 1 | HIGH | Missing Env Var | Add `CLAUDE_CODE_CHILD_SESSION` to Common Environment Variables table — set to `1` in subprocesses Claude Code spawns (Bash, PowerShell, Monitor tools, hooks, status line). Not set for stdio MCP servers. Reliably distinguishes nested `claude` sessions from top-level IDE launches unlike `CLAUDECODE`. Nested TUI sessions excluded from `--resume`/`--continue`/history; override with `CLAUDE_CODE_FORCE_SESSION_PERSISTENCE=1`. Confirmed on official /en/env-vars page (v2.1.172) | ✅ COMPLETE (added after `CLAUDECODE` row in env vars table) — NEW |
 | 2 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 34+ consecutive runs. Annotation "in v2.1.85 changelog, not yet on official env-vars page" remains accurate | ✋ ON HOLD (kept — recurring from 2026-04-14 v2.1.107) |
+
+---
+
+## [2026-06-15 10:45 AM PKT] Claude Code v2.1.176
+
+| # | Priority | Type | Action | Status |
+|---|----------|------|--------|--------|
+| 1 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 35+ consecutive runs. Annotation "in v2.1.85 changelog, not yet on official env-vars page" remains accurate | ✋ ON HOLD (kept — recurring from 2026-04-14 v2.1.107) |
+| 2 | INVALID | Spurious Drift Claim | `claude-code-guide` listed `DISABLE_PROMPT_CACHING_FABLE` as missing from env vars table. Not on official /en/env-vars page per Rule 8A. RECURRING (first rejected 2026-06-11 v2.1.172 #7) | ❌ INVALID (Rule 8A — not on official env-vars page) |
+| 3 | INVALID | Spurious Drift Claim | `claude-code-guide` listed `best` as a missing model alias. Not found in the official settings page model aliases section per Rule 8A | ❌ INVALID (Rule 8A — not on official settings page) |
+| 4 | INVALID | Spurious Drift Claim | `claude-code-guide` listed effort values as `fast`/`balanced`/`thorough`. Official /en/env-vars page confirms valid values are `low`, `medium`, `high`, `xhigh`, `max`, `auto`. RECURRING from v2.1.139 and v2.1.145 | ❌ INVALID (agent contradicted by official docs — recurring error) |


### PR DESCRIPTION
## Summary

**Zero actionable drift this run.** No new Claude Code version has been released since v2.1.176. The report is fully current. This PR contains only housekeeping: the mandatory changelog entry and Last Updated badge sync.

---

## Drift Report — Claude Code v2.1.176 (2026-06-15)

**Sources checked:**
- Settings docs: https://code.claude.com/docs/en/settings ✅
- Env vars docs: https://code.claude.com/docs/en/env-vars ✅
- Permissions docs: https://code.claude.com/docs/en/permissions ✅
- CLI reference: https://code.claude.com/docs/en/cli-reference ✅
- Raw changelog: https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md ✅ (latest: v2.1.176 — no new release)

---

### 1. New Settings Keys
None. All keys confirmed current at v2.1.176.

### 2. Changed Setting Behavior
None detected.

### 3. Deprecated/Removed Settings
None detected.

### 4. Permission Syntax Changes
None detected.

### 5. MCP Setting Changes
None detected.

### 6. Sandbox Setting Changes
None detected.

### 7. Plugin Setting Changes
None detected.

### 8. Model Configuration Changes
None detected. (`claude-code-guide` agent claimed `best` as a missing model alias — **rejected per Rule 8A**, not on official settings page.)

### 9. Display & UX Changes
None detected.

### 10. Environment Variable Completeness
No gaps. (`claude-code-guide` agent claimed `DISABLE_PROMPT_CACHING_FABLE` was missing — **rejected per Rule 8A**, not on official /en/env-vars page. First rejected 2026-06-11 v2.1.172 #7.)

### 11. Settings Hierarchy Accuracy
5-level chain + managed policy layer matches official docs. No changes.

### 12. Example Accuracy
Quick Reference example (lines 1121–1243) is current and valid.

### 13. Sources Accuracy
All source links valid. SchemaStore URL returns 301→`www.schemastore.org` (expected, accepted since v2.1.119 decision).

### 14. claude-code-guide Agent Findings — Contradictions Flagged
| Claim | Decision |
|-------|----------|
| `DISABLE_PROMPT_CACHING_FABLE` missing from env vars | ❌ INVALID — not on official /en/env-vars page (Rule 8A). Recurring from v2.1.172 |
| `best` missing from model aliases | ❌ INVALID — not on official settings page (Rule 8A) |
| Effort values `fast`/`balanced`/`thorough` | ❌ INVALID — official docs confirm `low`/`medium`/`high`/`xhigh`/`max`/`auto`. Recurring from v2.1.139, v2.1.145 |

---

## Verification Log

| Rule | Category | Depth | Result | Notes |
|------|----------|-------|--------|-------|
| 1A | Key Completeness | field-level | PASS | All keys present |
| 1B | Key Types | content-match | PASS | Types match official docs |
| 1C | Key Defaults | content-match | PASS | Defaults match official docs |
| 1D | Key Descriptions | content-match | PASS | Descriptions accurate |
| 1E | Scope Column | content-match | PASS | Scopes correct |
| 1F | Inverse Completeness | field-level | PASS | All report keys traceable to official source or annotated |
| 1G | Edge-Case Semantics | content-match | PASS | Boundary behaviors documented |
| 1H | File Scope Check | content-match | PASS | `showTurnDuration`/`terminalProgressBarEnabled` correctly in `~/.claude.json` section |
| 1I | Skills Settings Keys | field-level | PASS | `skillOverrides`, `disableSkillShellExecution`, `maxSkillDescriptionChars`, `skillListingBudgetFraction` all present |
| 2A | Priority Levels | field-level | PASS | 5-level chain + managed matches |
| 2B | File Locations | content-match | PASS | All paths correct |
| 2C | Merge Semantics | content-match | PASS | "concatenated and deduplicated" wording matches |
| 2D | Managed Internals | field-level | PASS | MDM/registry/file delivery + deprecation notes present |
| 3A | Permission Modes | field-level | PASS | All modes documented |
| 3B | Tool Syntax Patterns | content-match | PASS | Patterns and examples match |
| 3C | Bidirectional Mode Check | field-level | PASS | No undocumented modes in report |
| 3D | Evaluation Semantics | content-match | PASS | Deny-first, path prefixes documented |
| 4A | Hooks Redirect | exists | PASS | Redirect link to claude-code-hooks repo present |
| 5A | Env Var Completeness | field-level | PASS | All official env vars present |
| 5B | Ownership Boundary | cross-file | PASS | No overlap between settings report and cli-startup-flags report |
| 5C | Env Var Descriptions | content-match | PASS | Descriptions match official /en/env-vars page |
| 5D | Inverse Env Var Check | field-level | PASS | All report vars traceable; `OTEL_LOG_TOOL_DETAILS` annotated |
| 6A | Quick Reference Example | content-match | PASS | Example uses valid current settings |
| 6B | Example URL Validation | exists | PASS | `$schema` URL resolves correctly |
| 7A | CLAUDE.md Sync | cross-file | PASS | Configuration hierarchy consistent |
| 8A | Source Credibility Guard | content-match | PASS | 3 spurious agent-2 claims rejected; all flagged items confirmed against official docs |
| 9A | Local File Links | exists | PASS | `../best-practice/claude-cli-startup-flags.md`, `.claude/settings.json`, badge image all resolve |
| 9B | External URL Links | exists | PASS | All 6 Sources URLs return valid pages |
| 9C | Anchor Links | exists | PASS | Internal anchors intact |
| 10A | Version Metadata | content-match | PASS | Badge shows v2.1.176; header "As of v2.1.176" matches |
| 10B | Suspect Key Escalation | exists | PASS | `OTEL_LOG_TOOL_DETAILS` at 35+ runs — reviewed, annotation remains accurate; no escalation needed (already annotated "in v2.1.85 changelog, not yet on official env-vars page") |
| 10C | Bidirectional Completeness | field-level | PASS | Every key/mode/var traceable to official source or marked unverified |

All 31 rules: **PASS** ✅

---

## Priority Actions

| # | Priority | Type | Action | Status |
|---|----------|------|--------|--------|
| 1 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — 35+ consecutive runs not on official env-vars page | ✋ ON HOLD (recurring from 2026-04-14 v2.1.107) |
| 2 | INVALID | Spurious Drift Claim | `DISABLE_PROMPT_CACHING_FABLE` — not on official env-vars page | ❌ INVALID (Rule 8A) |
| 3 | INVALID | Spurious Drift Claim | `best` model alias — not on official settings page | ❌ INVALID (Rule 8A) |
| 4 | INVALID | Spurious Drift Claim | Effort values `fast`/`balanced`/`thorough` — contradicted by official docs | ❌ INVALID (recurring agent error) |

## Resolved Since Last Run

None — yesterday's run (2026-06-14) fully closed all HIGH items (`CLAUDE_CODE_CHILD_SESSION` added). This run confirms continued alignment.

---

## Changes in This PR

- `changelog/best-practice/claude-settings/changelog.md` — appended 2026-06-15 entry (Phase 2.5)
- `best-practice/claude-settings.md` — Last Updated badge → Jun 15, 2026 10:45 AM PKT (Phase 2.6)

https://claude.ai/code/session_01Le6QeWvod9cFcUhirU5B3H

---
_Generated by [Claude Code](https://claude.ai/code/session_01Le6QeWvod9cFcUhirU5B3H)_