### PR TITLE
Daily settings drift check — 2026-06-24 (Claude Code v2.1.187)

### DIFF
--- a/best-practice/claude-settings.md
+++ b/best-practice/claude-settings.md
@@ -1,9 +1,9 @@
 # Settings Best Practice
 
-![Last Updated](https://img.shields.io/badge/Last_Updated-Jun%2022%2C%202026%2010%3A42%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.185-blue?style=flat&labelColor=555)<br>
+![Last Updated](https://img.shields.io/badge/Last_Updated-Jun%2024%2C%202026%2010%3A37%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.187-blue?style=flat&labelColor=555)<br>
 [![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../.claude/settings.json)
 
-A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.185, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
+A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.187, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
 
 <table width="100%">
 <tr>
@@ -119,6 +119,7 @@ Within the managed tier, precedence is: server-managed > MDM/OS-level policies >
 | `disableArtifact` | boolean | `false` | Disable the Artifact web publishing tool. When `true`, Claude cannot create or publish web artifacts. Can be set at any scope |
 | `feedbackSurveyRate` | number | - | Probability (0–1) that the session quality survey appears when eligible. Enterprise admins can control how often the survey is shown. Example: `0.05` = 5% of eligible sessions |
 | `advisorModel` | string | - | Model for the server-side advisor tool. Accepts a model alias (`opus`, `sonnet`, `fable`) or a full model ID. When unset, the advisor uses the session model. Requires v2.1.98+ |
+| `respondToBashCommands` | boolean | `true` | Whether Claude automatically responds after a `!` shell command completes. Set to `false` to disable the automatic follow-up response when a `!` bash command finishes (v2.1.186) |
 
 **Example:**
 ```json
@@ -471,6 +472,7 @@ Configure bash command sandboxing for security.
 | `sandbox.bwrapPath` | string | - | **(Managed only, Linux/WSL2)** Absolute path to the bubblewrap (`bwrap`) binary. Overrides automatic `PATH` detection. Only honored from managed settings, not user or project settings. Example: `/opt/admin/bwrap` (v2.1.133) |
 | `sandbox.socatPath` | string | - | **(Managed only, Linux/WSL2)** Absolute path to the `socat` binary used for the sandbox network proxy. Overrides automatic `PATH` detection. Only honored from managed settings. Example: `/opt/admin/socat` (v2.1.133) |
 | `sandbox.allowAppleEvents` | boolean | `false` | **(macOS only)** Opt-in for sandboxed commands to send Apple Events. Required for tools that use `open`, `osascript`, or browser authentication flows that depend on Apple Events IPC (v2.1.181) |
+| `sandbox.credentials` | boolean | `false` | Block sandboxed commands from reading credential files and secret environment variables. When `true`, strips Anthropic API keys, AWS/GCP/Azure credentials, and similar secret env vars from the sandboxed subprocess environment (v2.1.187) |
 
 **Example:**
 ```json
@@ -647,7 +649,7 @@ Configure via `env` key:
 | `autoScrollEnabled` | boolean | `true` | Auto-scroll the conversation in fullscreen mode. Set to `false` to disable automatic scrolling (v2.1.110). Versions before v2.1.119 stored this in `~/.claude.json` |
 | `editorMode` | string | `"normal"` | Key binding mode for the input prompt: `"normal"` or `"vim"`. Appears in `/config` as **Editor mode**. Versions before v2.1.119 stored this in `~/.claude.json` |
 | `showTurnDuration` | boolean | `true` | Show turn duration messages after responses (e.g., "Cooked for 1m 6s"). Versions before v2.1.119 stored this in `~/.claude.json` |
-| `teammateMode` | string | `"auto"` | How [agent team](https://code.claude.com/docs/en/agent-teams) teammates display: `"auto"` (picks split panes in tmux or iTerm2, in-process otherwise), `"in-process"`, or `"tmux"`. See [choose a display mode](https://code.claude.com/docs/en/agent-teams#choose-a-display-mode). Versions before v2.1.119 stored this in `~/.claude.json` |
+| `teammateMode` | string | `"auto"` | How [agent team](https://code.claude.com/docs/en/agent-teams) teammates display: `"auto"` (picks split panes in tmux or iTerm2, in-process otherwise), `"in-process"`, `"tmux"`, or `"iterm2"` (force iTerm2 split panes regardless of auto-detection, v2.1.186). See [choose a display mode](https://code.claude.com/docs/en/agent-teams#choose-a-display-mode). Versions before v2.1.119 stored this in `~/.claude.json` |
 | `terminalProgressBarEnabled` | boolean | `true` | Show the terminal progress bar in supported terminals (ConEmu, Ghostty 1.2.0+, and iTerm2 3.6.6+). Appears in `/config` as **Terminal progress bar**. Versions before v2.1.119 stored this in `~/.claude.json` |
 | `preferredNotifChannel` | string | `"auto"` | Method for task-complete and permission-prompt notifications. Values: `"auto"`, `"terminal_bell"`, `"iterm2"`, `"iterm2_with_bell"`, `"kitty"`, `"ghostty"`, `"notifications_disabled"`. Default `"auto"` sends a desktop notification in iTerm2, Ghostty, and Kitty and does nothing in other terminals. Set `"terminal_bell"` to ring the bell character in any terminal. Appears in `/config` as **Notifications**. See [Get a terminal bell or notification](https://code.claude.com/docs/en/terminal-config#get-a-terminal-bell-or-notification) |
 | `wheelScrollAccelerationEnabled` | boolean | `true` | Disable mouse-wheel scroll acceleration in fullscreen mode. Set to `false` to use fixed per-tick scroll steps instead of the OS-level acceleration curve (v2.1.174) |

--- a/changelog/best-practice/claude-settings/changelog.md
+++ b/changelog/best-practice/claude-settings/changelog.md
@@ -936,3 +936,15 @@
 | 3 | LOW | Changed Description | `feedbackSurveyRate`: add "Set to 0 to suppress" note | ✋ ON HOLD (0.6 confidence — not confirmed at content-match depth) |
 | 4 | LOW | Changed Description | `autoScrollEnabled`: add "Permission prompts still scroll" note | ✋ ON HOLD (0.6 confidence — not confirmed at content-match depth) |
 | 5 | LOW | Suspect Key | `OTEL_LOG_TOOL_DETAILS` — 41+ consecutive ON HOLD runs; annotation "in v2.1.85 changelog, not yet on official env-vars page" remains accurate | ✋ ON HOLD (kept — recurring from 2026-04-14 v2.1.107) |
+
+---
+
+## [2026-06-24 10:44 AM PKT] Claude Code v2.1.187
+
+| # | Priority | Type | Action | Status |
+|---|----------|------|--------|--------|
+| 1 | HIGH | New Setting | Add `sandbox.credentials` (boolean, default `false`, v2.1.187) to Sandbox Settings table — blocks sandboxed commands from reading credential files and secret environment variables | ✅ COMPLETE (added to Sandbox Settings table after sandbox.allowAppleEvents) |
+| 2 | HIGH | Changed Behavior | Add `"iterm2"` to `teammateMode` valid values — force iTerm2 split-pane display for agent teammates (v2.1.186) | ✅ COMPLETE (added to Display Settings table teammateMode row) |
+| 3 | HIGH | New Setting | Add `respondToBashCommands` (boolean, default `true`, v2.1.186) to General Settings table — controls whether Claude auto-responds after `!` shell commands | ✅ COMPLETE (added to General Settings table after advisorModel) |
+| 4 | MED | Version Bump | Update report version badge from v2.1.185 → v2.1.187 and header "As of v2.1.185" → "As of v2.1.187" | ✅ COMPLETE (badge and header updated in Phase 2.6) |
+| 5 | LOW | Suspect Key | `OTEL_LOG_TOOL_DETAILS` — 42+ consecutive ON HOLD runs; annotation "in v2.1.85 changelog, not yet on official env-vars page" remains accurate | ✋ ON HOLD (kept — recurring from 2026-04-14 v2.1.107) |


### PR DESCRIPTION
## Settings Drift Report — 2026-06-24 (Claude Code v2.1.187)

Report upgraded from v2.1.185 → v2.1.187. Three new settings from the v2.1.186–v2.1.187 releases were missing from the report; all have been applied.

---

## Action Items

| # | Priority | Type | Action | Status |
|---|----------|------|--------|--------|
| 1 | HIGH | New Setting | Add `sandbox.credentials` (boolean, default `false`, v2.1.187) — blocks credential/secret env var leakage into sandboxed subprocesses | ✅ COMPLETE |
| 2 | HIGH | Changed Behavior | Add `"iterm2"` to `teammateMode` valid values (v2.1.186) — forces iTerm2 split-pane display regardless of auto-detection | ✅ COMPLETE |
| 3 | HIGH | New Setting | Add `respondToBashCommands` (boolean, default `true`, v2.1.186) — controls auto-response after `!` shell commands | ✅ COMPLETE |
| 4 | MED | Version Bump | Badge and header updated from v2.1.185 → v2.1.187 | ✅ COMPLETE |
| 5 | LOW | Suspect Key | `OTEL_LOG_TOOL_DETAILS` — 42+ consecutive ON HOLD runs; not on official /en/env-vars page; annotation retained | ✋ ON HOLD |

---

## Verification Log (23/23 rules executed)

| Rule | Category | Depth | Result | Notes |
|------|----------|-------|--------|-------|
| 1A | Key Completeness | field-level | FAIL → FIXED | `sandbox.credentials` and `respondToBashCommands` were missing; now added |
| 1B | Key Types | content-match | PASS | All key types verified |
| 1C | Key Defaults | content-match | PASS | All defaults verified |
| 1D | Key Descriptions | content-match | PASS | Descriptions match official docs |
| 1E | Scope Column | content-match | PASS | No scope mismatches found |
| 1F | Inverse Completeness | field-level | PASS | No orphaned keys in report |
| 1G | Edge-Case Semantics | content-match | PASS | `sandbox.credentials` `true`/`false` behavior documented |
| 1H | File Scope Check | content-match | PASS | No settings.json keys misplaced in ~/.claude.json section |
| 1I | Skills Settings Keys | field-level | PASS | `skillOverrides`, `disableSkillShellExecution`, `maxSkillDescriptionChars`, `skillListingBudgetFraction` all present |
| 2A | Priority Levels | field-level | PASS | 5-level chain + managed policy matches official docs |
| 2B | File Locations | content-match | PASS | All file paths correct |
| 2C | Merge Semantics | content-match | PASS | "concatenated and deduplicated" wording matches |
| 2D | Managed Internals | field-level | PASS | Server-managed, MDM, registry, file — all present |
| 3A | Permission Modes | field-level | PASS | All permission modes present |
| 3B | Tool Syntax Patterns | content-match | PASS | All patterns verified |
| 3C | Bidirectional Mode Check | field-level | PASS | No unverified modes |
| 3D | Evaluation Semantics | content-match | PASS | Deny-first, path-prefix patterns documented |
| 4A | Hooks Redirect | exists | PASS | Redirect link to claude-code-hooks repo is valid |
| 5A | Env Var Completeness | field-level | PASS | All env vars from official docs present |
| 5B | Ownership Boundary | cross-file | PASS | No duplication between settings and CLI flags files |
| 5C | Env Var Descriptions | content-match | PASS | All descriptions verified against /en/env-vars |
| 5D | Inverse Env Var Check | field-level | PASS | All env vars in report traceable to official docs or annotated |
| 6A | Quick Reference Example | content-match | PASS | Example uses valid current settings |
| 6B | Example URL Validation | exists | PASS | `$schema` URL resolves correctly |
| 7A | CLAUDE.md Sync | cross-file | PASS | CLAUDE.md hierarchy matches report |
| 8A | Source Credibility Guard | content-match | PASS | All findings confirmed via official sources only |
| 9A | Local File Links | exists | PASS | All relative file links resolve |
| 9B | External URL Links | exists | PASS | All 18 external URLs return valid pages |
| 9C | Anchor Links | exists | PASS | All anchor links point to existing headings |
| 10A | Version Metadata | content-match | FAIL → FIXED | Badge was v2.1.185; updated to v2.1.187 |
| 10B | Suspect Key Escalation | exists | PASS | `OTEL_LOG_TOOL_DETAILS` at 42+ runs — annotated per rule |
| 10C | Bidirectional Completeness | field-level | PASS | All keys traceable to official source or marked unverified |

---

## Hyperlink Validation Log

All 23 hyperlinks checked — no broken links found.

---

## Files Changed

| File | Change |
|------|--------|
| `best-practice/claude-settings.md` | Added `sandbox.credentials` row, `respondToBashCommands` row, `"iterm2"` to `teammateMode`; bumped badge + header to v2.1.187 |
| `changelog/best-practice/claude-settings/changelog.md` | Appended 2026-06-24 v2.1.187 entry |

---

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01BfrCFr5oVLJihxgNE43DLy

---
_Generated by [Claude Code](https://claude.ai/code/session_01BfrCFr5oVLJihxgNE43DLy)_