### PR TITLE
Daily settings drift check — 2026-06-19 (Claude Code v2.1.183)

### DIFF
--- a/best-practice/claude-settings.md
+++ b/best-practice/claude-settings.md
@@ -1,9 +1,9 @@
 # Settings Best Practice
 
-![Last Updated](https://img.shields.io/badge/Last_Updated-Jun%2018%2C%202026%2010%3A40%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.181-blue?style=flat&labelColor=555)<br>
+![Last Updated](https://img.shields.io/badge/Last_Updated-Jun%2019%2C%202026%2010%3A46%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.183-blue?style=flat&labelColor=555)<br>
 [![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../.claude/settings.json)
 
-A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.181, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
+A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.183, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
 
 <table width="100%">
 <tr>
@@ -180,6 +180,7 @@ Customize attribution messages for git commits and pull requests.
 | `attribution.commit` | string | Co-authored-by | Git commit attribution (supports trailers) |
 | `attribution.pr` | string | Generated message | Pull request description attribution |
 | `prUrlTemplate` | string | - | URL template that controls how the "PR" badge in commit attribution links to the pull request UI. Supports placeholders for the repo host, owner, repo, and PR number. Useful for self-hosted GitLab/Bitbucket/GitHub Enterprise instances where the default `https://github.com/...` URL does not apply (v2.1.119) |
+| `attribution.sessionUrl` | boolean | `true` | Whether to include the claude.ai session URL in commit attribution and PR descriptions. Set to `false` to omit the session link. Only applies in web and Remote Control sessions *(in v2.1.183 changelog, not yet on official settings page)* |
 | `includeCoAuthoredBy` | boolean | `true` | **DEPRECATED** - Use `attribution` instead |
 
 **Example:**
@@ -266,7 +267,7 @@ Control what tools and operations Claude can perform.
 | `permissions.disableBypassPermissionsMode` | string | Prevent bypass mode activation |
 | `permissions.skipDangerousModePermissionPrompt` | boolean | Skip the confirmation prompt shown before entering bypass permissions mode via `--dangerously-skip-permissions` or `defaultMode: "bypassPermissions"`. Ignored when set in project settings (`.claude/settings.json`) to prevent untrusted repositories from auto-bypassing the prompt |
 | `allowManagedPermissionRulesOnly` | boolean | **(Managed only)** Only managed permission rules apply; user/project `allow`, `ask`, `deny` rules are ignored |
-| `autoMode` | object | Customize what the [auto mode](https://code.claude.com/docs/en/permission-modes#eliminate-prompts-with-auto-mode) classifier blocks and allows. Contains `environment` (trusted infrastructure descriptions), `allow` (exceptions to block rules), `soft_deny` (block rules), and `hard_deny` (unconditional block rules — cannot be overridden by `allow` exceptions or the `$defaults` sentinel, v2.1.136) — all arrays of prose strings. **Not read from shared project settings** (`.claude/settings.json`) to prevent repo injection. Available in user, local, and managed settings. Setting `allow` or `soft_deny` **replaces** the entire default list for that section unless you include the literal string `"$defaults"` in the array — the sentinel inherits the built-in rules at that position so custom entries are added alongside them (v2.1.118). Run `claude auto-mode defaults` to see built-in rules before customizing |
+| `autoMode` | object | Customize what the [auto mode](https://code.claude.com/docs/en/permission-modes#eliminate-prompts-with-auto-mode) classifier blocks and allows. Contains `environment` (trusted infrastructure descriptions), `allow` (exceptions to block rules), `soft_deny` (block rules), and `hard_deny` (unconditional block rules — cannot be overridden by `allow` exceptions or the `$defaults` sentinel, v2.1.136) — all arrays of prose strings. **Not read from shared project settings** (`.claude/settings.json`) to prevent repo injection. Available in user, local, and managed settings. Setting `allow` or `soft_deny` **replaces** the entire default list for that section unless you include the literal string `"$defaults"` in the array — the sentinel inherits the built-in rules at that position so custom entries are added alongside them (v2.1.118). Run `claude auto-mode defaults` to see built-in rules before customizing. As of v2.1.183, the built-in classifier also blocks destructive git operations (`git reset --hard`, `git checkout -- .`, `git clean -fd`, `git stash drop`) unless the user explicitly requested discarding work, and blocks `terraform destroy`/`pulumi destroy`/`cdk destroy` unless the user asked for that specific stack |
 | `disableAutoMode` | string | Set to `"disable"` to prevent [auto mode](https://code.claude.com/docs/en/permission-modes#eliminate-prompts-with-auto-mode) from being activated. Removes `auto` from the `Shift+Tab` cycle and rejects `--permission-mode auto` at startup. Can be set at any settings level; most useful in managed settings where users cannot override it |
 | `useAutoModeDuringPlan` | boolean | Whether plan mode uses auto mode semantics when auto mode is available. Default: `true`. Not read from shared project settings (`.claude/settings.json`). Appears in `/config` as "Use auto mode during plan" |
 
@@ -466,7 +467,7 @@ Configure bash command sandboxing for security.
 | `sandbox.enableWeakerNetworkIsolation` | boolean | `false` | (macOS only) Allow access to system TLS trust (`com.apple.trustd.agent`); reduces security |
 | `sandbox.bwrapPath` | string | - | **(Managed only, Linux/WSL2)** Absolute path to the bubblewrap (`bwrap`) binary. Overrides automatic `PATH` detection. Only honored from managed settings, not user or project settings. Example: `/opt/admin/bwrap` (v2.1.133) |
 | `sandbox.socatPath` | string | - | **(Managed only, Linux/WSL2)** Absolute path to the `socat` binary used for the sandbox network proxy. Overrides automatic `PATH` detection. Only honored from managed settings. Example: `/opt/admin/socat` (v2.1.133) |
-| `sandbox.allowAppleEvents` | boolean | `false` | **(macOS only)** Opt-in for sandboxed commands to send Apple Events. Required for tools that use `open`, `osascript`, or browser authentication flows that depend on Apple Events IPC *(in v2.1.181 changelog, not yet on official settings page)* |
+| `sandbox.allowAppleEvents` | boolean | `false` | **(macOS only)** Opt-in for sandboxed commands to send Apple Events. Required for tools that use `open`, `osascript`, or browser authentication flows that depend on Apple Events IPC (v2.1.181) |
 
 **Example:**
 ```json
@@ -647,6 +648,7 @@ Configure via `env` key:
 | `preferredNotifChannel` | string | `"auto"` | Method for task-complete and permission-prompt notifications. Values: `"auto"`, `"terminal_bell"`, `"iterm2"`, `"iterm2_with_bell"`, `"kitty"`, `"ghostty"`, `"notifications_disabled"`. Default `"auto"` sends a desktop notification in iTerm2, Ghostty, and Kitty and does nothing in other terminals. Set `"terminal_bell"` to ring the bell character in any terminal. Appears in `/config` as **Notifications**. See [Get a terminal bell or notification](https://code.claude.com/docs/en/terminal-config#get-a-terminal-bell-or-notification) |
 | `wheelScrollAccelerationEnabled` | boolean | `true` | Disable mouse-wheel scroll acceleration in fullscreen mode. Set to `false` to use fixed per-tick scroll steps instead of the OS-level acceleration curve (v2.1.174) |
 | `footerLinksRegexes` | array | - | Regex patterns matched against URLs to display as link badges in the footer row. Each matching URL produces a clickable badge at the bottom of the chat UI (v2.1.176) |
+| `axScreenReader` | boolean | `false` | Render screen-reader friendly output: flat text without decorative borders or animations. Set to `true` to enable; use `CLAUDE_AX_SCREEN_READER=1` for per-session env control. Set `CLAUDE_AX_SCREEN_READER=0` to force off even when this setting is `true`. The `--ax-screen-reader` CLI flag takes precedence (v2.1.181) |
 
 ### Global Config Settings (`~/.claude.json`)
 
@@ -1037,6 +1039,7 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_DISABLE_MOUSE` | Set to `1` to disable mouse tracking in fullscreen rendering. Useful when mouse events interfere with terminal multiplexers or accessibility tools |
 | `CLAUDE_CODE_HIDE_CWD` | Set to `1` to hide the current working directory in the Claude Code startup logo banner. Useful in screen recordings, demos, or shared sessions where the CWD path leaks information about the host or project layout (v2.1.119) |
 | `CLAUDE_CODE_ACCESSIBILITY` | Set to `1` to keep native terminal cursor visible for screen readers and accessibility tools |
+| `CLAUDE_AX_SCREEN_READER` | Set to `1` to render screen-reader friendly output: flat text without decorative borders or animations. Set to `0` to force screen-reader mode off even when `axScreenReader` is `true`. The `--ax-screen-reader` flag takes precedence. Requires v2.1.181+ |
 | `CLAUDE_CODE_NATIVE_CURSOR` | Set to `1` to show the terminal's own cursor at the input caret position instead of Claude Code's custom cursor character |
 | `CLAUDE_CODE_SYNTAX_HIGHLIGHT` | Set to `0` to disable syntax highlighting in diff output |
 | `CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL` | Skip automatic IDE extension installation (`1` to skip) |

--- a/changelog/best-practice/claude-settings/changelog.md
+++ b/changelog/best-practice/claude-settings/changelog.md
@@ -891,3 +891,18 @@
 | 4 | MED | Useful Commands | Update `/config` entry to mention `key=value` syntax for prompt-based settings configuration: `/config model=sonnet` (v2.1.181 changelog) | ✅ COMPLETE (description updated in Useful Commands table) — NEW |
 | 5 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 38+ consecutive runs. Annotation "in v2.1.85 changelog, not yet on official env-vars page" remains accurate | ✋ ON HOLD (kept — recurring from 2026-04-14 v2.1.107) |
 | 6 | LOW | Ownership Question | `CLAUDE_CODE_SAFE_MODE` (v2.1.169, paired with `--safe-mode` startup flag) — out of scope for this report per previous run decision; belongs in `claude-cli-startup-flags.md` | ✋ ON HOLD (out of scope — recurring from 2026-06-09 v2.1.169 #4) |
+
+---
+
+## [2026-06-19 10:46 AM PKT] Claude Code v2.1.183
+
+| # | Priority | Type | Action | Status |
+|---|----------|------|--------|--------|
+| 1 | HIGH | Version Bump | Update report version badge from v2.1.181 → v2.1.183 and "As of v2.1.181" → "As of v2.1.183" | ✅ COMPLETE (badge and header updated in Phase 2.6) — NEW |
+| 2 | HIGH | New Setting | Add `axScreenReader` (boolean, default `false`) to Display Settings table — renders screen-reader friendly flat text output; pairs with `CLAUDE_AX_SCREEN_READER` env var and `--ax-screen-reader` CLI flag (v2.1.181, confirmed on official settings page) | ✅ COMPLETE (added after footerLinksRegexes) — NEW |
+| 3 | HIGH | New Env Var | Add `CLAUDE_AX_SCREEN_READER` to env vars table — set to `1` to enable screen-reader mode, `0` to force off even when `axScreenReader` is `true` (v2.1.181, confirmed on official /en/env-vars page) | ✅ COMPLETE (added after CLAUDE_CODE_ACCESSIBILITY) — NEW |
+| 4 | HIGH | New Setting | Add `attribution.sessionUrl` (boolean, default `true`) to Attribution Settings table — controls whether the claude.ai session URL appears in commit/PR attribution; applies in web and Remote Control sessions (v2.1.183 changelog, not yet on official settings page) | ✅ COMPLETE (added after prUrlTemplate with changelog annotation) — NEW |
+| 5 | MED | Changed Behavior | Update `autoMode` description: v2.1.183 built-in classifier now also blocks destructive git operations and infra-destroy commands (terraform/pulumi/cdk destroy) unless user explicitly requested them | ✅ COMPLETE (appended to autoMode description) — NEW |
+| 6 | MED | Stale Annotation | Remove "*(in v2.1.181 changelog, not yet on official settings page)*" from `sandbox.allowAppleEvents` — now confirmed on official settings page | ✅ COMPLETE (annotation replaced with version tag v2.1.181) — NEW |
+| 7 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 38+ consecutive runs. Annotation "in v2.1.85 changelog, not yet on official env-vars page" remains accurate | ✋ ON HOLD (kept — recurring from 2026-04-14 v2.1.107) |
+| 8 | LOW | Ownership Question | `CLAUDE_CODE_SAFE_MODE` (v2.1.169, paired with `--safe-mode` startup flag) — out of scope for this report per previous run decision; belongs in `claude-cli-startup-flags.md` | ✋ ON HOLD (out of scope — recurring from 2026-06-09 v2.1.169 #4) |


### PR DESCRIPTION
## Summary

Automated daily drift check against official Claude Code settings docs. Gap covered: **v2.1.181 → v2.1.183**.

### Changes Applied

| # | Priority | Type | Action |
|---|----------|------|--------|
| 1 | HIGH | Version Bump | Badge updated v2.1.181 → v2.1.183, Last Updated Jun 19, 2026 10:46 AM PKT |
| 2 | HIGH | New Setting | Added `axScreenReader` (boolean, default `false`) to Display Settings table — screen-reader friendly flat text output (v2.1.181, confirmed on official settings page) |
| 3 | HIGH | New Env Var | Added `CLAUDE_AX_SCREEN_READER` to env vars table — per-session env control for screen-reader mode (v2.1.181, confirmed on /en/env-vars page) |
| 4 | HIGH | New Setting | Added `attribution.sessionUrl` (boolean, default `true`) to Attribution Settings table — controls claude.ai session URL in commit/PR attribution; web and Remote Control sessions only *(v2.1.183 changelog, not yet on official settings page)* |
| 5 | MED | Changed Behavior | Updated `autoMode` description: v2.1.183 built-in classifier now blocks destructive git ops (`git reset --hard`, `git clean -fd`, etc.) and infra-destroy commands (`terraform destroy`, `pulumi destroy`, `cdk destroy`) unless user explicitly requested them |
| 6 | MED | Stale Annotation | Removed "*(in v2.1.181 changelog, not yet on official settings page)*" from `sandbox.allowAppleEvents` — now confirmed present on official settings page |

### Verification Log Summary

- Rules 1A, 5A (field-level): **FAIL** → fixed in this PR
- Rule 10A/10C (version metadata): **FAIL** → fixed in this PR  
- Rule 10B (suspect key escalation): **ON HOLD** — `OTEL_LOG_TOOL_DETAILS` at 38+ consecutive runs, kept with annotation per option (a)
- All hyperlinks: **PASS** — 6 external URLs confirmed valid including `platform.claude.com/docs/en/manage-claude/workload-identity-federation`
- Rule 8A (source credibility): Applied — rejected `telemetryLevel` and `best` model alias (not on official settings page)

### ON HOLD Items (no action needed)

- `OTEL_LOG_TOOL_DETAILS` — 38+ consecutive ON HOLD runs; annotation kept per Rule 10B option (a)
- `CLAUDE_CODE_SAFE_MODE` — belongs in `claude-cli-startup-flags.md` (startup-only flag), not in scope here

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01TqqbfYV4iherWcg2n1CgtQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01TqqbfYV4iherWcg2n1CgtQ)_