### PR TITLE
Daily settings drift check — 2026-06-25 (Claude Code v2.1.191)

### DIFF
--- a/best-practice/claude-settings.md
+++ b/best-practice/claude-settings.md
@@ -1,9 +1,9 @@
 # Settings Best Practice
 
-![Last Updated](https://img.shields.io/badge/Last_Updated-Jun%2024%2C%202026%2010%3A37%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.187-blue?style=flat&labelColor=555)<br>
+![Last Updated](https://img.shields.io/badge/Last_Updated-Jun%2025%2C%202026%2010%3A37%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.191-blue?style=flat&labelColor=555)<br>
 [![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../.claude/settings.json)
 
-A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.187, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
+A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.191, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
 
 <table width="100%">
 <tr>
@@ -472,7 +472,7 @@ Configure bash command sandboxing for security.
 | `sandbox.bwrapPath` | string | - | **(Managed only, Linux/WSL2)** Absolute path to the bubblewrap (`bwrap`) binary. Overrides automatic `PATH` detection. Only honored from managed settings, not user or project settings. Example: `/opt/admin/bwrap` (v2.1.133) |
 | `sandbox.socatPath` | string | - | **(Managed only, Linux/WSL2)** Absolute path to the `socat` binary used for the sandbox network proxy. Overrides automatic `PATH` detection. Only honored from managed settings. Example: `/opt/admin/socat` (v2.1.133) |
 | `sandbox.allowAppleEvents` | boolean | `false` | **(macOS only)** Opt-in for sandboxed commands to send Apple Events. Required for tools that use `open`, `osascript`, or browser authentication flows that depend on Apple Events IPC (v2.1.181) |
-| `sandbox.credentials` | boolean | `false` | Block sandboxed commands from reading credential files and secret environment variables. When `true`, strips Anthropic API keys, AWS/GCP/Azure credentials, and similar secret env vars from the sandboxed subprocess environment (v2.1.187) |
+| `sandbox.credentials` | object | - | Pass credential files and environment variables into the sandboxed subprocess. Sub-keys: `files` (array of `{path, env}` objects — each file is bind-mounted into the sandbox and the named env var is set to its contents) and `envVars` (array of env var names to pass through from the host environment). Example: `{"files": [{"path": "/var/lib/secrets/token", "env": "API_TOKEN"}], "envVars": ["AWS_ACCESS_KEY_ID"]}` (v2.1.187) |
 
 **Example:**
 ```json
@@ -904,6 +904,7 @@ Set environment variables for all Claude Code sessions.
 | `MCP_TIMEOUT` | MCP startup timeout in ms |
 | `CLAUDE_CODE_MCP_ALLOWLIST_ENV` | Spawn stdio MCP servers with a safe baseline environment only, stripping most inherited env vars to prevent credential leakage into untrusted server processes |
 | `MAX_MCP_OUTPUT_TOKENS` | Max MCP output tokens (default: 25000). Warning displayed when output exceeds 10,000 tokens |
+| `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT` | Idle timeout in ms for remote MCP tool calls (default: `300000` / 5 minutes). If a remote MCP tool produces no output for this duration, the call is aborted. Increase for long-running remote tools (v2.1.189) *(in v2.1.189 changelog, not yet on official env-vars page)* |
 | `API_TIMEOUT_MS` | Timeout in ms for API requests (default: 600000) |
 | `API_FORCE_IDLE_TIMEOUT` | Override the 5-minute idle timeout for streaming connections. Set to `0` to disable the idle timeout entirely, `1` to enforce it on all connections, or leave unset for the default (auto-enabled on slow or unreliable gateways that frequently stall). Useful for slow API gateways (v2.1.169) |
 | `CLAUDE_CODE_CONNECT_TIMEOUT_MS` | Timeout in milliseconds for the connect, TLS, and response-header phase of a streaming API request (default: `60000` / 60 seconds). If no response headers arrive within this window, the request is aborted and retried. Set to `0` to disable and rely on `API_TIMEOUT_MS` alone |
@@ -1035,6 +1036,7 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_ASYNC_AGENT_STALL_TIMEOUT_MS` | Stall timeout in ms for background subagents (default: 600000 / 10 minutes). The subagent is killed if it produces no output for this duration |
 | `MCP_CONNECTION_NONBLOCKING` | Set to `true` in `-p` mode to skip the MCP connection wait entirely. Bounds `--mcp-config` server connections at 5s instead of blocking on the slowest server *(in v2.1.89 changelog, not yet on official env-vars page)* |
 | `CLAUDE_CODE_SESSIONEND_HOOKS_TIMEOUT_MS` | SessionEnd hook timeout in ms (replaces hard 1.5s limit) |
+| `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP` | Maximum number of times a blocking Stop hook can defer the session end (default: `8`). Once the cap is reached, Claude Code terminates even if the hook would still block. Prevents runaway Stop hooks from keeping a session alive indefinitely (v2.1.191) |
 | `CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY` | Disable feedback survey prompts (`1` to disable) |
 | `CLAUDE_CODE_ENABLE_FEEDBACK_SURVEY_FOR_OTEL` | Set to `1` to route the session quality survey to your own OpenTelemetry collector when Anthropic-bound nonessential traffic is blocked. Survey ratings are emitted only as OTEL events to your configured collector — no survey data is sent to Anthropic. Applies when `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`, `DISABLE_TELEMETRY`, or `DO_NOT_TRACK` is set; has no effect otherwise. `CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY` and the organization product feedback policy take precedence (v2.1.136) |
 | `CLAUDE_CODE_DISABLE_TERMINAL_TITLE` | Disable terminal title updates (`1` to disable) |

--- a/changelog/best-practice/claude-settings/changelog.md
+++ b/changelog/best-practice/claude-settings/changelog.md
@@ -948,3 +948,16 @@
 | 3 | HIGH | New Setting | Add `respondToBashCommands` (boolean, default `true`, v2.1.186) to General Settings table — controls whether Claude auto-responds after `!` shell commands | ✅ COMPLETE (added to General Settings table after advisorModel) |
 | 4 | MED | Version Bump | Update report version badge from v2.1.185 → v2.1.187 and header "As of v2.1.185" → "As of v2.1.187" | ✅ COMPLETE (badge and header updated in Phase 2.6) |
 | 5 | LOW | Suspect Key | `OTEL_LOG_TOOL_DETAILS` — 42+ consecutive ON HOLD runs; annotation "in v2.1.85 changelog, not yet on official env-vars page" remains accurate | ✋ ON HOLD (kept — recurring from 2026-04-14 v2.1.107) |
+
+---
+
+## [2026-06-25 10:47 AM PKT] Claude Code v2.1.191
+
+| # | Priority | Type | Action | Status |
+|---|----------|------|--------|--------|
+| 1 | HIGH | Bug Fix | Fix `sandbox.credentials` type: previous run added it as `boolean` (WRONG) — official settings page confirms it is an `object` with `files` and `envVars` sub-keys that passes credentials into the sandbox | ✅ COMPLETE (corrected type, default, and description in Sandbox Settings table) |
+| 2 | HIGH | New Env Var | Add `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP` (default `8`, v2.1.191) to Environment Variables table — caps the number of times a blocking Stop hook can defer session end | ✅ COMPLETE (added near CLAUDE_CODE_SESSIONEND_HOOKS_TIMEOUT_MS) |
+| 3 | MED | New Env Var | Add `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT` (default `300000` / 5 min, v2.1.189, changelog-only) to Environment Variables table — idle timeout for remote MCP tool calls | ✅ COMPLETE (added near MCP_TIMEOUT entries, annotated changelog-only) |
+| 4 | MED | Scope Check | `enforceAvailableModels` scope: report says "(Managed only)", official page reportedly says scope "Any" — needs human verification before changing | ✋ ON HOLD (pending manual check of official settings page scope column) |
+| 5 | MED | Version Bump | Update report version badge from v2.1.187 → v2.1.191 and header "As of v2.1.187" → "As of v2.1.191" | ✅ COMPLETE (badge and header updated in Phase 2.6) |
+| 6 | LOW | Suspect Key | `OTEL_LOG_TOOL_DETAILS` — 43+ consecutive ON HOLD runs; annotation "in v2.1.85 changelog, not yet on official env-vars page" remains accurate | ✋ ON HOLD (kept — recurring from 2026-04-14 v2.1.107) |


### PR DESCRIPTION
## Summary

Automated daily drift check against Claude Code v2.1.191 official docs.

### Changes Applied

| # | Priority | Type | Change |
|---|----------|------|--------|
| 1 | HIGH | Bug Fix | `sandbox.credentials`: fixed type `boolean` → `object` with `files`/`envVars` sub-keys. Previous run (v2.1.187) had inverted semantics — the feature *passes* credentials into the sandbox, it does not block them |
| 2 | HIGH | New Env Var | Added `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP` (default `8`, v2.1.191) — caps how many times a blocking Stop hook can defer session end |
| 3 | MED | New Env Var | Added `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT` (default `300000` / 5 min, v2.1.189, changelog-only annotation) — idle timeout for remote MCP tool calls |
| 4 | MED | Version Bump | Badge and intro paragraph: v2.1.187 → v2.1.191, Jun 24 → Jun 25 |

### Needs Human Review

- **`enforceAvailableModels` scope**: Report currently says `(Managed only)`. Research found the official settings page scope column may say `"Any"`. Kept ON HOLD — please verify on https://code.claude.com/docs/en/settings before removing the annotation.

### Verification Log (abbreviated)

All 20+ checklist rules (1A–10C) executed. Key results:
- **1A Key Completeness**: PASS (v2.1.188–191 are bug-fix releases; no new `settings.json` keys)
- **1B/1C/1D Types/Defaults/Descriptions**: FAIL → FIXED (`sandbox.credentials`)
- **5A Env Var Completeness**: FAIL → FIXED (`CLAUDE_CODE_STOP_HOOK_BLOCK_CAP`, `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT` added)
- **9A/9B/9C Hyperlinks**: PASS (all local file links, anchors, and external URLs validated)
- **10A Version Metadata**: PASS (badge and header updated)
- **10B Suspect Key Escalation**: `OTEL_LOG_TOOL_DETAILS` — 43+ runs ON HOLD, annotation remains accurate

### Files Changed

- `best-practice/claude-settings.md` — 3 content fixes + badge/version bump
- `changelog/best-practice/claude-settings/changelog.md` — appended v2.1.191 run entry

---
Generated by automated daily drift checker · 2026-06-25 10:47 AM PKT

---
_Generated by [Claude Code](https://claude.ai/code/session_01JPovREvxFD1Tyw38qm9CLW)_