### PR TITLE
Daily settings drift check — 2026-06-23 (Claude Code v2.1.186)

### DIFF
--- a/best-practice/claude-settings.md
+++ b/best-practice/claude-settings.md
@@ -1,9 +1,9 @@
 # Settings Best Practice
 
-![Last Updated](https://img.shields.io/badge/Last_Updated-Jun%2022%2C%202026%2010%3A42%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.185-blue?style=flat&labelColor=555)<br>
+![Last Updated](https://img.shields.io/badge/Last_Updated-Jun%2023%2C%202026%2010%3A57%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.186-blue?style=flat&labelColor=555)<br>
 [![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../.claude/settings.json)
 
-A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.185, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
+A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.186, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
 
 <table width="100%">
 <tr>
@@ -91,6 +91,7 @@ Within the managed tier, precedence is: server-managed > MDM/OS-level policies >
 | `enforceAvailableModels` | boolean | `false` | **(Managed only)** When `true`, the `availableModels` allowlist also constrains the Default model option — users cannot select a model outside the allowlist even via the Default slot. Without this flag, `availableModels` leaves the Default option unrestricted. Pair with `availableModels` for full model lockdown (v2.1.175) |
 | `fastModePerSessionOptIn` | boolean | `false` | Require users to opt in to fast mode each session |
 | `defaultShell` | string | `"bash"` | Default shell for input-box `!` commands. Accepts `"bash"` (default) or `"powershell"`. Setting `"powershell"` routes interactive `!` commands through PowerShell on Windows. Requires `CLAUDE_CODE_USE_POWERSHELL_TOOL=1` (v2.1.84). **v2.1.120:** When PowerShell is available, it is used as the fallback shell on Windows even without Git for Windows installed. **v2.1.126:** When PowerShell is enabled, it is treated as the *primary* shell instead of defaulting to Bash. PowerShell 7 detection now also covers Microsoft Store installs, MSI installs not on PATH, and `.NET` global tool installs |
+| `respondToBashCommands` | boolean | `true` | Claude automatically responds after a `!` shell command runs. Set to `false` to disable automatic post-command analysis. By default (`true`), Claude analyzes the output of every `!` command; set to `false` when you frequently run shell commands and do not want automatic follow-up responses (v2.1.186) |
 | `includeGitInstructions` | boolean | `true` | Include built-in commit and PR workflow instructions and the git status snapshot in Claude's system prompt. The `CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS` environment variable takes precedence over this setting when set |
 | `voice` | object | - | Voice dictation configuration. Object with three fields: `enabled` (boolean — push-to-talk on/off), `mode` (string — `"hold"` for hold-to-talk or `"tap"` for tap-to-toggle), and `autoSubmit` (boolean — submit transcript immediately when dictation ends). Written automatically when you run `/voice`. Requires a Claude.ai account (v2.1.118 expanded structure) |
 | `voiceEnabled` | boolean | - | **DEPRECATED** — legacy alias for `voice.enabled`. Use the `voice` object instead to get `mode` and `autoSubmit` controls |
@@ -647,7 +648,7 @@ Configure via `env` key:
 | `autoScrollEnabled` | boolean | `true` | Auto-scroll the conversation in fullscreen mode. Set to `false` to disable automatic scrolling (v2.1.110). Versions before v2.1.119 stored this in `~/.claude.json` |
 | `editorMode` | string | `"normal"` | Key binding mode for the input prompt: `"normal"` or `"vim"`. Appears in `/config` as **Editor mode**. Versions before v2.1.119 stored this in `~/.claude.json` |
 | `showTurnDuration` | boolean | `true` | Show turn duration messages after responses (e.g., "Cooked for 1m 6s"). Versions before v2.1.119 stored this in `~/.claude.json` |
-| `teammateMode` | string | `"auto"` | How [agent team](https://code.claude.com/docs/en/agent-teams) teammates display: `"auto"` (picks split panes in tmux or iTerm2, in-process otherwise), `"in-process"`, or `"tmux"`. See [choose a display mode](https://code.claude.com/docs/en/agent-teams#choose-a-display-mode). Versions before v2.1.119 stored this in `~/.claude.json` |
+| `teammateMode` | string | `"auto"` | How [agent team](https://code.claude.com/docs/en/agent-teams) teammates display: `"auto"` (picks split panes in tmux or iTerm2, in-process otherwise), `"in-process"`, `"tmux"`, or `"iterm2"` (force iTerm2 split panes — shows a warning when auto mode would have chosen differently, v2.1.186). See [choose a display mode](https://code.claude.com/docs/en/agent-teams#choose-a-display-mode). Versions before v2.1.119 stored this in `~/.claude.json` |
 | `terminalProgressBarEnabled` | boolean | `true` | Show the terminal progress bar in supported terminals (ConEmu, Ghostty 1.2.0+, and iTerm2 3.6.6+). Appears in `/config` as **Terminal progress bar**. Versions before v2.1.119 stored this in `~/.claude.json` |
 | `preferredNotifChannel` | string | `"auto"` | Method for task-complete and permission-prompt notifications. Values: `"auto"`, `"terminal_bell"`, `"iterm2"`, `"iterm2_with_bell"`, `"kitty"`, `"ghostty"`, `"notifications_disabled"`. Default `"auto"` sends a desktop notification in iTerm2, Ghostty, and Kitty and does nothing in other terminals. Set `"terminal_bell"` to ring the bell character in any terminal. Appears in `/config` as **Notifications**. See [Get a terminal bell or notification](https://code.claude.com/docs/en/terminal-config#get-a-terminal-bell-or-notification) |
 | `wheelScrollAccelerationEnabled` | boolean | `true` | Disable mouse-wheel scroll acceleration in fullscreen mode. Set to `false` to use fixed per-tick scroll steps instead of the OS-level acceleration curve (v2.1.174) |
@@ -904,7 +905,7 @@ Set environment variables for all Claude Code sessions.
 | `MAX_MCP_OUTPUT_TOKENS` | Max MCP output tokens (default: 25000). Warning displayed when output exceeds 10,000 tokens |
 | `API_TIMEOUT_MS` | Timeout in ms for API requests (default: 600000) |
 | `API_FORCE_IDLE_TIMEOUT` | Override the 5-minute idle timeout for streaming connections. Set to `0` to disable the idle timeout entirely, `1` to enforce it on all connections, or leave unset for the default (auto-enabled on slow or unreliable gateways that frequently stall). Useful for slow API gateways (v2.1.169) |
-| `CLAUDE_CODE_CONNECT_TIMEOUT_MS` | Timeout in milliseconds for the connect, TLS, and response-header phase of a streaming API request (default: `60000` / 60 seconds). If no response headers arrive within this window, the request is aborted and retried. Set to `0` to disable and rely on `API_TIMEOUT_MS` alone |
+| `CLAUDE_CODE_CONNECT_TIMEOUT_MS` | **REMOVED in v2.1.186** — The separate connect/TLS/response-header phase timeout has been removed. Use `API_TIMEOUT_MS` for per-request timeout control. Previously set the timeout in milliseconds for the connect, TLS, and response-header phase of a streaming API request (default: `60000` / 60 seconds) |
 | `BASH_MAX_TIMEOUT_MS` | Bash command timeout |
 | `BASH_MAX_OUTPUT_LENGTH` | Max bash output length |
 | `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` | Auto-compact threshold percentage (1-100). Default is ~95%. Set lower (e.g., `50`) to trigger compaction earlier. Values above 95% have no effect. Use `/context` to monitor current usage. Example: `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=50 claude` |
@@ -1026,7 +1027,8 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB` | Set to `1` to strip Anthropic and cloud provider credentials from subprocess environments (Bash tool, hooks, MCP stdio servers). Use for defense-in-depth when subprocesses should not inherit API keys (v2.1.83) |
 | `CLAUDE_CODE_SCRIPT_CAPS` | JSON object limiting how many times specific scripts may be invoked per session when `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB` is set. Keys are substrings matched against the command text; values are integer call limits. For example, `{"deploy.sh": 2}` allows `deploy.sh` to be called at most twice. Matching is substring-based; runtime fan-out via `xargs` or `find -exec` is not detected — this is a defense-in-depth control |
 | `CLAUDE_CODE_PERFORCE_MODE` | Set to `1` to enable Perforce-aware write protection. When set, Edit, Write, and NotebookEdit fail with a `p4 edit <file>` hint if the target file lacks the owner-write bit, which Perforce clears on synced files until `p4 edit` opens them. Prevents Claude Code from bypassing Perforce change tracking (v2.1.98) |
-| `CLAUDE_CODE_MAX_RETRIES` | Override API request retry count (default: 10) |
+| `CLAUDE_CODE_MAX_RETRIES` | Override API request retry count (default: 10, capped at a maximum of 15 as of v2.1.183). For unattended sessions that need to survive beyond 15 failures, use `CLAUDE_CODE_RETRY_WATCHDOG` instead |
+| `CLAUDE_CODE_RETRY_WATCHDOG` | Set to `1` to enable a persistent retry watchdog for unattended sessions. Retries beyond the `CLAUDE_CODE_MAX_RETRIES` cap when the session needs to survive extended outages. Use when `CLAUDE_CODE_MAX_RETRIES` alone is insufficient for long-running unattended workflows (v2.1.183) *(in v2.1.183 changelog, not yet on official env-vars page)* |
 | `CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY` | Max parallel read-only tools (default: 10) |
 | `CLAUDE_AGENT_SDK_DISABLE_BUILTIN_AGENTS` | Disable built-in subagent types in SDK mode (`1` to disable) |
 | `CLAUDE_AGENT_SDK_MCP_NO_PREFIX` | Skip `mcp__<server>__` prefix for MCP tools in SDK mode (`1` to enable) |
@@ -1119,6 +1121,8 @@ Set environment variables for all Claude Code sessions.
 | `/memory` | View/edit all memory files |
 | `/agents` | Manage subagents |
 | `/mcp` | Manage MCP servers |
+| `claude mcp login <name>` | Authenticate to a named MCP server without opening the interactive menu. Useful for SSH and headless environments (v2.1.186) |
+| `claude mcp logout <name>` | Sign out of a named MCP server's authentication session (v2.1.186) |
 | `/hooks` | View configured hooks |
 | `/plugin` | Manage plugins |
 | `claude plugin tag` | Tag a plugin version in a marketplace for distribution. Run from the marketplace repo with the plugin name and version (v2.1.118) |
@@ -1151,6 +1155,7 @@ Set environment variables for all Claude Code sessions.
   "awaySummaryEnabled": false,
   "includeGitInstructions": true,
   "defaultShell": "bash",
+  "respondToBashCommands": true,
   "plansDirectory": "./plans",
   "claudeMdExcludes": ["**/vendor/**/CLAUDE.md"],
   "effortLevel": "high",

--- a/changelog/best-practice/claude-settings/changelog.md
+++ b/changelog/best-practice/claude-settings/changelog.md
@@ -936,3 +936,18 @@
 | 3 | LOW | Changed Description | `feedbackSurveyRate`: add "Set to 0 to suppress" note | ✋ ON HOLD (0.6 confidence — not confirmed at content-match depth) |
 | 4 | LOW | Changed Description | `autoScrollEnabled`: add "Permission prompts still scroll" note | ✋ ON HOLD (0.6 confidence — not confirmed at content-match depth) |
 | 5 | LOW | Suspect Key | `OTEL_LOG_TOOL_DETAILS` — 41+ consecutive ON HOLD runs; annotation "in v2.1.85 changelog, not yet on official env-vars page" remains accurate | ✋ ON HOLD (kept — recurring from 2026-04-14 v2.1.107) |
+
+---
+
+## [2026-06-23 10:57 AM PKT] Claude Code v2.1.186
+
+| # | Priority | Type | Action | Status |
+|---|----------|------|--------|--------|
+| 1 | HIGH | Version Bump | Update badge v2.1.185 → v2.1.186 and header "As of v2.1.185" → "As of v2.1.186" | ✅ COMPLETE (badge and header updated in Phase 2.6) |
+| 2 | HIGH | New Setting | Add `respondToBashCommands` (boolean, default `true`) to General Settings table — controls whether Claude auto-responds after `!` shell commands; set `false` to disable (v2.1.186, confirmed on official settings page) | ✅ COMPLETE (added after defaultShell) |
+| 3 | HIGH | Removed Env Var | Annotate `CLAUDE_CODE_CONNECT_TIMEOUT_MS` as **REMOVED in v2.1.186** — use `API_TIMEOUT_MS` instead; confirmed removed on official env-vars page | ✅ COMPLETE (removal annotation added) |
+| 4 | MED | Changed Description | Update `teammateMode` description to add `"iterm2"` as explicit option (force iTerm2 split panes with warning, v2.1.186) | ✅ COMPLETE (description updated) |
+| 5 | MED | Changed Description | Update `CLAUDE_CODE_MAX_RETRIES` description — add "capped at a maximum of 15 as of v2.1.183" | ✅ COMPLETE (description updated) |
+| 6 | MED | Missing Env Var | Add `CLAUDE_CODE_RETRY_WATCHDOG` — persistent retry watchdog for unattended sessions beyond `CLAUDE_CODE_MAX_RETRIES` cap (v2.1.183 changelog) | ✅ COMPLETE (added after CLAUDE_CODE_MAX_RETRIES, annotated as changelog-only) |
+| 7 | LOW | New CLI Commands | Add `claude mcp login <name>` and `claude mcp logout <name>` to Useful Commands — headless MCP server auth (v2.1.186) | ✅ COMPLETE (added to Useful Commands table) |
+| 8 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — 41+ consecutive ON HOLD runs; still not on official /en/env-vars page | ✋ ON HOLD (recurring from 2026-04-14 v2.1.107; annotation retained) |


### PR DESCRIPTION
## Daily Settings Drift Report — 2026-06-23

**Audited version:** Claude Code v2.1.186 (latest as of 2026-06-23)
**Previous version:** v2.1.185
**Run timestamp:** 2026-06-23 10:57 AM PKT

---

## Verification Log

| Rule | Category | Depth | Result | Notes |
|------|----------|-------|--------|-------|
| 1A | Key Completeness | field-level | **FAIL** | `respondToBashCommands` (v2.1.186) missing — FIXED |
| 1B | Key Types | content-match | PASS | All types verified against official settings page |
| 1C | Key Defaults | content-match | PASS | All defaults verified |
| 1D | Key Descriptions | content-match | **FAIL** | `teammateMode` missing `"iterm2"` option; `CLAUDE_CODE_MAX_RETRIES` missing cap-at-15 — FIXED |
| 1E | Scope Column | content-match | PASS | All scopes verified |
| 1F | Inverse Completeness | field-level | PASS | All report keys traceable to official sources or annotated |
| 1G | Edge-Case Semantics | content-match | PASS | No new boundary-value issues |
| 1H | File Scope Check | content-match | PASS | Display settings correctly placed in settings.json vs ~/.claude.json |
| 1I | Skills Settings Keys | field-level | PASS | `skillOverrides`, `disableSkillShellExecution`, `maxSkillDescriptionChars`, `skillListingBudgetFraction` all present |
| 2A | Priority Levels | field-level | PASS | All 5 priority levels + managed documented |
| 2B | File Locations | content-match | PASS | File paths match official docs |
| 2C | Merge Semantics | content-match | PASS | "concatenated and deduplicated" wording correct |
| 2D | Managed Internals | field-level | PASS | Delivery methods and precedence order verified |
| 3A | Permission Modes | field-level | PASS | All 6 modes documented (default, acceptEdits, dontAsk, bypassPermissions, auto, plan) |
| 3B | Tool Syntax Patterns | content-match | PASS | All tool patterns verified |
| 3C | Bidirectional Mode Check | field-level | PASS | All report modes exist in docs and vice versa |
| 3D | Evaluation Semantics | content-match | PASS | Deny-first, path-prefix patterns documented |
| 4A | Hooks Redirect | exists | PASS | Valid link to `shanraisshan/claude-code-hooks` confirmed |
| 5A | Env Var Completeness | field-level | **FAIL** | `CLAUDE_CODE_RETRY_WATCHDOG` (v2.1.183) missing — FIXED |
| 5B | Ownership Boundary | cross-file | PASS | No duplication between settings and CLI flags files |
| 5C | Env Var Descriptions | content-match | **FAIL** | `CLAUDE_CODE_MAX_RETRIES` missing "capped at 15" — FIXED |
| 5D | Inverse Env Var Check | field-level | **FAIL** | `CLAUDE_CODE_CONNECT_TIMEOUT_MS` confirmed REMOVED in v2.1.186, needs annotation — FIXED |
| 6A | Quick Reference Example | content-match | PASS | Example updated with `respondToBashCommands` |
| 6B | Example URL Validation | exists | PASS | `$schema` URL resolves (redirects json→www.schemastore.org, valid) |
| 7A | CLAUDE.md Sync | cross-file | PASS | Configuration hierarchy matches report |
| 8A | Source Credibility Guard | content-match | PASS | All findings sourced from official GitHub changelog or official settings/env-vars pages |
| 9A | Local File Links | exists | PASS | `../.claude/settings.json`, `./claude-cli-startup-flags.md`, `../!/claude-jumping.svg` all resolve |
| 9B | External URL Links | exists | PASS | `code.claude.com`, `json.schemastore.org`, `github.com/shanraisshan/claude-code-hooks` all valid |
| 9C | Anchor Links | exists | PASS | All TOC anchors match headings |
| 10A | Version Metadata | content-match | **FAIL** | Badge showed v2.1.185 — FIXED to v2.1.186 |
| 10B | Suspect Key Escalation | exists | ON HOLD | `OTEL_LOG_TOOL_DETAILS` at 41+ consecutive runs; annotation retained |
| 10C | Bidirectional Completeness | field-level | PASS (after fix) | All keys traceable after removal annotation added |

---

## 1. New Settings Keys

| Key | Type | Default | Section | Version | Source |
|-----|------|---------|---------|---------|--------|
| `respondToBashCommands` | boolean | `true` | General Settings | v2.1.186 | Official settings page |

**Details:** Controls whether Claude automatically responds after a `!` shell command runs. Set to `false` to disable automatic post-command analysis. Default `true` (new behavior since v2.1.186: `!` commands now trigger automatic Claude response by default).

---

## 2. Changed Setting Behavior

| Key | Change | Version | Source |
|-----|--------|---------|--------|
| `teammateMode` | Added `"iterm2"` as explicit option (force iTerm2 split panes with warning when auto mode would have chosen differently) | v2.1.186 | Official GitHub changelog |
| `CLAUDE_CODE_MAX_RETRIES` | Now capped at maximum 15 (was uncapped) | v2.1.183 | Official GitHub changelog |

---

## 3. Deprecated/Removed Settings

| Key | Action | Version | Source |
|-----|--------|---------|--------|
| `CLAUDE_CODE_CONNECT_TIMEOUT_MS` | **REMOVED** — separate connect/TLS phase timeout eliminated; use `API_TIMEOUT_MS` | v2.1.186 | Official env-vars page |

> ⚠️ **High-risk finding:** This env var was only *added* to our report in the v2.1.185 run (yesterday). It was removed from Claude Code in the very next version (v2.1.186). The removal annotation has been added.

---

## 4. Permission Syntax Changes

None detected in v2.1.186.

---

## 5. MCP Setting Changes

**New CLI commands** (not settings keys — added to Useful Commands section):
- `claude mcp login <name>` — authenticate to a named MCP server without interactive menu (v2.1.186)
- `claude mcp logout <name>` — sign out of a named MCP server (v2.1.186)

---

## 6. Sandbox Setting Changes

None detected in v2.1.186.

---

## 7. Plugin Setting Changes

None detected in v2.1.186.

---

## 8. Model Configuration Changes

None detected in v2.1.186. (The "best" model alias claimed by some agents was **not confirmed** on the official settings page — Rule 8A: not flagged.)

---

## 9. Display & UX Changes

`teammateMode` gained `"iterm2"` value — see §2 above.

---

## 10. Environment Variable Completeness

| Variable | Action | Version | Source |
|----------|--------|---------|--------|
| `CLAUDE_CODE_CONNECT_TIMEOUT_MS` | Annotated REMOVED | v2.1.186 | Official env-vars page |
| `CLAUDE_CODE_RETRY_WATCHDOG` | Added (annotated changelog-only) | v2.1.183 | Official GitHub changelog |

---

## 11. Settings Hierarchy Accuracy

No changes detected. The 5-level hierarchy + managed policy layer matches official docs.

---

## 12. Example Accuracy

Quick Reference JSON example updated to include `respondToBashCommands: true`.

---

## 13. Sources Accuracy

All 6 source links verified:
- `code.claude.com/docs/en/settings` — OK
- `json.schemastore.org/claude-code-settings.json` — OK (redirects to www.schemastore.org, valid)
- `github.com/anthropics/claude-code/blob/main/CHANGELOG.md` — OK
- `github.com/feiskyer/claude-code-settings` — OK
- `code.claude.com/docs/en/env-vars` — OK
- `code.claude.com/docs/en/permissions` — OK

---

## 14. claude-code-guide Agent Findings

Unique insights from the independent research agent:
- Confirmed `respondToBashCommands` default is `true` (not `false` as the changelog note could imply — the setting *disables* response when set to `false`)
- Confirmed `CLAUDE_CODE_CONNECT_TIMEOUT_MS` removal is definitive — not just deprecated, fully removed
- Agent noted `CLAUDE_CODE_RETRY_WATCHDOG` behavior: it is a persistent loop, not just a higher retry cap

No contradictions between the two agents' findings.

---

## Priority Actions Summary

| # | Priority | Type | Action | Status |
|---|----------|------|--------|--------|
| 1 | HIGH | Version Bump | Update badge v2.1.185 → v2.1.186 | ✅ COMPLETE |
| 2 | HIGH | New Setting | Add `respondToBashCommands` (boolean, `true`) to General Settings | ✅ COMPLETE |
| 3 | HIGH | Removed Env Var | Annotate `CLAUDE_CODE_CONNECT_TIMEOUT_MS` as REMOVED in v2.1.186 | ✅ COMPLETE |
| 4 | MED | Changed Description | Add `"iterm2"` option to `teammateMode` description | ✅ COMPLETE |
| 5 | MED | Changed Description | Update `CLAUDE_CODE_MAX_RETRIES` — capped at 15 as of v2.1.183 | ✅ COMPLETE |
| 6 | MED | Missing Env Var | Add `CLAUDE_CODE_RETRY_WATCHDOG` (v2.1.183, changelog-annotated) | ✅ COMPLETE |
| 7 | LOW | New CLI Commands | Add `claude mcp login/logout` to Useful Commands | ✅ COMPLETE |
| 8 | LOW | Suspect Key | `OTEL_LOG_TOOL_DETAILS` — 41+ consecutive ON HOLD runs | ✋ ON HOLD |

## Resolved Since Last Run

Items from the 2026-06-22 run that required human judgment were all ON HOLD — none auto-resolved. No previous ON HOLD items converted to COMPLETE in this run.

---

## Hyperlink Validation Log

| # | Type | Link | Status |
|---|------|------|--------|
| 1 | Local | `../.claude/settings.json` | OK |
| 2 | Local | `./claude-cli-startup-flags.md#environment-variables` | OK |
| 3 | Local | `../!/claude-jumping.svg` | OK |
| 4 | External | `https://code.claude.com/docs/en/settings` | OK |
| 5 | External | `https://code.claude.com/docs/en/env-vars` | OK |
| 6 | External | `https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md` | OK |
| 7 | External | `https://json.schemastore.org/claude-code-settings.json` | OK (301 → www.schemastore.org) |
| 8 | External | `https://github.com/shanraisshan/claude-code-hooks` | OK |
| 9 | External | `https://github.com/feiskyer/claude-code-settings` | OK |
| 10 | External | `https://datatracker.ietf.org/doc/rfc9728/` | OK (RFC, stable) |

---

*Generated by the unattended daily drift checker. Do not merge — leave open for human review.*

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXRJtRmJZwVc1aPxMSZ4xC)_