### PR TITLE
Daily settings drift check — 2026-06-16 (Claude Code v2.1.178)

### DIFF
--- a/best-practice/claude-settings.md
+++ b/best-practice/claude-settings.md
@@ -1,9 +1,9 @@
 # Settings Best Practice
 
-![Last Updated](https://img.shields.io/badge/Last_Updated-Jun%2015%2C%202026%2010%3A45%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.176-blue?style=flat&labelColor=555)<br>
+![Last Updated](https://img.shields.io/badge/Last_Updated-Jun%2016%2C%202026%2010%3A46%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.178-blue?style=flat&labelColor=555)<br>
 [![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../.claude/settings.json)
 
-A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.176, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
+A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.178, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
 
 <table width="100%">
 <tr>
@@ -105,13 +105,16 @@ Within the managed tier, precedence is: server-managed > MDM/OS-level policies >
 | `wslInheritsWindowsSettings` | boolean | `false` | **(Windows managed settings only)** When `true`, Claude Code on WSL reads managed settings from the Windows policy chain (HKLM registry + `C:\Program Files\ClaudeCode\managed-settings.json`) in addition to `/etc/claude-code`, with Windows sources taking priority. Only honored when set in the HKLM registry key or `C:\Program Files\ClaudeCode\managed-settings.json`, both of which require Windows admin to write. For HKCU policy to also apply on WSL, the flag must additionally be set in HKCU itself. Has no effect on native Windows (v2.1.118) |
 | `tui` | string | `"default"` | Rendering mode: `"fullscreen"` or `"default"`. Set via `/tui fullscreen` for flicker-free alt-screen rendering (v2.1.110) |
 | `awaySummaryEnabled` | boolean | `true` | Generate an "away summary" (idle-session recap) when the user returns after being away. Set to `false` to opt out. Pairs with the `CLAUDE_CODE_ENABLE_AWAY_SUMMARY` env var (v2.1.110) |
+| `autoCompactEnabled` | boolean | `true` | Auto-compact the conversation when context approaches the model's limit. Set to `false` to disable automatic compaction and manage context manually. Also disableable via the `DISABLE_AUTO_COMPACT` env var |
 | `skillOverrides` | object | - | Per-skill visibility overrides keyed by skill name. Value is `"on"` (full), `"name-only"` (visible but not auto-described), `"user-invocable-only"` (hidden from model discovery but still slash-invocable), or `"off"` (fully hidden). Example: `{"legacy-context": "name-only", "deploy": "off"}` (v2.1.129) |
 | `disableRemoteControl` | boolean | `false` | Disable [Remote Control](https://code.claude.com/docs/en/remote-control): blocks `claude remote-control`, the `--remote-control` flag, auto-start, and the in-session toggle. Typically placed in managed settings for per-device MDM enforcement, but works from any scope (v2.1.128) |
+| `agentPushNotifEnabled` | boolean | `false` | Send proactive push notifications to [Remote Control](https://code.claude.com/docs/en/remote-control) when Claude decides to push (e.g., task complete). Appears in `/config` as **Push when Claude decides** |
+| `inputNeededNotifEnabled` | boolean | `false` | Send a push notification to [Remote Control](https://code.claude.com/docs/en/remote-control) when a permission prompt or question awaits user input. Appears in `/config` as **Push when actions required** |
 | `disableAgentView` | boolean | `false` | Set to `true` to turn off [background agents and agent view](https://code.claude.com/docs/en/agent-view): `claude agents`, `--bg`, `/background`, and the on-demand supervisor. Can be set at any scope but typically placed in managed settings. Equivalent to setting the `CLAUDE_CODE_DISABLE_AGENT_VIEW` env var to `1` |
 | `disableWorkflows` | boolean | `false` | Set to `true` to disable [dynamic workflows](https://code.claude.com/docs/en/workflows) (`/workflows`) and the bundled workflow slash commands. Can be set at any scope. Equivalent to the `CLAUDE_CODE_DISABLE_WORKFLOWS` env var. Workflows were introduced in v2.1.154 |
 | `workflowKeywordTriggerEnabled` | boolean | `true` | Whether typing the word "ultracode" in a prompt triggers a [dynamic workflow](https://code.claude.com/docs/en/workflows). Set to `false` to require explicit `/workflows` invocation. Ultracode, `/workflows`, and saved workflow commands are unaffected by this setting. Appears in `/config` as **Workflow keyword trigger** (v2.1.157; trigger keyword renamed workflow→ultracode in v2.1.160) |
 | `ultracode` | boolean | - | **(Session-only — not persisted)** When `true`, the harness authors and runs a workflow for every substantive task by default, maximizing thoroughness regardless of token cost. Appears in the official "Available settings" list but is session-scoped: set via `/effort ultracode`, `--settings`, or the SDK rather than written to `settings.json` (v2.1.154) |
-| `disableBundledSkills` | boolean | `false` | Conceal Claude Code's built-in capabilities (bundled skills) from the model. When `true`, the model cannot invoke built-in skills. Paired with the `CLAUDE_CODE_DISABLE_BUNDLED_SKILLS` env var. Useful when strict plugin-only customization is required *(in v2.1.169 changelog, not yet on official settings page)* |
+| `disableBundledSkills` | boolean | `false` | Conceal Claude Code's built-in capabilities (bundled skills) from the model. When `true`, the model cannot invoke built-in skills. Paired with the `CLAUDE_CODE_DISABLE_BUNDLED_SKILLS` env var. Useful when strict plugin-only customization is required (v2.1.169) |
 | `feedbackSurveyRate` | number | - | Probability (0–1) that the session quality survey appears when eligible. Enterprise admins can control how often the survey is shown. Example: `0.05` = 5% of eligible sessions |
 | `advisorModel` | string | - | Model for the server-side advisor tool. Accepts a model alias (`opus`, `sonnet`, `fable`) or a full model ID. When unset, the advisor uses the session model. Requires v2.1.98+ |
 
@@ -136,6 +139,7 @@ Store plan and auto-memory files in custom locations.
 | `plansDirectory` | string | `~/.claude/plans` | Directory where `/plan` outputs are stored |
 | `autoMemoryDirectory` | string | - | Custom directory for auto-memory storage. Accepts `~/`-expanded paths. Not accepted in project settings (`.claude/settings.json`) to prevent redirecting memory writes to sensitive locations; accepted from policy, local, and user settings |
 | `autoMemoryEnabled` | boolean | `true` | Enable [auto memory](https://code.claude.com/docs/en/memory). When `false`, Claude does not read from or write to the auto-memory directory. Can also be toggled with `/memory` during a session, or disabled via the `CLAUDE_CODE_DISABLE_AUTO_MEMORY` env var |
+| `fileCheckpointingEnabled` | boolean | `true` | Snapshot files before each edit so you can restore them with `/rewind`. Set to `false` to skip checkpointing and save disk space. Also disableable via the `CLAUDE_CODE_DISABLE_FILE_CHECKPOINTING` env var |
 
 **Example:**
 ```json
@@ -293,6 +297,7 @@ Control what tools and operations Claude can perform.
 | `Agent` | `Agent(name)` | `Agent(researcher)`, `Agent(*)` — permission scoped to subagent spawning |
 | `Skill` | `Skill(skill-name)` or `Skill(prefix *)` | `Skill(weather-fetcher)`, `Skill(weather *)` matches `weather-fetcher`/`weather-svg-creator` (v2.1.139) |
 | `MCP` | `mcp__server__tool` or `MCP(server:tool)` | `mcp__memory__*`, `MCP(github:*)` |
+| `Tool` | `Tool(param:value)` | `Agent(model:opus)`, `Bash(cmd:npm run *)` — match permission rules against a tool's input parameters; supports `*` wildcards in the value position (v2.1.178) |
 | `Cd` | `Cd(path pattern)` | `Cd(/home/*)`, `Cd(~/projects/*)` — controls which directories the `/cd` command may navigate to |
 
 **Evaluation order:** Rules are evaluated in order: deny rules first, then ask, then allow. The first matching rule wins.
@@ -640,7 +645,7 @@ Configure via `env` key:
 | `terminalProgressBarEnabled` | boolean | `true` | Show the terminal progress bar in supported terminals (ConEmu, Ghostty 1.2.0+, and iTerm2 3.6.6+). Appears in `/config` as **Terminal progress bar**. Versions before v2.1.119 stored this in `~/.claude.json` |
 | `preferredNotifChannel` | string | `"auto"` | Method for task-complete and permission-prompt notifications. Values: `"auto"`, `"terminal_bell"`, `"iterm2"`, `"iterm2_with_bell"`, `"kitty"`, `"ghostty"`, `"notifications_disabled"`. Default `"auto"` sends a desktop notification in iTerm2, Ghostty, and Kitty and does nothing in other terminals. Set `"terminal_bell"` to ring the bell character in any terminal. Appears in `/config` as **Notifications**. See [Get a terminal bell or notification](https://code.claude.com/docs/en/terminal-config#get-a-terminal-bell-or-notification) |
 | `wheelScrollAccelerationEnabled` | boolean | `true` | Disable mouse-wheel scroll acceleration in fullscreen mode. Set to `false` to use fixed per-tick scroll steps instead of the OS-level acceleration curve (v2.1.174) |
-| `footerLinksRegexes` | array | - | Regex patterns matched against URLs to display as link badges in the footer row. Each matching URL produces a clickable badge at the bottom of the chat UI. (in v2.1.176 changelog, not yet on official settings page) |
+| `footerLinksRegexes` | array | - | Regex patterns matched against URLs to display as link badges in the footer row. Each matching URL produces a clickable badge at the bottom of the chat UI (v2.1.176) |
 
 ### Global Config Settings (`~/.claude.json`)
 
@@ -902,7 +907,7 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` | Enable the experimental agent teams feature (`1` to enable). Allows spawning coordinated teams of subagents within a session |
 | `CLAUDE_CODE_DISABLE_WORKFLOWS` | Set to `1` to disable [dynamic workflows](https://code.claude.com/docs/en/workflows) (`/workflows`) and the bundled workflow slash commands. Env-var equivalent of the `disableWorkflows` setting |
 | `CLAUDE_CODE_ENABLE_AUTO_MODE` | Set to `1` to make [auto mode](https://code.claude.com/docs/en/permission-modes#eliminate-prompts-with-auto-mode) available on Amazon Bedrock, Google Cloud Vertex AI, and Microsoft Foundry. Has no effect on the Anthropic API, where auto mode is available by default (v2.1.158) |
-| `CLAUDE_CODE_DISABLE_BUNDLED_SKILLS` | Set to `1` to conceal Claude Code's built-in capabilities (bundled skills) from the model. Env-var equivalent of the `disableBundledSkills` setting *(in v2.1.169 changelog, not yet on official env-vars page)* |
+| `CLAUDE_CODE_DISABLE_BUNDLED_SKILLS` | Set to `1` to conceal Claude Code's built-in capabilities (bundled skills) from the model. Env-var equivalent of the `disableBundledSkills` setting (v2.1.169) |
 | `ENABLE_TOOL_SEARCH` | MCP tool search threshold (e.g., `auto:5`) |
 | `ENABLE_PROMPT_CACHING_1H` | Opt into 1-hour prompt cache TTL. Replaces the deprecated `ENABLE_PROMPT_CACHING_1H_BEDROCK` *(in v2.1.108 changelog, not yet on official env-vars page)* |
 | `FORCE_PROMPT_CACHING_5M` | Force 5-minute prompt cache TTL *(in v2.1.108 changelog, not yet on official env-vars page)* |

--- a/changelog/best-practice/claude-settings/changelog.md
+++ b/changelog/best-practice/claude-settings/changelog.md
@@ -852,3 +852,17 @@
 | 2 | INVALID | Spurious Drift Claim | `claude-code-guide` listed `DISABLE_PROMPT_CACHING_FABLE` as missing from env vars table. Not on official /en/env-vars page per Rule 8A. RECURRING (first rejected 2026-06-11 v2.1.172 #7) | ❌ INVALID (Rule 8A — not on official env-vars page) |
 | 3 | INVALID | Spurious Drift Claim | `claude-code-guide` listed `best` as a missing model alias. Not found in the official settings page model aliases section per Rule 8A | ❌ INVALID (Rule 8A — not on official settings page) |
 | 4 | INVALID | Spurious Drift Claim | `claude-code-guide` listed effort values as `fast`/`balanced`/`thorough`. Official /en/env-vars page confirms valid values are `low`, `medium`, `high`, `xhigh`, `max`, `auto`. RECURRING from v2.1.139 and v2.1.145 | ❌ INVALID (agent contradicted by official docs — recurring error) |
+
+---
+
+## [2026-06-16 10:46 AM PKT] Claude Code v2.1.178
+
+| # | Priority | Type | Action | Status |
+|---|----------|------|--------|--------|
+| 1 | HIGH | Missing Settings | Add `agentPushNotifEnabled` (boolean, false) and `inputNeededNotifEnabled` (boolean, false) to General Settings table — Remote Control push notification controls. Confirmed on official settings page | ✅ COMPLETE (added to General Settings table after disableRemoteControl) |
+| 2 | HIGH | Missing Setting | Add `autoCompactEnabled` (boolean, true) to General Settings table — auto-compact conversation when context approaches limit. Confirmed on official settings page | ✅ COMPLETE (added after awaySummaryEnabled) |
+| 3 | HIGH | Missing Setting | Add `fileCheckpointingEnabled` (boolean, true) to Plans & Memory Directories table — snapshot files before edits for /rewind restoration. Confirmed on official settings page | ✅ COMPLETE (added after autoMemoryEnabled) |
+| 4 | HIGH | Permission Syntax | Add `Tool(param:value)` row to Tool Permission Syntax table — new parameter-matching syntax (v2.1.178 changelog). Example: `Agent(model:opus)` | ✅ COMPLETE (added after MCP row with wildcard support note) |
+| 5 | MED | Stale Annotation | Remove "(in v2.1.176 changelog, not yet on official settings page)" from `footerLinksRegexes` — now confirmed on official settings page | ✅ COMPLETE (annotation updated to (v2.1.176)) |
+| 6 | MED | Stale Annotation | Remove "*(in v2.1.169 changelog, not yet on official settings page)*" from `disableBundledSkills` and `CLAUDE_CODE_DISABLE_BUNDLED_SKILLS` — now confirmed on official page | ✅ COMPLETE (annotations updated to (v2.1.169)) |
+| 7 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 36+ consecutive runs. Annotation "in v2.1.85 changelog, not yet on official env-vars page" remains accurate | ✋ ON HOLD (kept — recurring from 2026-04-14 v2.1.107) |


### PR DESCRIPTION
## Daily Settings Drift Report — Claude Code v2.1.178 (2026-06-16)

Automated drift check against [official settings docs](https://code.claude.com/docs/en/settings), [env-vars page](https://code.claude.com/docs/en/env-vars), and [GitHub CHANGELOG](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md).

---

## 1. New Settings Keys

| Key | Type | Default | Section | Version | Status |
|-----|------|---------|---------|---------|--------|
| `agentPushNotifEnabled` | boolean | `false` | General Settings | v2.1.178 | ✅ ADDED |
| `inputNeededNotifEnabled` | boolean | `false` | General Settings | v2.1.178 | ✅ ADDED |
| `autoCompactEnabled` | boolean | `true` | General Settings | v2.1.178 | ✅ ADDED |
| `fileCheckpointingEnabled` | boolean | `true` | Plans & Memory Directories | v2.1.178 | ✅ ADDED |

**`agentPushNotifEnabled`** — Send proactive push notifications to Remote Control when Claude decides to push (e.g., task complete). Appears in `/config` as **Push when Claude decides**.

**`inputNeededNotifEnabled`** — Send a push notification to Remote Control when a permission prompt or question awaits user input. Appears in `/config` as **Push when actions required**.

**`autoCompactEnabled`** — Auto-compact the conversation when context approaches the model's limit. Set to `false` to disable and manage context manually. Also disableable via `DISABLE_AUTO_COMPACT` env var.

**`fileCheckpointingEnabled`** — Snapshot files before each edit so you can restore them with `/rewind`. Set to `false` to skip checkpointing and save disk space. Also disableable via `CLAUDE_CODE_DISABLE_FILE_CHECKPOINTING` env var.

---

## 2. Changed Setting Behavior

No changed types, defaults, or descriptions detected this run.

---

## 3. Deprecated/Removed Settings

No deprecated or removed settings detected this run.

---

## 4. Permission Syntax Changes

| Pattern | Example | Notes | Status |
|---------|---------|-------|--------|
| `Tool(param:value)` | `Agent(model:opus)`, `Bash(cmd:npm run *)` | Match permission rules against a tool's input parameters; supports `*` wildcards in value position (v2.1.178) | ✅ ADDED |

---

## 5–9. MCP / Sandbox / Plugin / Model / Display Changes

No drift detected in MCP, Sandbox, Plugin, Model Configuration, or Display & UX sections.

---

## 10. Environment Variable Completeness

No missing or removed env vars. One recurring ON HOLD item:

- `OTEL_LOG_TOOL_DETAILS` — still **not on official /en/env-vars page** after **36+ consecutive runs** (recurring since v2.1.107, 2026-04-14). Annotated per Rule 10B option (a): "in v2.1.85 changelog, not yet on official env-vars page".

---

## 11. Settings Hierarchy Accuracy

No changes to hierarchy detected. 5-level chain + managed policy layer match official docs.

---

## 12. Example Accuracy

Quick Reference example validated — uses current settings with correct syntax.

---

## 13. Sources Accuracy

All 6 source links validated (Phase 2.7):

| # | Type | Link | Status |
|---|------|------|--------|
| 1 | External | https://code.claude.com/docs/en/settings | ✅ OK |
| 2 | External | https://json.schemastore.org/claude-code-settings.json | ✅ OK (301 redirect) |
| 3 | External | https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md | ✅ OK |
| 4 | External | https://github.com/feiskyer/claude-code-settings | ✅ OK |
| 5 | External | https://code.claude.com/docs/en/env-vars | ✅ OK |
| 6 | External | https://code.claude.com/docs/en/permissions | ✅ OK |

---

## 14. Stale Annotation Cleanup

Two settings had stale "not yet on official settings page" annotations that are now confirmed documented:

- `footerLinksRegexes` — annotation updated from `(in v2.1.176 changelog, not yet on official settings page)` → `(v2.1.176)` ✅
- `disableBundledSkills` — annotation updated from `*(in v2.1.169 changelog, not yet on official settings page)*` → `(v2.1.169)` ✅
- `CLAUDE_CODE_DISABLE_BUNDLED_SKILLS` — same stale annotation removed, updated to `(v2.1.169)` ✅

---

## Verification Log

| Rule | Category | Depth | Result | Notes |
|------|----------|-------|--------|-------|
| 1A | Key Completeness | field-level | ✅ PASS | 4 missing keys caught and added |
| 1B | Key Types | content-match | ✅ PASS | All types match official docs |
| 1C | Key Defaults | content-match | ✅ PASS | All defaults match official docs |
| 1D | Key Descriptions | content-match | ✅ PASS | All descriptions accurate |
| 1E | Scope Column | content-match | ✅ PASS | No scope drift |
| 1F | Inverse Completeness | field-level | ✅ PASS | No orphaned report keys |
| 1G | Edge-Case Semantics | content-match | ✅ PASS | Boundary values documented |
| 1H | File Scope Check | content-match | ✅ PASS | No settings.json / ~/.claude.json scope mismatches |
| 1I | Skills Settings Keys | field-level | ✅ PASS | skillOverrides, disableSkillShellExecution, maxSkillDescriptionChars, skillListingBudgetFraction present |
| 2A | Priority Levels | field-level | ✅ PASS | 5-level chain + managed matches official docs |
| 2B | File Locations | content-match | ✅ PASS | All paths correct |
| 2C | Merge Semantics | content-match | ✅ PASS | "concatenated and deduplicated" wording matches |
| 2D | Managed Internals | field-level | ✅ PASS | MDM/registry delivery methods documented |
| 3A | Permission Modes | field-level | ✅ PASS | All modes present |
| 3B | Tool Syntax Patterns | content-match | ⚠️ FAIL→FIXED | Tool(param:value) was missing; now added |
| 3C | Bidirectional Mode Check | field-level | ✅ PASS | No unverified modes |
| 3D | Evaluation Semantics | content-match | ✅ PASS | Deny-first order and path-prefix patterns documented |
| 4A | Hooks Redirect | exists | ✅ PASS | Redirect link valid |
| 5A | Env Var Completeness | field-level | ✅ PASS | All env vars from official docs present |
| 5B | Ownership Boundary | cross-file | ✅ PASS | No cross-file duplication |
| 5C | Env Var Descriptions | content-match | ✅ PASS | All descriptions match official /en/env-vars |
| 5D | Inverse Env Var Check | field-level | ✅ PASS | OTEL_LOG_TOOL_DETAILS annotated per Rule 10B |
| 6A | Quick Reference Example | content-match | ✅ PASS | Example uses current valid settings |
| 6B | Example URL Validation | exists | ✅ PASS | Schema URL resolves correctly |
| 7A | CLAUDE.md Sync | cross-file | ✅ PASS | CLAUDE.md hierarchy consistent with report |
| 8A | Source Credibility Guard | content-match | ✅ PASS | All findings confirmed via official docs only |
| 9A | Local File Links | exists | ✅ PASS | All relative links resolve |
| 9B | External URL Links | exists | ✅ PASS | All 6 external URLs valid |
| 9C | Anchor Links | exists | ✅ PASS | All anchor targets exist |
| 10A | Version Metadata | content-match | ⚠️ FAIL→FIXED | Badge and header updated v2.1.176→v2.1.178 |
| 10B | Suspect Key Escalation | exists | ✅ PASS | OTEL_LOG_TOOL_DETAILS annotated (36th run) |
| 10C | Bidirectional Completeness | field-level | ✅ PASS | All report keys traceable to official sources |

---

## Priority Actions

| # | Priority | Type | Action | Status |
|---|----------|------|--------|--------|
| 1 | HIGH | Missing Settings | Added `agentPushNotifEnabled` + `inputNeededNotifEnabled` to General Settings | ✅ COMPLETE — NEW |
| 2 | HIGH | Missing Setting | Added `autoCompactEnabled` to General Settings | ✅ COMPLETE — NEW |
| 3 | HIGH | Missing Setting | Added `fileCheckpointingEnabled` to Plans & Memory Directories | ✅ COMPLETE — NEW |
| 4 | HIGH | Permission Syntax | Added `Tool(param:value)` row to Tool Permission Syntax table | ✅ COMPLETE — NEW |
| 5 | MED | Stale Annotation | Cleaned `footerLinksRegexes` annotation | ✅ COMPLETE — NEW |
| 6 | MED | Stale Annotation | Cleaned `disableBundledSkills` + `CLAUDE_CODE_DISABLE_BUNDLED_SKILLS` annotations | ✅ COMPLETE — NEW |
| 7 | LOW | Suspect Key | `OTEL_LOG_TOOL_DETAILS` — 36th consecutive ON HOLD | ✋ ON HOLD — RECURRING (first seen: 2026-04-14 v2.1.107) |

## Resolved Since Last Run

All items from the 2026-06-15 run were either COMPLETE or INVALID. Nothing carried forward as unresolved.

---

*Automated run — unattended daily drift check. Do not merge without human review.*

https://claude.ai/code/session_01KEQrQTV64tcYAdmSy9tkgj

---
_Generated by [Claude Code](https://claude.ai/code/session_01KEQrQTV64tcYAdmSy9tkgj)_