### PR TITLE
Daily settings drift check — 2026-06-26 (Claude Code v2.1.193)

### DIFF
--- a/best-practice/claude-settings.md
+++ b/best-practice/claude-settings.md
@@ -1,9 +1,9 @@
 # Settings Best Practice
 
-![Last Updated](https://img.shields.io/badge/Last_Updated-Jun%2024%2C%202026%2010%3A37%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.187-blue?style=flat&labelColor=555)<br>
+![Last Updated](https://img.shields.io/badge/Last_Updated-Jun%2026%2C%202026%2010%3A46%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.193-blue?style=flat&labelColor=555)<br>
 [![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../.claude/settings.json)
 
-A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.187, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
+A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.193, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
 
 <table width="100%">
 <tr>
@@ -270,7 +270,7 @@ Control what tools and operations Claude can perform.
 | `permissions.disableBypassPermissionsMode` | string | Prevent bypass mode activation |
 | `permissions.skipDangerousModePermissionPrompt` | boolean | Skip the confirmation prompt shown before entering bypass permissions mode via `--dangerously-skip-permissions` or `defaultMode: "bypassPermissions"`. Ignored when set in project settings (`.claude/settings.json`) to prevent untrusted repositories from auto-bypassing the prompt |
 | `allowManagedPermissionRulesOnly` | boolean | **(Managed only)** Only managed permission rules apply; user/project `allow`, `ask`, `deny` rules are ignored |
-| `autoMode` | object | Customize what the [auto mode](https://code.claude.com/docs/en/permission-modes#eliminate-prompts-with-auto-mode) classifier blocks and allows. Contains `environment` (trusted infrastructure descriptions), `allow` (exceptions to block rules), `soft_deny` (block rules), and `hard_deny` (unconditional block rules — cannot be overridden by `allow` exceptions or the `$defaults` sentinel, v2.1.136) — all arrays of prose strings. **Not read from shared project settings** (`.claude/settings.json`) to prevent repo injection. Available in user, local, and managed settings. Setting `allow` or `soft_deny` **replaces** the entire default list for that section unless you include the literal string `"$defaults"` in the array — the sentinel inherits the built-in rules at that position so custom entries are added alongside them (v2.1.118). Run `claude auto-mode defaults` to see built-in rules before customizing |
+| `autoMode` | object | Customize what the [auto mode](https://code.claude.com/docs/en/permission-modes#eliminate-prompts-with-auto-mode) classifier blocks and allows. Contains `environment` (trusted infrastructure descriptions), `allow` (exceptions to block rules), `soft_deny` (block rules), and `hard_deny` (unconditional block rules — cannot be overridden by `allow` exceptions or the `$defaults` sentinel, v2.1.136) — all arrays of prose strings. Also accepts `classifyAllShell` (boolean, default `false`): when `true`, routes all Bash/PowerShell commands through the auto-mode classifier instead of only arbitrary-code-execution patterns, giving stricter coverage at the cost of more classifier calls (v2.1.193). **Not read from shared project settings** (`.claude/settings.json`) to prevent repo injection. Available in user, local, and managed settings. Setting `allow` or `soft_deny` **replaces** the entire default list for that section unless you include the literal string `"$defaults"` in the array — the sentinel inherits the built-in rules at that position so custom entries are added alongside them (v2.1.118). Run `claude auto-mode defaults` to see built-in rules before customizing |
 | `disableAutoMode` | string | Set to `"disable"` to prevent [auto mode](https://code.claude.com/docs/en/permission-modes#eliminate-prompts-with-auto-mode) from being activated. Removes `auto` from the `Shift+Tab` cycle and rejects `--permission-mode auto` at startup. Can be set at any settings level; most useful in managed settings where users cannot override it |
 | `useAutoModeDuringPlan` | boolean | Whether plan mode uses auto mode semantics when auto mode is available. Default: `true`. Not read from shared project settings (`.claude/settings.json`). Appears in `/config` as "Use auto mode during plan" |
 
@@ -472,7 +472,7 @@ Configure bash command sandboxing for security.
 | `sandbox.bwrapPath` | string | - | **(Managed only, Linux/WSL2)** Absolute path to the bubblewrap (`bwrap`) binary. Overrides automatic `PATH` detection. Only honored from managed settings, not user or project settings. Example: `/opt/admin/bwrap` (v2.1.133) |
 | `sandbox.socatPath` | string | - | **(Managed only, Linux/WSL2)** Absolute path to the `socat` binary used for the sandbox network proxy. Overrides automatic `PATH` detection. Only honored from managed settings. Example: `/opt/admin/socat` (v2.1.133) |
 | `sandbox.allowAppleEvents` | boolean | `false` | **(macOS only)** Opt-in for sandboxed commands to send Apple Events. Required for tools that use `open`, `osascript`, or browser authentication flows that depend on Apple Events IPC (v2.1.181) |
-| `sandbox.credentials` | boolean | `false` | Block sandboxed commands from reading credential files and secret environment variables. When `true`, strips Anthropic API keys, AWS/GCP/Azure credentials, and similar secret env vars from the sandboxed subprocess environment (v2.1.187) |
+| `sandbox.credentials` | object | — | Fine-grained control over which credential files and environment variables are blocked from sandboxed subprocess environments. Contains `files` (array of file paths to block from sandboxed reads) and `envVars` (array of env var names to strip from the subprocess environment). An individual invalid entry in `files` or `envVars` is stripped with a warning and the valid subset is enforced (v2.1.187; extended to object with sub-arrays in v2.1.191+) |
 
 **Example:**
 ```json
@@ -913,6 +913,7 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_MAX_CONTEXT_TOKENS` | Override the context window size Claude Code assumes for the active model. Only takes effect when `DISABLE_COMPACT` is also set. Use when routing to a model through `ANTHROPIC_BASE_URL` whose context window does not match the built-in size for its name |
 | `CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR` | Keep cwd between bash calls (`1` to enable) |
 | `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS` | Disable background tasks (`1` to disable) |
+| `CLAUDE_CODE_DISABLE_BG_SHELL_PRESSURE_REAP` | Set to `1` to disable automatic memory-pressure reaping of idle background shell commands. When unset, Claude Code automatically reaps idle background shells under memory pressure to free resources (v2.1.193 changelog, not yet on official env-vars page) |
 | `CLAUDE_CODE_DISABLE_ADVISOR_TOOL` | Set to `1` to disable the advisor tool and the `/advisor` command. Env-var equivalent of omitting advisor usage. Pair with `advisorModel` for advisor configuration (min v2.1.98) |
 | `CLAUDE_CODE_DISABLE_AGENT_VIEW` | Set to `1` to turn off background agents and agent view (`claude agents`, `--bg`, `/background`, on-demand supervisor). Env-var equivalent of the `disableAgentView` setting *(referenced on official settings page; not listed on the env-vars page)* |
 | `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` | Enable the experimental agent teams feature (`1` to enable). Allows spawning coordinated teams of subagents within a session. Also configurable as a startup-only var — see [CLI Startup Flags](./claude-cli-startup-flags.md#environment-variables) |
@@ -1180,6 +1181,7 @@ Set environment variables for all Claude Code sessions.
   },
 
   "autoMode": {
+    "classifyAllShell": false,
     "environment": [
       "Source control: github.example.com/acme-corp and all repos under it",
       "Trusted internal domains: *.internal.example.com"

--- a/changelog/best-practice/claude-settings/changelog.md
+++ b/changelog/best-practice/claude-settings/changelog.md
@@ -948,3 +948,17 @@
 | 3 | HIGH | New Setting | Add `respondToBashCommands` (boolean, default `true`, v2.1.186) to General Settings table — controls whether Claude auto-responds after `!` shell commands | ✅ COMPLETE (added to General Settings table after advisorModel) |
 | 4 | MED | Version Bump | Update report version badge from v2.1.185 → v2.1.187 and header "As of v2.1.185" → "As of v2.1.187" | ✅ COMPLETE (badge and header updated in Phase 2.6) |
 | 5 | LOW | Suspect Key | `OTEL_LOG_TOOL_DETAILS` — 42+ consecutive ON HOLD runs; annotation "in v2.1.85 changelog, not yet on official env-vars page" remains accurate | ✋ ON HOLD (kept — recurring from 2026-04-14 v2.1.107) |
+
+---
+
+## [2026-06-26 10:46 AM PKT] Claude Code v2.1.193
+
+| # | Priority | Type | Action | Status |
+|---|----------|------|--------|--------|
+| 1 | HIGH | Changed Behavior | Update `sandbox.credentials` type from `boolean \| false` to object with `files` (array) and `envVars` (array) sub-fields per official settings page (v2.1.191+ change; entry was added as boolean in v2.1.187, evolved to object) | ✅ COMPLETE (type and description updated in Sandbox Settings table) |
+| 2 | HIGH | New Setting | Add `autoMode.classifyAllShell` (boolean) to `autoMode` description — routes all Bash/PowerShell commands through auto-mode classifier instead of only arbitrary-code-execution patterns (v2.1.193 changelog) | ✅ COMPLETE (added to autoMode description and Quick Reference JSON example) |
+| 3 | HIGH | Version Bump | Update report version badge v2.1.187 → v2.1.193 and header "As of v2.1.187" → "As of v2.1.193" | ✅ COMPLETE (badge and header updated in Phase 2.6) |
+| 4 | MED | New Env Var | Add `CLAUDE_CODE_DISABLE_BG_SHELL_PRESSURE_REAP` to env vars section — disable memory-pressure reaping of idle background shell commands (v2.1.193 changelog, not yet on official env-vars page) | ✅ COMPLETE (added with changelog annotation) |
+| 5 | LOW | Suspect Key | `OTEL_LOG_TOOL_DETAILS` — 43+ consecutive ON HOLD runs (since v2.1.107, 2026-04-14); Rule 10B escalation threshold exceeded but still not on official env-vars page or JSON schema | ✋ ON HOLD (recurring from 2026-04-14 v2.1.107) |
+| 6 | LOW | Suspect Key | `OTEL_LOG_ASSISTANT_RESPONSES` — possible new OTEL env var for `claude_code.assistant_response` event added in v2.1.193, not confirmed on official env-vars page | ✋ ON HOLD (new — pending official confirmation) |
+| 7 | LOW | Potential New Setting | `skillDirectories` — listed on official settings page but description truncated; type, default, and scope unconfirmed | ✋ ON HOLD (new — pending official confirmation) |


### PR DESCRIPTION
## Summary

Daily automated settings drift check against Claude Code v2.1.193 official docs. **3 confirmed drift items applied** (1 type change, 1 new setting sub-field, 1 new env var) plus badge/header version bump.

---

## Drift Report — Claude Code v2.1.193

**Run:** 2026-06-26 10:46 AM PKT | **Previous run:** 2026-06-24 v2.1.187 | **Versions checked:** v2.1.188–v2.1.193

### Changes Applied

| # | Priority | Type | Change | Status |
|---|----------|------|--------|--------|
| 1 | HIGH | Changed Behavior | `sandbox.credentials`: updated type from `boolean \| false` → object with `files`/`envVars` sub-arrays per official settings page (evolved in v2.1.191+) | ✅ APPLIED |
| 2 | HIGH | New Setting | `autoMode.classifyAllShell` (boolean, default `false`): routes all Bash/PowerShell through classifier, not just ACE patterns (v2.1.193 changelog) | ✅ APPLIED |
| 3 | HIGH | Version Bump | Badge + header: v2.1.187 → v2.1.193 | ✅ APPLIED |
| 4 | MED | New Env Var | `CLAUDE_CODE_DISABLE_BG_SHELL_PRESSURE_REAP`: disable idle background shell memory reaping (v2.1.193 changelog, not yet on official env-vars page) | ✅ APPLIED |

### Deferred / ON HOLD

| # | Priority | Type | Item | Status |
|---|----------|------|------|--------|
| 5 | LOW | Suspect Key | `OTEL_LOG_TOOL_DETAILS` — 43+ consecutive ON HOLD runs (since v2.1.107); still not on official env-vars page | ✋ ON HOLD (recurring since 2026-04-14) |
| 6 | LOW | Suspect Key | `OTEL_LOG_ASSISTANT_RESPONSES` — possible new OTEL env var for `claude_code.assistant_response` event (v2.1.193), not confirmed on official env-vars page | ✋ ON HOLD (new) |
| 7 | LOW | Potential New Setting | `skillDirectories` — listed on settings page but description truncated; type/default/scope unconfirmed | ✋ ON HOLD (new) |

---

## Verification Log

| Rule | Category | Depth | Result | Notes |
|------|----------|-------|--------|-------|
| 1A | Key Completeness | field-level | FAIL→FIXED | `autoMode.classifyAllShell` was missing — added |
| 1B | Key Types | content-match | FAIL→FIXED | `sandbox.credentials` was boolean, now object |
| 1C | Key Defaults | content-match | FAIL→FIXED | `sandbox.credentials` default updated |
| 1D | Key Descriptions | content-match | FAIL→FIXED | `autoMode` description updated with `classifyAllShell` |
| 1E | Scope Column | content-match | PASS | No scope mismatches found |
| 1F | Inverse Completeness | field-level | PASS | OTEL vars correctly annotated as changelog-only |
| 1G | Edge-Case Semantics | content-match | PASS | No new boundary cases identified |
| 1H | File Scope Check | content-match | PASS | No settings.json vs ~/.claude.json mismatches |
| 1I | Skills Settings Keys | field-level | PASS | `maxSkillDescriptionChars` + `skillListingBudgetFraction` present |
| 2A | Priority Levels | field-level | PASS | 5-level hierarchy intact |
| 2B | File Locations | content-match | PASS | All file paths correct |
| 2C | Merge Semantics | content-match | PASS | "concatenated and deduplicated" wording correct |
| 2D | Managed Internals | field-level | PASS | Managed tier delivery methods documented |
| 3A | Permission Modes | field-level | PASS | All 6 modes documented |
| 3B | Tool Syntax Patterns | content-match | PASS | No syntax changes detected |
| 3C | Bidirectional Mode Check | field-level | PASS | No orphaned modes |
| 3D | Evaluation Semantics | content-match | PASS | Deny-first, path-prefix patterns documented |
| 4A | Hooks Redirect | exists | PASS | Redirect to `shanraisshan/claude-code-hooks` present |
| 5A | Env Var Completeness | field-level | FAIL→FIXED | `CLAUDE_CODE_DISABLE_BG_SHELL_PRESSURE_REAP` added |
| 5B | Ownership Boundary | cross-file | PASS | No duplicates between settings + CLI flags reports |
| 5C | Env Var Descriptions | content-match | PASS | Spot-checked descriptions accurate |
| 5D | Inverse Env Var Check | field-level | PASS | All unannotated vars traceable to official docs |
| 6A | Quick Reference Example | content-match | PASS (updated) | Added `classifyAllShell` to autoMode block |
| 6B | Example URL Validation | exists | NOTE | `json.schemastore.org` → 301 redirect to `www.schemastore.org`; functional |
| 7A | CLAUDE.md Sync | cross-file | PASS | Configuration hierarchy consistent |
| 8A | Source Credibility Guard | content-match | PASS | All changes sourced from official docs + changelog only |
| 9A | Local File Links | exists | PASS | `../.claude/settings.json`, `../`, `../!/claude-jumping.svg` verified |
| 9B | External URL Links | exists | PASS | All 6 source URLs return valid pages |
| 9C | Anchor Links | exists | PASS | ToC anchors verified |
| 10A | Version Metadata | content-match | FAIL→FIXED | Badge + header bumped to v2.1.193 |
| 10B | Suspect Key Escalation | exists | WARN | `OTEL_LOG_TOOL_DETAILS` at 43+ consecutive ON HOLD runs (Rule 10B threshold: 5+) |
| 10C | Bidirectional Completeness | field-level | PASS | All keys traceable or annotated |

---

## Sources Used

- [Claude Code Settings Documentation](https://code.claude.com/docs/en/settings)
- [Claude Code Environment Variables Reference](https://code.claude.com/docs/en/env-vars)
- [Claude Code Permissions Reference](https://code.claude.com/docs/en/permissions)
- [Claude Code CHANGELOG](https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md) — v2.1.188–v2.1.193

## Files Changed

- `best-practice/claude-settings.md` — 6 changes applied (badge, header, autoMode, sandbox.credentials, new env var, Quick Reference example)
- `changelog/best-practice/claude-settings/changelog.md` — new entry appended for 2026-06-26 v2.1.193

---

Generated with [Claude Code](https://claude.ai/code)
https://claude.ai/code/session_01SACRiPG3H53hLu6YEQW3um

---
_Generated by [Claude Code](https://claude.ai/code/session_01SACRiPG3H53hLu6YEQW3um)_