### PR TITLE
Daily settings drift check — 2026-06-21 (Claude Code v2.1.185)

### DIFF
--- a/best-practice/claude-settings.md
+++ b/best-practice/claude-settings.md
@@ -1,9 +1,9 @@
 # Settings Best Practice
 
-![Last Updated](https://img.shields.io/badge/Last_Updated-Jun%2020%2C%202026%2010%3A39%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.183-blue?style=flat&labelColor=555)<br>
+![Last Updated](https://img.shields.io/badge/Last_Updated-Jun%2021%2C%202026%2010%3A47%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.185-blue?style=flat&labelColor=555)<br>
 [![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../.claude/settings.json)
 
-A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.183, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
+A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.185, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
 
 <table width="100%">
 <tr>
@@ -877,6 +877,7 @@ Set environment variables for all Claude Code sessions.
 | `ANTHROPIC_DEFAULT_HAIKU_MODEL_SUPPORTED_CAPABILITIES` | Override capability detection for a pinned Haiku model. Comma-separated values (e.g., `effort,thinking`). Required when the pinned model supports features the auto-detection cannot confirm |
 | `CLAUDECODE` | Set to `1` in shell environments Claude Code spawns (Bash tool, tmux sessions). Not set in hooks or status line commands. Use to detect when a script is running inside a Claude Code shell |
 | `CLAUDE_CODE_CHILD_SESSION` | Set to `1` in subprocesses Claude Code spawns via the Bash, PowerShell, and Monitor tools, hook commands, and status line commands. Not set for stdio MCP server subprocesses. Unlike `CLAUDECODE`, this is only set by Claude Code's own spawn path (not IDE extensions), so it reliably distinguishes a nested `claude` session from a top-level `claude` launched in an IDE-integrated terminal. Nested interactive TUI sessions are automatically excluded from `--resume`, `--continue`, up-arrow history, and `claude agents`. Non-interactive `claude -p` sessions still persist. Set `CLAUDE_CODE_FORCE_SESSION_PERSISTENCE=1` to override this exclusion (v2.1.172) |
+| `CLAUDE_CODE_FORCE_SESSION_PERSISTENCE` | Set to `1` to override the automatic exclusion of nested interactive TUI sessions from `--resume`, `--continue`, up-arrow history, and `claude agents`. By default, nested sessions (where `CLAUDE_CODE_CHILD_SESSION=1`) are excluded to prevent them from polluting history. Set this to force persistence when you want nested sessions tracked |
 | `CLAUDE_CODE_SESSION_ID` | Read-only. Set automatically in Bash and PowerShell tool subprocesses to the current session ID. Matches the `session_id` field passed to hooks. Updated on `/clear`. Use to correlate scripts and external tools with the Claude Code session that launched them (v2.1.132). Also injected into stdio MCP server environments on `--resume` (v2.1.163 changelog) *(in v2.1.163 changelog; not yet on official env-vars page — read-only)* |
 | `AI_AGENT` | Set automatically by Claude Code in subprocess environments (Bash tool, hooks, MCP stdio servers). Generic flag identifying the parent process as an AI agent — useful for tools that adapt behavior when invoked from any AI agent rather than checking each agent-specific variable like `CLAUDECODE` *(in v2.1.120 changelog, not yet on official env-vars page)* |
 | `CLAUDE_CODE_SKIP_FAST_MODE_NETWORK_ERRORS` | Set to `1` to allow fast mode when the organization status check fails due to a network error. Useful when a corporate proxy blocks the status endpoint |
@@ -889,7 +890,7 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_REMOTE` | Read-only. Set automatically to `true` when Claude Code is running as a cloud session. Read this from a hook or setup script to detect whether you are in a cloud environment |
 | `CLAUDE_CODE_REMOTE_SESSION_ID` | Read-only. Set automatically in cloud sessions to the current session's ID. Read this to construct a link back to the session transcript |
 | `CLAUDE_REMOTE_CONTROL_SESSION_NAME_PREFIX` | Prefix for auto-generated Remote Control session names. Defaults to the machine hostname |
-| `CLAUDE_CLIENT_PRESENCE_FILE` | Path to a file that, when present, signals an active client and suppresses mobile push notifications from Remote Control. Useful in environments where a desktop client is always running and mobile pings are unwanted *(in v2.1.181 changelog, not yet on official env-vars page)* |
+| `CLAUDE_CLIENT_PRESENCE_FILE` | Path to a file that, when present, signals an active client and suppresses mobile push notifications from Remote Control. Useful in environments where a desktop client is always running and mobile pings are unwanted |
 | `CLAUDE_CODE_ENABLE_TELEMETRY` | Enable/disable telemetry (`0` or `1`) |
 | `DISABLE_ERROR_REPORTING` | Disable error reporting (`1` to disable) |
 | `DISABLE_AUTOUPDATER` | Set to `1` to disable automatic update checks against the npm registry. Also configurable as a startup-only var — see [CLI Startup Flags](./claude-cli-startup-flags.md#environment-variables) |
@@ -903,6 +904,7 @@ Set environment variables for all Claude Code sessions.
 | `MAX_MCP_OUTPUT_TOKENS` | Max MCP output tokens (default: 25000). Warning displayed when output exceeds 10,000 tokens |
 | `API_TIMEOUT_MS` | Timeout in ms for API requests (default: 600000) |
 | `API_FORCE_IDLE_TIMEOUT` | Override the 5-minute idle timeout for streaming connections. Set to `0` to disable the idle timeout entirely, `1` to enforce it on all connections, or leave unset for the default (auto-enabled on slow or unreliable gateways that frequently stall). Useful for slow API gateways (v2.1.169) |
+| `CLAUDE_CODE_CONNECT_TIMEOUT_MS` | Timeout in milliseconds for the connect, TLS, and response-header phase of a streaming API request (default: `60000` / 60 seconds). If no response headers arrive within this window, the request is aborted and retried. Set to `0` to disable and rely on `API_TIMEOUT_MS` alone |
 | `BASH_MAX_TIMEOUT_MS` | Bash command timeout |
 | `BASH_MAX_OUTPUT_LENGTH` | Max bash output length |
 | `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` | Auto-compact threshold percentage (1-100). Default is ~95%. Set lower (e.g., `50`) to trigger compaction earlier. Values above 95% have no effect. Use `/context` to monitor current usage. Example: `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=50 claude` |
@@ -915,6 +917,8 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_DISABLE_WORKFLOWS` | Set to `1` to disable [dynamic workflows](https://code.claude.com/docs/en/workflows) (`/workflows`) and the bundled workflow slash commands. Env-var equivalent of the `disableWorkflows` setting |
 | `CLAUDE_CODE_ENABLE_AUTO_MODE` | Set to `1` to make [auto mode](https://code.claude.com/docs/en/permission-modes#eliminate-prompts-with-auto-mode) available on Amazon Bedrock, Google Cloud Vertex AI, and Microsoft Foundry. Has no effect on the Anthropic API, where auto mode is available by default (v2.1.158) |
 | `CLAUDE_CODE_DISABLE_BUNDLED_SKILLS` | Set to `1` to conceal Claude Code's built-in capabilities (bundled skills) from the model. Env-var equivalent of the `disableBundledSkills` setting (v2.1.169) |
+| `CLAUDE_CODE_DISABLE_ARTIFACT` | Set to `1` to disable the [Artifact](https://code.claude.com/docs/en/artifacts) tool, which publishes session output as a private web page on claude.ai. Equivalent to the `disableArtifact` setting |
+| `CLAUDE_CODE_ARTIFACT_AUTO_OPEN` | Set to `0` to stop Claude Code from opening the browser automatically when a new artifact is published. Republishing an existing artifact does not open the browser regardless of this setting |
 | `ENABLE_TOOL_SEARCH` | MCP tool search threshold (e.g., `auto:5`) |
 | `ENABLE_PROMPT_CACHING_1H` | Opt into 1-hour prompt cache TTL. Replaces the deprecated `ENABLE_PROMPT_CACHING_1H_BEDROCK` *(in v2.1.108 changelog, not yet on official env-vars page)* |
 | `FORCE_PROMPT_CACHING_5M` | Force 5-minute prompt cache TTL *(in v2.1.108 changelog, not yet on official env-vars page)* |
@@ -1010,7 +1014,7 @@ Set environment variables for all Claude Code sessions.
 | `DISABLE_EXTRA_USAGE_COMMAND` | Hide the `/extra-usage` command — renamed to `/usage-credits` in v2.1.144, though this env var name is unchanged (`1` to disable) |
 | `DISABLE_INSTALL_GITHUB_APP_COMMAND` | Hide the `/install-github-app` command (`1` to disable) |
 | `DISABLE_NON_ESSENTIAL_MODEL_CALLS` | Disable flavor text and non-essential model calls *(not in official docs — unverified)* |
-| `CLAUDE_CODE_DEBUG_LOGS_DIR` | Override debug log file directory path |
+| `CLAUDE_CODE_DEBUG_LOGS_DIR` | Override debug log file path. Despite the name, this is a file path, not a directory. Requires debug mode enabled separately via `--debug`, `/debug`, or the `DEBUG` env var; setting this variable alone does not enable logging. Use `--debug-file` to both enable debug mode and set the path at once. Default: `~/.claude/debug/<session-id>.txt` |
 | `CLAUDE_CODE_DEBUG_LOG_LEVEL` | Minimum debug log level |
 | `CLAUDE_AUTO_BACKGROUND_TASKS` | Force auto-backgrounding of long tasks (`1` to enable) |
 | `CLAUDE_CODE_DISABLE_LEGACY_MODEL_REMAP` | Prevent remapping Opus 4.0/4.1 to newer models (`1` to disable) |
@@ -1042,6 +1046,7 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_DISABLE_MOUSE` | Set to `1` to disable mouse tracking in fullscreen rendering. Useful when mouse events interfere with terminal multiplexers or accessibility tools |
 | `CLAUDE_CODE_HIDE_CWD` | Set to `1` to hide the current working directory in the Claude Code startup logo banner. Useful in screen recordings, demos, or shared sessions where the CWD path leaks information about the host or project layout (v2.1.119) |
 | `CLAUDE_CODE_ACCESSIBILITY` | Set to `1` to keep native terminal cursor visible for screen readers and accessibility tools |
+| `CLAUDE_AX_SCREEN_READER` | Set to `1` to render screen-reader friendly output: flat text without decorative borders or animations. Set to `0` to force screen-reader mode off even when the `axScreenReader` setting is `true`. The `--ax-screen-reader` CLI flag takes precedence (v2.1.181+) |
 | `CLAUDE_CODE_NATIVE_CURSOR` | Set to `1` to show the terminal's own cursor at the input caret position instead of Claude Code's custom cursor character |
 | `CLAUDE_CODE_SYNTAX_HIGHLIGHT` | Set to `0` to disable syntax highlighting in diff output |
 | `CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL` | Skip automatic IDE extension installation (`1` to skip) |

--- a/changelog/best-practice/claude-settings/changelog.md
+++ b/changelog/best-practice/claude-settings/changelog.md
@@ -906,3 +906,21 @@
 | 6 | HIGH | New Setting | Add `remoteControlAtStartup` (boolean/null, any scope) to General Settings table — auto-connect Remote Control on startup; `true`/`false`/unset-for-org-default (v2.1.119+, confirmed on official settings page) | ✅ COMPLETE (added after inputNeededNotifEnabled) |
 | 7 | MED | Annotation Fix | Remove "(in v2.1.181 changelog, not yet on official settings page)" from `sandbox.allowAppleEvents` — now confirmed on official settings page | ✅ COMPLETE (annotation updated to (v2.1.181)) |
 | 8 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 39+ consecutive runs. Annotation "in v2.1.85 changelog, not yet on official env-vars page" remains accurate | ✋ ON HOLD (kept — recurring from 2026-04-14 v2.1.107) |
+
+---
+
+## [2026-06-21 10:47 AM PKT] Claude Code v2.1.185
+
+| # | Priority | Type | Action | Status |
+|---|----------|------|--------|--------|
+| 1 | HIGH | Version Bump | Update badge v2.1.183 → v2.1.185 and header "As of v2.1.183" → "As of v2.1.185" | ✅ COMPLETE (badge and header updated in Phase 2.6) |
+| 2 | HIGH | Missing Env Var | Add `CLAUDE_CODE_CONNECT_TIMEOUT_MS` — timeout (ms) for connect/TLS/response-header phase; default 60000ms (60s); set `0` to disable and rely on `API_TIMEOUT_MS` alone | ✅ COMPLETE (added after API_FORCE_IDLE_TIMEOUT) |
+| 3 | HIGH | Missing Env Var | Add `CLAUDE_AX_SCREEN_READER` — set `1` for screen-reader friendly output (flat text, no borders/animations); set `0` to force off even when `axScreenReader: true`; `--ax-screen-reader` CLI flag takes precedence (v2.1.181+) | ✅ COMPLETE (added after CLAUDE_CODE_ACCESSIBILITY) |
+| 4 | HIGH | Missing Env Var | Add `CLAUDE_CODE_DISABLE_ARTIFACT` — set `1` to disable the Artifact tool; equivalent to `disableArtifact` setting | ✅ COMPLETE (added after CLAUDE_CODE_DISABLE_BUNDLED_SKILLS) |
+| 5 | HIGH | Missing Env Var | Add `CLAUDE_CODE_ARTIFACT_AUTO_OPEN` — set `0` to stop Claude Code from auto-opening browser when a new artifact is published | ✅ COMPLETE (added after CLAUDE_CODE_DISABLE_ARTIFACT) |
+| 6 | HIGH | Missing Env Var | Add `CLAUDE_CODE_FORCE_SESSION_PERSISTENCE` — set `1` to override exclusion of nested interactive sessions from `--resume`/`--continue`/history/`claude agents` | ✅ COMPLETE (added after CLAUDE_CODE_CHILD_SESSION) |
+| 7 | MED | Changed Description | Fix `CLAUDE_CODE_DEBUG_LOGS_DIR` — official docs say "despite the name, this is a file path, not a directory"; current report says "Override debug log file directory path" | ✅ COMPLETE (description updated to clarify file path vs directory) |
+| 8 | MED | Annotation Resolved | Remove "not yet on official env-vars page" annotation from `CLAUDE_CLIENT_PRESENCE_FILE` — confirmed present on official /en/env-vars page | ✅ COMPLETE (annotation removed) |
+| 9 | LOW | Invalid Finding | `disableSkillShellExecution` managed-only annotation proposed but INVALID per official docs — scope is User/Project/Local/Managed (any scope) | ❌ INVALID (official settings page confirms any scope — not managed-only) |
+| 10 | LOW | Invalid Finding | `verbose` missing setting proposed but INVALID per official docs — it is a `/config` session-only parameter, not a persistable `settings.json` key | ❌ INVALID (official settings page confirms not a settings.json key) |
+| 11 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — 40+ consecutive ON HOLD runs; still not on official /en/env-vars page | ✋ ON HOLD (recurring from 2026-04-14 v2.1.107; annotation retained)


### PR DESCRIPTION
## Settings Drift Report — 2026-06-21 (Claude Code v2.1.185)

**Run type:** Unattended daily drift check  
**Audited version:** v2.1.185 (stream-stall messaging update; v2.1.184 was bug fixes only — no new settings keys in either)  
**Report:** `best-practice/claude-settings.md`

---

## Summary

6 confirmed drift items fixed (5 missing env vars + 1 description fix), 1 annotation resolved, 2 proposed actions invalidated by official docs verification (Rule 8A).

---

## Verification Log

| Rule | Category | Depth | Result | Notes |
|------|----------|-------|--------|-------|
| 1A | Key Completeness | field-level | PASS | All settings keys present |
| 1B | Key Types | content-match | PASS | Types match official docs |
| 1C | Key Defaults | content-match | PASS | Defaults match official docs |
| 1D | Key Descriptions | content-match | PASS | Descriptions accurate |
| 1E | Scope Column | content-match | PASS | Scopes verified |
| 1F | Inverse Completeness | field-level | PASS | All report keys traceable to official sources |
| 1G | Edge-Case Semantics | content-match | PASS | Boundary values documented |
| 1H | File Scope Check | content-match | PASS | Display settings in correct scope |
| 1I | Skills Settings Keys | field-level | PASS | `maxSkillDescriptionChars`, `skillListingBudgetFraction`, `skillOverrides`, `disableSkillShellExecution` all present |
| 2A | Priority Levels | field-level | PASS | 5-level hierarchy + managed policy correct |
| 2B | File Locations | content-match | PASS | File paths correct |
| 2C | Merge Semantics | content-match | PASS | "concatenated and deduplicated" wording matches |
| 2D | Managed Internals | field-level | PASS | Managed tier delivery methods correct |
| 3A | Permission Modes | field-level | PASS | All modes present |
| 3B | Tool Syntax Patterns | content-match | PASS | Syntax patterns match |
| 3C | Bidirectional Mode Check | field-level | PASS | No orphaned modes |
| 3D | Evaluation Semantics | content-match | PASS | Deny-first, path prefixes documented |
| 4A | Hooks Redirect | exists | PASS | Redirect link to claude-code-hooks repo present |
| 5A | Env Var Completeness | field-level | **FAIL → FIXED** | 5 vars missing: added `CLAUDE_CODE_CONNECT_TIMEOUT_MS`, `CLAUDE_AX_SCREEN_READER`, `CLAUDE_CODE_DISABLE_ARTIFACT`, `CLAUDE_CODE_ARTIFACT_AUTO_OPEN`, `CLAUDE_CODE_FORCE_SESSION_PERSISTENCE` |
| 5B | Ownership Boundary | cross-file | PASS | No cross-file duplication with cli-startup-flags.md |
| 5C | Env Var Descriptions | content-match | **FAIL → FIXED** | `CLAUDE_CODE_DEBUG_LOGS_DIR` described as "directory path" but official docs say "file path, not a directory" |
| 5D | Inverse Env Var Check | field-level | PASS | `CLAUDE_CLIENT_PRESENCE_FILE` annotation removed (now confirmed on official page) |
| 6A | Quick Reference Example | content-match | PASS | Example uses valid current settings |
| 6B | Example URL Validation | exists | PASS | `$schema` URL at `json.schemastore.org` redirects 301 to `www.schemastore.org` (still resolves — LOW note only) |
| 7A | CLAUDE.md Sync | cross-file | PASS | Config hierarchy matches report |
| 8A | Source Credibility Guard | content-match | PASS | All findings confirmed against official docs only |
| 9A | Local File Links | exists | PASS | All relative links resolve |
| 9B | External URL Links | exists | PASS | Settings, env-vars, permissions pages all valid |
| 9C | Anchor Links | exists | PASS | No broken anchors detected |
| 10A | Version Metadata | content-match | FIXED | Badge updated v2.1.183 → v2.1.185 |
| 10B | Suspect Key Escalation | exists | ON HOLD | `OTEL_LOG_TOOL_DETAILS` at 40+ consecutive runs — annotation retained |
| 10C | Bidirectional Completeness | field-level | PASS | All report entries traceable to official sources |

---

## Changes Made

### 1. New Environment Variables (HIGH)

| Variable | Description | Placement |
|----------|-------------|-----------|
| `CLAUDE_CODE_CONNECT_TIMEOUT_MS` | Timeout (ms) for connect/TLS/response-header phase; default 60000ms; set `0` to rely on `API_TIMEOUT_MS` alone | After `API_FORCE_IDLE_TIMEOUT` |
| `CLAUDE_CODE_FORCE_SESSION_PERSISTENCE` | Set `1` to override exclusion of nested interactive TUI sessions from `--resume`/history/`claude agents` | After `CLAUDE_CODE_CHILD_SESSION` |
| `CLAUDE_CODE_DISABLE_ARTIFACT` | Set `1` to disable Artifact tool; equivalent to `disableArtifact` setting | After `CLAUDE_CODE_DISABLE_BUNDLED_SKILLS` |
| `CLAUDE_CODE_ARTIFACT_AUTO_OPEN` | Set `0` to stop auto-opening browser when a new artifact is published | After `CLAUDE_CODE_DISABLE_ARTIFACT` |
| `CLAUDE_AX_SCREEN_READER` | Set `1` for screen-reader friendly output; set `0` to force off even when `axScreenReader: true`; CLI flag `--ax-screen-reader` takes precedence (v2.1.181+) | After `CLAUDE_CODE_ACCESSIBILITY` |

### 2. Description Fix (MED)

`CLAUDE_CODE_DEBUG_LOGS_DIR` — corrected from "Override debug log file directory path" to full accurate description: file path (not directory), requires debug mode separately, `--debug-file` flag does both at once, default path documented.

### 3. Annotation Resolved (MED)

`CLAUDE_CLIENT_PRESENCE_FILE` — removed "*(in v2.1.181 changelog, not yet on official env-vars page)*" annotation. Confirmed present on the official `/en/env-vars` page.

### 4. Invalid Findings (per Rule 8A)

- **`disableSkillShellExecution` managed-only**: INVALID — official settings page shows scope is User/Project/Local/Managed (any scope), not managed-only
- **`verbose` missing setting**: INVALID — official settings page confirms `verbose` is a `/config` session-only parameter, not a persistable `settings.json` key

---

## Hyperlink Validation Log

| # | Type | Link | Status | Notes |
|---|------|------|--------|-------|
| 1 | Local | `../.claude/settings.json` | OK | File exists |
| 2 | Local | `best-practice/claude-cli-startup-flags.md` | OK | File exists |
| 3 | Local | `!/claude-jumping.svg` | OK | File exists |
| 4 | External | `https://code.claude.com/docs/en/settings` | OK | Valid page |
| 5 | External | `https://code.claude.com/docs/en/env-vars` | OK | Valid page |
| 6 | External | `https://code.claude.com/docs/en/permissions` | OK | Valid page |
| 7 | External | `https://json.schemastore.org/claude-code-settings.json` | 301 | Permanent redirect to `www.schemastore.org` — still resolves, LOW priority |

---

## Resolved Since Last Run

All items from the [2026-06-20 v2.1.183] run were COMPLETE or ON HOLD. No new resolutions from that run needed.

---

## Priority Actions

| # | Priority | Type | Action | Status |
|---|----------|------|--------|--------|
| 1 | HIGH | Version Bump | Update badge v2.1.183 → v2.1.185 | ✅ COMPLETE |
| 2 | HIGH | Missing Env Var | Add `CLAUDE_CODE_CONNECT_TIMEOUT_MS` | ✅ COMPLETE |
| 3 | HIGH | Missing Env Var | Add `CLAUDE_AX_SCREEN_READER` | ✅ COMPLETE |
| 4 | HIGH | Missing Env Var | Add `CLAUDE_CODE_DISABLE_ARTIFACT` | ✅ COMPLETE |
| 5 | HIGH | Missing Env Var | Add `CLAUDE_CODE_ARTIFACT_AUTO_OPEN` | ✅ COMPLETE |
| 6 | HIGH | Missing Env Var | Add `CLAUDE_CODE_FORCE_SESSION_PERSISTENCE` | ✅ COMPLETE |
| 7 | MED | Changed Description | Fix `CLAUDE_CODE_DEBUG_LOGS_DIR` (file path not directory) | ✅ COMPLETE |
| 8 | MED | Annotation Resolved | Remove stale annotation from `CLAUDE_CLIENT_PRESENCE_FILE` | ✅ COMPLETE |
| 9 | LOW | Invalid Finding | `disableSkillShellExecution` managed-only — INVALID per official docs | ❌ INVALID |
| 10 | LOW | Invalid Finding | `verbose` as settings.json key — INVALID per official docs | ❌ INVALID |
| 11 | LOW | Suspect Key | `OTEL_LOG_TOOL_DETAILS` — 40+ consecutive ON HOLD runs | ✋ ON HOLD |

---

Generated by unattended daily drift check — 2026-06-21 10:47 AM PKT

---
_Generated by [Claude Code](https://claude.ai/code/session_01JXVQ2vs3pH1orv9Spgk4ey)_