### PR TITLE
Daily settings drift check — 2026-06-17 (Claude Code v2.1.179)

### DIFF
--- a/best-practice/claude-settings.md
+++ b/best-practice/claude-settings.md
@@ -1,9 +1,9 @@
 # Settings Best Practice
 
-![Last Updated](https://img.shields.io/badge/Last_Updated-Jun%2016%2C%202026%2010%3A46%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.178-blue?style=flat&labelColor=555)<br>
+![Last Updated](https://img.shields.io/badge/Last_Updated-Jun%2017%2C%202026%2010%3A44%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.179-blue?style=flat&labelColor=555)<br>
 [![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../.claude/settings.json)
 
-A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.178, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
+A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.179, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
 
 <table width="100%">
 <tr>
@@ -904,7 +904,7 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS` | Disable background tasks (`1` to disable) |
 | `CLAUDE_CODE_DISABLE_ADVISOR_TOOL` | Set to `1` to disable the advisor tool and the `/advisor` command. Env-var equivalent of omitting advisor usage. Pair with `advisorModel` for advisor configuration (min v2.1.98) |
 | `CLAUDE_CODE_DISABLE_AGENT_VIEW` | Set to `1` to turn off background agents and agent view (`claude agents`, `--bg`, `/background`, on-demand supervisor). Env-var equivalent of the `disableAgentView` setting *(referenced on official settings page; not listed on the env-vars page)* |
-| `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` | Enable the experimental agent teams feature (`1` to enable). Allows spawning coordinated teams of subagents within a session |
+| `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` | Enable the experimental agent teams feature (`1` to enable). Allows spawning coordinated teams of subagents within a session. Also configurable as a startup-only var — see [CLI Startup Flags](./claude-cli-startup-flags.md#environment-variables) |
 | `CLAUDE_CODE_DISABLE_WORKFLOWS` | Set to `1` to disable [dynamic workflows](https://code.claude.com/docs/en/workflows) (`/workflows`) and the bundled workflow slash commands. Env-var equivalent of the `disableWorkflows` setting |
 | `CLAUDE_CODE_ENABLE_AUTO_MODE` | Set to `1` to make [auto mode](https://code.claude.com/docs/en/permission-modes#eliminate-prompts-with-auto-mode) available on Amazon Bedrock, Google Cloud Vertex AI, and Microsoft Foundry. Has no effect on the Anthropic API, where auto mode is available by default (v2.1.158) |
 | `CLAUDE_CODE_DISABLE_BUNDLED_SKILLS` | Set to `1` to conceal Claude Code's built-in capabilities (bundled skills) from the model. Env-var equivalent of the `disableBundledSkills` setting (v2.1.169) |
@@ -1101,8 +1101,8 @@ Set environment variables for all Claude Code sessions.
 
 | Command | Description |
 |---------|-------------|
-| `/model` | Switch models and adjust Opus 4.6 effort level |
-| `/effort` | Set effort level directly: `low`, `medium`, `high`, `xhigh` (Opus 4.7 only, v2.1.111), or `max` (Opus 4.6 only) (v2.1.76+) |
+| `/model` | Switch models and adjust effort level (Opus 4.7 and 4.8) |
+| `/effort` | Set effort level directly: `low`, `medium`, `high`, `xhigh` (Opus 4.7 and 4.8, v2.1.111), or `max` (Opus 4.6 only) (v2.1.76+) |
 | `/config` | Interactive configuration UI |
 | `/memory` | View/edit all memory files |
 | `/agents` | Manage subagents |

--- a/changelog/best-practice/claude-settings/changelog.md
+++ b/changelog/best-practice/claude-settings/changelog.md
@@ -866,3 +866,16 @@
 | 5 | MED | Stale Annotation | Remove "(in v2.1.176 changelog, not yet on official settings page)" from `footerLinksRegexes` — now confirmed on official settings page | ✅ COMPLETE (annotation updated to (v2.1.176)) |
 | 6 | MED | Stale Annotation | Remove "*(in v2.1.169 changelog, not yet on official settings page)*" from `disableBundledSkills` and `CLAUDE_CODE_DISABLE_BUNDLED_SKILLS` — now confirmed on official page | ✅ COMPLETE (annotations updated to (v2.1.169)) |
 | 7 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 36+ consecutive runs. Annotation "in v2.1.85 changelog, not yet on official env-vars page" remains accurate | ✋ ON HOLD (kept — recurring from 2026-04-14 v2.1.107) |
+
+---
+
+## [2026-06-17 10:44 AM PKT] Claude Code v2.1.179
+
+| # | Priority | Type | Action | Status |
+|---|----------|------|--------|--------|
+| 1 | HIGH | Version Bump | Update report version badge from v2.1.178 → v2.1.179 and header "As of v2.1.178" → "As of v2.1.179" | ✅ COMPLETE (badge and header updated in Phase 2.6) — NEW |
+| 2 | LOW | Stale Text | Fix `/model` Useful Commands row: "Switch models and adjust Opus 4.6 effort level" → "Switch models and adjust effort level (Opus 4.7 and 4.8)" — Opus 4.6 is superseded | ✅ COMPLETE (updated in Useful Commands table) — NEW |
+| 3 | LOW | Stale Text | Fix `/effort` Useful Commands row: "xhigh (Opus 4.7 only, v2.1.111)" → "xhigh (Opus 4.7 and 4.8, v2.1.111)" — Opus 4.8 also supports xhigh; consistent with env var row fix from v2.1.175 run | ✅ COMPLETE (updated in Useful Commands table) — NEW |
+| 4 | LOW | Ownership Boundary | Add startup-flag cross-link to `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` in settings report — CLI flags file already has cross-link to settings report (v2.1.161), but settings report was missing the reciprocal link. Rule 5B | ✅ COMPLETE (cross-reference note added to settings report line 907) — RECURRING (first identified 2026-06-03 v2.1.161 #5; CLI flags direction was fixed then; settings→flags direction missed) |
+| 5 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 37+ consecutive runs. Annotation "in v2.1.85 changelog, not yet on official env-vars page" remains accurate | ✋ ON HOLD (kept — recurring from 2026-04-14 v2.1.107) |
+| 6 | LOW | Ownership Question | `CLAUDE_CODE_SAFE_MODE` (v2.1.169, paired with `--safe-mode` startup flag) — out of scope for this report per previous run decision; belongs in `claude-cli-startup-flags.md` | ✋ ON HOLD (out of scope — recurring from 2026-06-09 v2.1.169 #4) |


### PR DESCRIPTION
## Settings Drift Report — 2026-06-17

**Audited version:** Claude Code v2.1.179
**Previous badge:** v2.1.178 (Jun 16, 2026)
**Run timestamp:** 2026-06-17 10:44 AM PKT

---

## Summary

v2.1.179 contains **no settings changes** (bug fixes only, confirmed via official GitHub changelog). This run corrects 3 stale text items and 1 missing cross-link that carried over from previous runs.

---

## Verification Log

| Rule | Category | Depth | Result | Notes |
|------|----------|-------|--------|-------|
| 1A | Key Completeness | field-level | PASS | All settings keys present; v2.1.179 introduced no new keys |
| 1B | Key Types | content-match | PASS | All types match official docs |
| 1C | Key Defaults | content-match | PASS | All defaults match |
| 1D | Key Descriptions | content-match | PASS | No description drift in v2.1.179 |
| 1E | Scope Column | content-match | PASS | No scope changes |
| 1F | Inverse Completeness | field-level | PASS | No orphaned keys |
| 1G | Edge-Case Semantics | content-match | PASS | No boundary-value changes in v2.1.179 |
| 1H | File Scope Check | content-match | PASS | Display settings in correct file scope |
| 1I | Skills Settings Keys | field-level | PASS | `maxSkillDescriptionChars` and `skillListingBudgetFraction` present |
| 2A | Priority Levels | field-level | PASS | 5-level chain + managed policy present |
| 2B | File Locations | content-match | PASS | All paths correct |
| 2C | Merge Semantics | content-match | PASS | "concatenated and deduplicated" wording correct |
| 2D | Managed Internals | field-level | PASS | Server-managed, MDM, registry, file delivery methods present |
| 3A | Permission Modes | field-level | PASS | All 6 modes present |
| 3B | Tool Syntax Patterns | content-match | PASS | Includes v2.1.178 `Tool(param:value)` syntax |
| 3C | Bidirectional Mode Check | field-level | PASS | All modes traceable to official docs |
| 3D | Evaluation Semantics | content-match | PASS | Deny-first, path-prefix patterns all present |
| 4A | Hooks Redirect | exists | PASS | Redirect link to claude-code-hooks repo present |
| 5A | Env Var Completeness | field-level | PASS | 200+ env vars; no new vars in v2.1.179 |
| 5B | Ownership Boundary | cross-file | **FIXED** | `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` now has reciprocal cross-link in settings report |
| 5C | Env Var Descriptions | content-match | PASS | All descriptions match official /en/env-vars page |
| 5D | Inverse Env Var Check | field-level | PASS | All unverified vars annotated |
| 6A | Quick Reference Example | content-match | PASS | Example uses valid current settings |
| 6B | Example URL Validation | exists | PASS | `$schema` URL uses correct `json.schemastore.org` domain |
| 7A | CLAUDE.md Sync | cross-file | PASS | Configuration hierarchy consistent |
| 8A | Source Credibility Guard | content-match | PASS | All findings from official sources only |
| 9A | Local File Links | exists | PASS | All relative paths resolve |
| 9B | External URL Links | exists | PASS | All 6 Sources links valid; docs pages live |
| 9C | Anchor Links | exists | PASS | All TOC anchors resolve to existing headings |
| 10A | Version Metadata | content-match | PASS | Badge updated to v2.1.179; counts accurate |
| 10B | Suspect Key Escalation | exists | PASS | `OTEL_LOG_TOOL_DETAILS` at 37+ runs — requires resolution next 3 runs per Rule 10B |
| 10C | Bidirectional Completeness | field-level | PASS | All entries traceable or annotated |

---

## Drift Findings

### 1. New Settings Keys
None — v2.1.179 is a bug-fix release.

### 2. Changed Setting Behavior
None confirmed from official sources (Rule 8A).

### 3. Deprecated/Removed Settings
None.

### 4. Permission Syntax Changes
None. (v2.1.178 `Tool(param:value)` was already added last run.)

### 5–9. MCP / Sandbox / Plugin / Model / Display Changes
None in v2.1.179.

### 10. Environment Variable Completeness
No new vars in v2.1.179.

**Ongoing ON HOLD items:**
- `OTEL_LOG_TOOL_DETAILS` — 37+ consecutive runs, annotation present, not on official env-vars page
- `CLAUDE_CODE_SAFE_MODE` — startup-only; belongs in `claude-cli-startup-flags.md` (decided v2.1.169 run)

### 11. Settings Hierarchy Accuracy
PASS — 5-level chain + managed tier delivery methods all correct.

### 12. Example Accuracy
PASS — Quick Reference example uses current settings syntax.

### 13. Sources Accuracy
PASS — All 6 source links returned valid pages.

### 14. Phase 2.7 Hyperlink Validation

| # | Type | Link | Status |
|---|------|------|--------|
| 1 | Local | `../.claude/settings.json` | OK |
| 2 | Local | `./claude-cli-startup-flags.md#environment-variables` | OK |
| 3 | External | `https://code.claude.com/docs/en/settings` | OK |
| 4 | External | `https://json.schemastore.org/claude-code-settings.json` | OK |
| 5 | External | `https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md` | OK |
| 6 | External | `https://github.com/feiskyer/claude-code-settings` | OK |
| 7 | External | `https://code.claude.com/docs/en/env-vars` | OK |
| 8 | External | `https://code.claude.com/docs/en/permissions` | OK |
| 9 | External | `https://github.com/shanraisshan/claude-code-hooks` | OK |

---

## Priority Actions

| # | Priority | Type | Action | Status |
|---|----------|------|--------|--------|
| 1 | HIGH | Version Bump | Badge + header updated: v2.1.178 → v2.1.179 | COMPLETE — NEW |
| 2 | LOW | Stale Text | `/model` row: removed stale "Opus 4.6" reference | COMPLETE — NEW |
| 3 | LOW | Stale Text | `/effort` row: xhigh changed to "Opus 4.7 and 4.8" | COMPLETE — NEW |
| 4 | LOW | Ownership Boundary | `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`: added reciprocal cross-link to CLI flags file | COMPLETE — RECURRING (partial fix from 2026-06-03 v2.1.161) |
| 5 | LOW | Suspect Key | `OTEL_LOG_TOOL_DETAILS` ON HOLD 37+ runs | ON HOLD — RECURRING (from 2026-04-14 v2.1.107) |
| 6 | LOW | Ownership | `CLAUDE_CODE_SAFE_MODE` belongs in CLI flags file | ON HOLD — RECURRING (from 2026-06-09 v2.1.169) |

## Resolved Since Last Run
None — all HIGH items from v2.1.178 run were already COMPLETE.

---

*Generated by the `workflow-claude-settings` scheduled routine.*

---
_Generated by [Claude Code](https://claude.ai/code/session_01SaRoufWzvzMMsXRkpxmEzc)_