### PR TITLE
Daily settings drift check — 2026-06-27 (Claude Code v2.1.195)

### DIFF
--- a/best-practice/claude-settings.md
+++ b/best-practice/claude-settings.md
@@ -1,9 +1,9 @@
 # Settings Best Practice
 
-![Last Updated](https://img.shields.io/badge/Last_Updated-Jun%2026%2C%202026%2010%3A46%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.193-blue?style=flat&labelColor=555)<br>
+![Last Updated](https://img.shields.io/badge/Last_Updated-Jun%2027%2C%202026%2010%3A39%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.195-blue?style=flat&labelColor=555)<br>
 [![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../.claude/settings.json)
 
-A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.193, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
+A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.195, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
 
 <table width="100%">
 <tr>
@@ -1047,6 +1047,7 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_SCROLL_SPEED` | Mouse wheel scroll multiplier for fullscreen rendering. Increase for faster scrolling, decrease for finer control |
 | `CLAUDE_CODE_DISABLE_VIRTUAL_SCROLL` | Set to `1` to disable virtual scrolling in fullscreen rendering and render every message in the transcript. Use if scrolling in fullscreen mode shows blank regions where messages should appear |
 | `CLAUDE_CODE_DISABLE_MOUSE` | Set to `1` to disable mouse tracking in fullscreen rendering. Useful when mouse events interfere with terminal multiplexers or accessibility tools |
+| `CLAUDE_CODE_DISABLE_MOUSE_CLICKS` | Set to `1` to disable mouse click, drag, and hover events in fullscreen rendering while preserving mouse wheel scrolling. Useful when you want terminal-native mouse selection while retaining scroll support (v2.1.195) |
 | `CLAUDE_CODE_HIDE_CWD` | Set to `1` to hide the current working directory in the Claude Code startup logo banner. Useful in screen recordings, demos, or shared sessions where the CWD path leaks information about the host or project layout (v2.1.119) |
 | `CLAUDE_CODE_ACCESSIBILITY` | Set to `1` to keep native terminal cursor visible for screen readers and accessibility tools |
 | `CLAUDE_AX_SCREEN_READER` | Set to `1` to render screen-reader friendly output: flat text without decorative borders or animations. Set to `0` to force screen-reader mode off even when the `axScreenReader` setting is `true`. The `--ax-screen-reader` CLI flag takes precedence (v2.1.181+) |
@@ -1065,6 +1066,7 @@ Set environment variables for all Claude Code sessions.
 | `OTEL_LOG_RAW_API_BODIES` | Set to `1` to emit full API request and response bodies as OpenTelemetry log events. Omitted by default for privacy and payload size. Useful for debugging at a gateway or proxy *(in v2.1.111 changelog, not yet on official env-vars page)* |
 | `OTEL_RESOURCE_ATTRIBUTES` | Comma-separated `key=value` pairs added as resource attributes on all OpenTelemetry metric data points emitted by Claude Code. Use to attach environment or deployment labels (e.g., `environment=production,team=platform`) that appear on every metric for filtering in your collector (v2.1.162) |
 | `OTEL_LOG_USER_PROMPTS` | Set to `1` to include the `user_system_prompt` field in OpenTelemetry LLM request spans. Omitted by default for privacy — user prompts can contain sensitive data, so opt in only when you control the OTel collector and have policies in place *(in v2.1.121 changelog, not yet on official env-vars page)* |
+| `OTEL_LOG_ASSISTANT_RESPONSES` | Set to `1` to include model response content in OpenTelemetry log events. Defaults to the value of `OTEL_LOG_USER_PROMPTS`; when user prompts are logged, assistant responses are logged alongside them. Omitted by default for privacy (v2.1.193) |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | OpenTelemetry collector endpoint URL for metrics and logs. See [Monitoring](https://code.claude.com/docs/en/monitoring-usage) |
 | `OTEL_EXPORTER_OTLP_HEADERS` | OpenTelemetry exporter headers (`Name=Value` format, comma-separated) for authenticating with your collector |
 | `OTEL_LOG_TOOL_CONTENT` | Set to `1` to emit full tool inputs and outputs as OpenTelemetry log events. Omitted by default for privacy |

--- a/changelog/best-practice/claude-settings/changelog.md
+++ b/changelog/best-practice/claude-settings/changelog.md
@@ -962,3 +962,16 @@
 | 5 | LOW | Suspect Key | `OTEL_LOG_TOOL_DETAILS` — 43+ consecutive ON HOLD runs (since v2.1.107, 2026-04-14); Rule 10B escalation threshold exceeded but still not on official env-vars page or JSON schema | ✋ ON HOLD (recurring from 2026-04-14 v2.1.107) |
 | 6 | LOW | Suspect Key | `OTEL_LOG_ASSISTANT_RESPONSES` — possible new OTEL env var for `claude_code.assistant_response` event added in v2.1.193, not confirmed on official env-vars page | ✋ ON HOLD (new — pending official confirmation) |
 | 7 | LOW | Potential New Setting | `skillDirectories` — listed on official settings page but description truncated; type, default, and scope unconfirmed | ✋ ON HOLD (new — pending official confirmation) |
+
+---
+
+## [2026-06-27 10:44 AM PKT] Claude Code v2.1.195
+
+| # | Priority | Type | Action | Status |
+|---|----------|------|--------|--------|
+| 1 | HIGH | Version Bump | Update report version badge from v2.1.193 → v2.1.195 and header "As of v2.1.193" → "As of v2.1.195" | ✅ COMPLETE (badge and header updated in Phase 2.6) — NEW |
+| 2 | HIGH | Missing Env Var | Add `OTEL_LOG_ASSISTANT_RESPONSES` to Common Environment Variables table — controls logging of model responses in OTel; defaults to follow `OTEL_LOG_USER_PROMPTS`. Promoted from ON HOLD (v2.1.193 #6) after changelog confirmation | ✅ COMPLETE (added to env vars table after OTEL_LOG_USER_PROMPTS) — RECURRING (first seen: 2026-06-26) |
+| 3 | HIGH | Missing Env Var | Add `CLAUDE_CODE_DISABLE_MOUSE_CLICKS` to Common Environment Variables table — disables mouse click, drag, and hover events in fullscreen while preserving wheel scroll (v2.1.195) | ✅ COMPLETE (added to env vars table after CLAUDE_CODE_DISABLE_MOUSE) — NEW |
+| 4 | LOW | Suspect Key | `CLAUDE_CODE_SAFE_MODE` — startup-only var, belongs in `claude-cli-startup-flags.md` per prior runs | ✋ ON HOLD (out of scope — recurring from 2026-06-09 v2.1.169) |
+| 5 | LOW | Suspect Key | `skillDirectories` — still not confirmed with sufficient detail on official settings page | ✋ ON HOLD (pending official confirmation — recurring from 2026-06-26 v2.1.193 #7) |
+| 6 | LOW | Suspect Key | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 44+ consecutive runs | ✋ ON HOLD (recurring from 2026-04-14 v2.1.107) |


### PR DESCRIPTION
## Summary

Automated daily drift check against official Claude Code settings documentation. Three changes applied to `best-practice/claude-settings.md`:

- **Version bump**: prose header and badge updated from v2.1.193 → v2.1.195
- **New env var** `CLAUDE_CODE_DISABLE_MOUSE_CLICKS` (v2.1.195): disables mouse click/drag/hover in fullscreen rendering while preserving wheel scrolling — useful for terminal-native mouse selection
- **New env var** `OTEL_LOG_ASSISTANT_RESPONSES` (v2.1.193): includes model response content in OTel log events; defaults to `OTEL_LOG_USER_PROMPTS` value; promoted from ON HOLD after changelog confirmation

## Verification Log (selected rules)

| Rule | Category | Depth | Result |
|------|----------|-------|--------|
| 1A | Key Completeness | field-level | PASS |
| 1H | File Scope Check | content-match | PASS |
| 1I | Skills Settings Keys | field-level | PASS |
| 5A | Env Var Completeness | field-level | PASS (after additions) |
| 5B | Ownership Boundary | cross-file | PASS |
| 5D | Inverse Env Var Check | field-level | PASS |
| 8A | Source Credibility Guard | content-match | PASS — 2 low-confidence agent claims rejected |
| 9A | Local File Links | exists | PASS |
| 9B | External URL Links | exists | PASS |
| 10A | Version Metadata | content-match | PASS (after badge update) |
| 10B | Suspect Key Escalation | exists | ON HOLD — OTEL_LOG_TOOL_DETAILS at 44+ runs |

## ON HOLD items (carried forward)

| Key | Reason |
|-----|--------|
| `OTEL_LOG_TOOL_DETAILS` | 44+ consecutive runs; not on official env-vars page |
| `skillDirectories` | Listed on settings page but description truncated; type/default/scope unconfirmed |
| `CLAUDE_CODE_SAFE_MODE` | Startup-only var — belongs in `claude-cli-startup-flags.md` |

## Test plan

- [ ] Verify `CLAUDE_CODE_DISABLE_MOUSE_CLICKS` row appears after `CLAUDE_CODE_DISABLE_MOUSE` in env vars table
- [ ] Verify `OTEL_LOG_ASSISTANT_RESPONSES` row appears after `OTEL_LOG_USER_PROMPTS` in env vars table
- [ ] Verify prose header reads "As of v2.1.195"
- [ ] Verify badge shows v2.1.195 and Jun 27, 2026 timestamp
- [ ] Verify changelog entry appended (not overwritten) at end of changelog.md

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01JxHkDrr3jMeSRaVrvGGcRk

---
_Generated by [Claude Code](https://claude.ai/code/session_01JxHkDrr3jMeSRaVrvGGcRk)_