### PR TITLE
Daily settings drift check — 2026-06-18 (Claude Code v2.1.181)

### DIFF
--- a/best-practice/claude-settings.md
+++ b/best-practice/claude-settings.md
@@ -1,9 +1,9 @@
 # Settings Best Practice
 
-![Last Updated](https://img.shields.io/badge/Last_Updated-Jun%2017%2C%202026%2010%3A44%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.179-blue?style=flat&labelColor=555)<br>
+![Last Updated](https://img.shields.io/badge/Last_Updated-Jun%2018%2C%202026%2010%3A40%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.181-blue?style=flat&labelColor=555)<br>
 [![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../.claude/settings.json)
 
-A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.179, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
+A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.181, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
 
 <table width="100%">
 <tr>
@@ -466,6 +466,7 @@ Configure bash command sandboxing for security.
 | `sandbox.enableWeakerNetworkIsolation` | boolean | `false` | (macOS only) Allow access to system TLS trust (`com.apple.trustd.agent`); reduces security |
 | `sandbox.bwrapPath` | string | - | **(Managed only, Linux/WSL2)** Absolute path to the bubblewrap (`bwrap`) binary. Overrides automatic `PATH` detection. Only honored from managed settings, not user or project settings. Example: `/opt/admin/bwrap` (v2.1.133) |
 | `sandbox.socatPath` | string | - | **(Managed only, Linux/WSL2)** Absolute path to the `socat` binary used for the sandbox network proxy. Overrides automatic `PATH` detection. Only honored from managed settings. Example: `/opt/admin/socat` (v2.1.133) |
+| `sandbox.allowAppleEvents` | boolean | `false` | **(macOS only)** Opt-in for sandboxed commands to send Apple Events. Required for tools that use `open`, `osascript`, or browser authentication flows that depend on Apple Events IPC *(in v2.1.181 changelog, not yet on official settings page)* |
 
 **Example:**
 ```json
@@ -883,6 +884,7 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_REMOTE` | Read-only. Set automatically to `true` when Claude Code is running as a cloud session. Read this from a hook or setup script to detect whether you are in a cloud environment |
 | `CLAUDE_CODE_REMOTE_SESSION_ID` | Read-only. Set automatically in cloud sessions to the current session's ID. Read this to construct a link back to the session transcript |
 | `CLAUDE_REMOTE_CONTROL_SESSION_NAME_PREFIX` | Prefix for auto-generated Remote Control session names. Defaults to the machine hostname |
+| `CLAUDE_CLIENT_PRESENCE_FILE` | Path to a file that, when present, signals an active client and suppresses mobile push notifications from Remote Control. Useful in environments where a desktop client is always running and mobile pings are unwanted *(in v2.1.181 changelog, not yet on official env-vars page)* |
 | `CLAUDE_CODE_ENABLE_TELEMETRY` | Enable/disable telemetry (`0` or `1`) |
 | `DISABLE_ERROR_REPORTING` | Disable error reporting (`1` to disable) |
 | `DISABLE_AUTOUPDATER` | Set to `1` to disable automatic update checks against the npm registry. Also configurable as a startup-only var — see [CLI Startup Flags](./claude-cli-startup-flags.md#environment-variables) |
@@ -1103,7 +1105,7 @@ Set environment variables for all Claude Code sessions.
 |---------|-------------|
 | `/model` | Switch models and adjust effort level (Opus 4.7 and 4.8) |
 | `/effort` | Set effort level directly: `low`, `medium`, `high`, `xhigh` (Opus 4.7 and 4.8, v2.1.111), or `max` (Opus 4.6 only) (v2.1.76+) |
-| `/config` | Interactive configuration UI |
+| `/config` | Interactive configuration UI; also accepts `key=value` syntax for prompt-based settings: `/config model=sonnet` (v2.1.181) |
 | `/memory` | View/edit all memory files |
 | `/agents` | Manage subagents |
 | `/mcp` | Manage MCP servers |

--- a/changelog/best-practice/claude-settings/changelog.md
+++ b/changelog/best-practice/claude-settings/changelog.md
@@ -878,4 +878,16 @@
 | 3 | LOW | Stale Text | Fix `/effort` Useful Commands row: "xhigh (Opus 4.7 only, v2.1.111)" → "xhigh (Opus 4.7 and 4.8, v2.1.111)" — Opus 4.8 also supports xhigh; consistent with env var row fix from v2.1.175 run | ✅ COMPLETE (updated in Useful Commands table) — NEW |
 | 4 | LOW | Ownership Boundary | Add startup-flag cross-link to `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` in settings report — CLI flags file already has cross-link to settings report (v2.1.161), but settings report was missing the reciprocal link. Rule 5B | ✅ COMPLETE (cross-reference note added to settings report line 907) — RECURRING (first identified 2026-06-03 v2.1.161 #5; CLI flags direction was fixed then; settings→flags direction missed) |
 | 5 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 37+ consecutive runs. Annotation "in v2.1.85 changelog, not yet on official env-vars page" remains accurate | ✋ ON HOLD (kept — recurring from 2026-04-14 v2.1.107) |
+
+---
+
+## [2026-06-18 10:40 AM PKT] Claude Code v2.1.181
+
+| # | Priority | Type | Action | Status |
+|---|----------|------|--------|--------|
+| 1 | HIGH | Version Bump | Update report version badge from v2.1.179 → v2.1.181 and "As of v2.1.179" → "As of v2.1.181" | ✅ COMPLETE (badge and header updated in Phase 2.6) — NEW |
+| 2 | HIGH | New Setting | Add `sandbox.allowAppleEvents` (boolean, macOS only, default `false`) to Sandbox Settings table — opt-in for sandboxed commands to send Apple Events; required for `open`, `osascript`, browser auth flows (v2.1.181 changelog) | ✅ COMPLETE (added after sandbox.socatPath with changelog annotation) — NEW |
+| 3 | MED | New Env Var | Add `CLAUDE_CLIENT_PRESENCE_FILE` to Common Environment Variables table — path to a file that suppresses mobile push notifications when present (v2.1.181 changelog) | ✅ COMPLETE (added after CLAUDE_REMOTE_CONTROL_SESSION_NAME_PREFIX with changelog annotation) — NEW |
+| 4 | MED | Useful Commands | Update `/config` entry to mention `key=value` syntax for prompt-based settings configuration: `/config model=sonnet` (v2.1.181 changelog) | ✅ COMPLETE (description updated in Useful Commands table) — NEW |
+| 5 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 38+ consecutive runs. Annotation "in v2.1.85 changelog, not yet on official env-vars page" remains accurate | ✋ ON HOLD (kept — recurring from 2026-04-14 v2.1.107) |
 | 6 | LOW | Ownership Question | `CLAUDE_CODE_SAFE_MODE` (v2.1.169, paired with `--safe-mode` startup flag) — out of scope for this report per previous run decision; belongs in `claude-cli-startup-flags.md` | ✋ ON HOLD (out of scope — recurring from 2026-06-09 v2.1.169 #4) |


### PR DESCRIPTION
## Summary

Daily automated drift check for `best-practice/claude-settings.md` against Claude Code v2.1.181 official docs and changelog. Report was previously current through v2.1.179 (run 2026-06-17). This run covers the 2-version gap (v2.1.180 bug-fix only, v2.1.181 adds 2 new items).

**Changes applied:**
- Bumped version badge and header v2.1.179 → v2.1.181
- Added `sandbox.allowAppleEvents` to Sandbox Settings table (v2.1.181 changelog)
- Added `CLAUDE_CLIENT_PRESENCE_FILE` to Environment Variables table (v2.1.181 changelog)
- Updated `/config` Useful Commands entry to mention `key=value` syntax (v2.1.181)

---

## Verification Log

| Rule # | Category | Depth | Result | Notes |
|--------|----------|-------|--------|-------|
| 1A | Key Completeness | field-level | PARTIAL FAIL → FIXED | `sandbox.allowAppleEvents` (v2.1.181) was missing; added |
| 1B | Key Types | content-match | PASS | All type columns verified against official settings page |
| 1C | Key Defaults | content-match | PASS | All defaults spot-checked against official docs |
| 1D | Key Descriptions | content-match | PASS | Descriptions accurate per official docs |
| 1E | Scope Column | content-match | PASS | All scope values correct |
| 1F | Inverse Completeness | field-level | PASS | All report keys traceable to official sources or annotated |
| 1G | Edge-Case Semantics | content-match | PASS | Boundary values documented correctly |
| 1H | File Scope Check | content-match | PASS | settings.json vs ~/.claude.json scoping accurate |
| 1I | Skills Settings Keys | field-level | PASS | All 5 skill keys present (`skillOverrides`, `disableSkillShellExecution`, `maxSkillDescriptionChars`, `skillListingBudgetFraction`, `disableBundledSkills`) |
| 2A | Priority Levels | field-level | PASS | 5-level hierarchy + managed policy layer correct |
| 2B | File Locations | content-match | PASS | All file paths verified |
| 2C | Merge Semantics | content-match | PASS | "concatenated and deduplicated" wording matches official docs |
| 2D | Managed Internals | field-level | PASS | Server-managed > MDM > file > HKCU order, drop-in dir, Windows path note all correct |
| 3A | Permission Modes | field-level | PASS | All 6 modes documented (default, acceptEdits, plan, auto, bypassPermissions, dontAsk) |
| 3B | Tool Syntax Patterns | content-match | PASS | `Tool(param:value)` (v2.1.178), `Cd(...)`, `"*"` deny-all all present |
| 3C | Bidirectional Mode Check | field-level | PASS | No orphaned modes |
| 3D | Evaluation Semantics | content-match | PASS | Deny-first evaluation order documented |
| 4A | Hooks Redirect | exists | PASS | Redirect to claude-code-hooks repo present |
| 5A | Env Var Completeness | field-level | PARTIAL FAIL → FIXED | `CLAUDE_CLIENT_PRESENCE_FILE` (v2.1.181) was missing; added |
| 5B | Ownership Boundary | cross-file | PASS | No duplication between settings report and CLI flags file |
| 5C | Env Var Descriptions | content-match | PASS | Descriptions verified spot-check |
| 5D | Inverse Env Var Check | field-level | PASS | All env vars either official-docs-confirmed or annotated unverified |
| 6A | Quick Reference Example | content-match | PASS | Example uses valid current keys; JSON structure correct |
| 6B | Example URL Validation | exists | PASS | `https://json.schemastore.org/claude-code-settings.json` uses correct domain |
| 7A | CLAUDE.md Sync | cross-file | PASS | Configuration hierarchy consistent between CLAUDE.md and report |
| 8A | Source Credibility Guard | content-match | PASS | All new findings from official changelog (GitHub); annotated as changelog-sourced |
| 9A | Local File Links | exists | PASS | Back-navigation `../` and `./claude-cli-startup-flags.md` resolve correctly |
| 9B | External URL Links | exists | PASS | All Sources section URLs verified valid (settings, schema, changelog, env-vars, permissions, feiskyer repo) |
| 9C | Anchor Links | exists | PASS | Table of Contents anchors match headings |
| 10A | Version Metadata | content-match | FAIL → FIXED | Badge v2.1.179 → v2.1.181; header text updated |
| 10B | Suspect Key Escalation | exists | ON HOLD | `OTEL_LOG_TOOL_DETAILS` — 38th consecutive ON HOLD run since 2026-04-14; annotation maintained |
| 10C | Bidirectional Completeness | field-level | PASS | All keys traceable to official sources or annotated |

---

## Priority Actions

| # | Priority | Type | Action | Status |
|---|----------|------|--------|--------|
| 1 | HIGH | Version Bump | Update badge + header v2.1.179 → v2.1.181 | ✅ COMPLETE |
| 2 | HIGH | New Setting | Add `sandbox.allowAppleEvents` (boolean, macOS, default `false`) — v2.1.181 changelog | ✅ COMPLETE (changelog annotation added) |
| 3 | MED | New Env Var | Add `CLAUDE_CLIENT_PRESENCE_FILE` — suppress mobile push notifications — v2.1.181 changelog | ✅ COMPLETE (changelog annotation added) |
| 4 | MED | Useful Commands | Update `/config` to mention `key=value` syntax — v2.1.181 changelog | ✅ COMPLETE |
| 5 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — 38th consecutive ON HOLD since 2026-04-14 | ✋ ON HOLD (annotation kept) |

## Resolved Since Last Run

Nothing from the previous run (2026-06-17 v2.1.179) is newly resolved. The previous run was version-bump only.

## Hyperlink Validation

All hyperlinks valid. No broken links found. Notable verifications:
- `https://json.schemastore.org/claude-code-settings.json` — correct domain (not `www.schemastore.org`)
- `https://github.com/feiskyer/claude-code-settings` — active repo (1.6k stars)
- All official docs links (settings, env-vars, permissions, cli-reference, remote-control, workflows) return valid pages

---

Generated with [Claude Code](https://claude.ai/code)
https://claude.ai/code/session_01QXeX9i51gipB6aEv9Uaxoy

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXeX9i51gipB6aEv9Uaxoy)_