### PR TITLE
Daily settings drift check — 2026-06-28 (Claude Code v2.1.195)

### DIFF
--- a/best-practice/claude-settings.md
+++ b/best-practice/claude-settings.md
@@ -1,9 +1,9 @@
 # Settings Best Practice
 
-![Last Updated](https://img.shields.io/badge/Last_Updated-Jun%2026%2C%202026%2010%3A46%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.193-blue?style=flat&labelColor=555)<br>
+![Last Updated](https://img.shields.io/badge/Last_Updated-Jun%2028%2C%202026%2010%3A42%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.195-blue?style=flat&labelColor=555)<br>
 [![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../.claude/settings.json)
 
-A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.193, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
+A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.195, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
 
 <table width="100%">
 <tr>
@@ -906,7 +906,7 @@ Set environment variables for all Claude Code sessions.
 | `MAX_MCP_OUTPUT_TOKENS` | Max MCP output tokens (default: 25000). Warning displayed when output exceeds 10,000 tokens |
 | `API_TIMEOUT_MS` | Timeout in ms for API requests (default: 600000) |
 | `API_FORCE_IDLE_TIMEOUT` | Override the 5-minute idle timeout for streaming connections. Set to `0` to disable the idle timeout entirely, `1` to enforce it on all connections, or leave unset for the default (auto-enabled on slow or unreliable gateways that frequently stall). Useful for slow API gateways (v2.1.169) |
-| `CLAUDE_CODE_CONNECT_TIMEOUT_MS` | Timeout in milliseconds for the connect, TLS, and response-header phase of a streaming API request (default: `60000` / 60 seconds). If no response headers arrive within this window, the request is aborted and retried. Set to `0` to disable and rely on `API_TIMEOUT_MS` alone |
+| `CLAUDE_CODE_CONNECT_TIMEOUT_MS` | **REMOVED in v2.1.186** — this env var is a no-op. Use `API_TIMEOUT_MS` instead to configure the overall request timeout |
 | `BASH_MAX_TIMEOUT_MS` | Bash command timeout |
 | `BASH_MAX_OUTPUT_LENGTH` | Max bash output length |
 | `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` | Auto-compact threshold percentage (1-100). Default is ~95%. Set lower (e.g., `50`) to trigger compaction earlier. Values above 95% have no effect. Use `/context` to monitor current usage. Example: `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=50 claude` |
@@ -1047,6 +1047,7 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_SCROLL_SPEED` | Mouse wheel scroll multiplier for fullscreen rendering. Increase for faster scrolling, decrease for finer control |
 | `CLAUDE_CODE_DISABLE_VIRTUAL_SCROLL` | Set to `1` to disable virtual scrolling in fullscreen rendering and render every message in the transcript. Use if scrolling in fullscreen mode shows blank regions where messages should appear |
 | `CLAUDE_CODE_DISABLE_MOUSE` | Set to `1` to disable mouse tracking in fullscreen rendering. Useful when mouse events interfere with terminal multiplexers or accessibility tools |
+| `CLAUDE_CODE_DISABLE_MOUSE_CLICKS` | Set to `1` to disable mouse click interactions in fullscreen rendering while preserving mouse-wheel scroll. Useful when click events interfere with terminal selection or accessibility tools but scroll functionality is still desired (v2.1.195) |
 | `CLAUDE_CODE_HIDE_CWD` | Set to `1` to hide the current working directory in the Claude Code startup logo banner. Useful in screen recordings, demos, or shared sessions where the CWD path leaks information about the host or project layout (v2.1.119) |
 | `CLAUDE_CODE_ACCESSIBILITY` | Set to `1` to keep native terminal cursor visible for screen readers and accessibility tools |
 | `CLAUDE_AX_SCREEN_READER` | Set to `1` to render screen-reader friendly output: flat text without decorative borders or animations. Set to `0` to force screen-reader mode off even when the `axScreenReader` setting is `true`. The `--ax-screen-reader` CLI flag takes precedence (v2.1.181+) |

--- a/changelog/best-practice/claude-settings/changelog.md
+++ b/changelog/best-practice/claude-settings/changelog.md
@@ -962,3 +962,19 @@
 | 5 | LOW | Suspect Key | `OTEL_LOG_TOOL_DETAILS` — 43+ consecutive ON HOLD runs (since v2.1.107, 2026-04-14); Rule 10B escalation threshold exceeded but still not on official env-vars page or JSON schema | ✋ ON HOLD (recurring from 2026-04-14 v2.1.107) |
 | 6 | LOW | Suspect Key | `OTEL_LOG_ASSISTANT_RESPONSES` — possible new OTEL env var for `claude_code.assistant_response` event added in v2.1.193, not confirmed on official env-vars page | ✋ ON HOLD (new — pending official confirmation) |
 | 7 | LOW | Potential New Setting | `skillDirectories` — listed on official settings page but description truncated; type, default, and scope unconfirmed | ✋ ON HOLD (new — pending official confirmation) |
+
+---
+
+## [2026-06-28 10:39 AM PKT] Claude Code v2.1.195
+
+| # | Priority | Type | Action | Status |
+|---|----------|------|--------|--------|
+| 1 | HIGH | Version Bump | Update report version badge v2.1.193 → v2.1.195 and header "As of v2.1.193" → "As of v2.1.195" | ✅ COMPLETE (badge and header updated in Phase 2.6) |
+| 2 | HIGH | Missing Env Var | Add `CLAUDE_CODE_DISABLE_MOUSE_CLICKS` to Common Environment Variables table — disables mouse click interactions in fullscreen while preserving wheel scroll (v2.1.195). Confirmed in changelog | ✅ COMPLETE (added after CLAUDE_CODE_DISABLE_MOUSE in env vars table) |
+| 3 | MED | Removed Env Var | Mark `CLAUDE_CODE_CONNECT_TIMEOUT_MS` as REMOVED in v2.1.186 — official /en/env-vars page lists it under deprecated section; use `API_TIMEOUT_MS` instead. Added in v2.1.185 run, removed one version later, missed by 4 subsequent runs | ✅ COMPLETE (marked REMOVED with redirect to API_TIMEOUT_MS) |
+| 4 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — 44+ consecutive ON HOLD runs since v2.1.107 (2026-04-14); annotation "in v2.1.85 changelog, not yet on official env-vars page" remains accurate | ✋ ON HOLD (recurring from 2026-04-14 v2.1.107) |
+| 5 | LOW | Suspect Key Recurrence | `OTEL_LOG_ASSISTANT_RESPONSES` — still changelog-only (v2.1.193), not on official /en/env-vars page. Defer per Rule 8A | ✋ ON HOLD (recurring from 2026-06-26 v2.1.193) |
+| 6 | LOW | Potential New Setting | `skillDirectories` — listed on official settings page but type, default, and scope unconfirmed. Defer per Rule 8A | ✋ ON HOLD (recurring from 2026-06-26 v2.1.193) |
+| 7 | INVALID | Spurious Drift Claim | `sandbox.credentials` polarity — report says "block/strip" semantics; report wording aligns with v2.1.187 changelog and claude-code-guide example (`mode: "deny"`). Per Rule 8A | ❌ INVALID (report wording confirmed by changelog and agent example) |
+| 8 | INVALID | Spurious Drift Claim | `sandbox.network.disableOutbound` — flagged at 0.7 confidence by workflow agent; not on official settings page. Per Rule 8A | ❌ INVALID (insufficient source-verified evidence) |
+| 9 | INVALID | Spurious Drift Claim | `claude-code-guide` listed effort values as `fast`/`balanced`/`thorough` — official docs confirm: `low`, `medium`, `high`, `xhigh`, `max`, `auto`. RECURRING from multiple prior runs | ❌ INVALID (agent contradicted by official docs — recurring error) |


### PR DESCRIPTION
## Summary

Automated daily drift check for `best-practice/claude-settings.md` against Claude Code v2.1.195 official docs.

**3 fixes applied · 3 ON HOLD · 3 INVALID**

---

## Changes Applied

| # | Priority | Type | Action | Status |
|---|----------|------|--------|--------|
| 1 | HIGH | Version Bump | Badge + header: `v2.1.193` → `v2.1.195`, date → `Jun 28, 2026 10:42 AM PKT` | ✅ COMPLETE |
| 2 | HIGH | Missing Env Var | Added `CLAUDE_CODE_DISABLE_MOUSE_CLICKS` — disables mouse click interactions in fullscreen while preserving wheel scroll (v2.1.195) | ✅ COMPLETE |
| 3 | MED | Removed Env Var | Marked `CLAUDE_CODE_CONNECT_TIMEOUT_MS` as **REMOVED in v2.1.186** (→ use `API_TIMEOUT_MS`). Added in v2.1.185 run, removed one version later; slipped through 4 subsequent runs | ✅ COMPLETE |

## Deferred Items (ON HOLD)

| # | Item | Reason |
|---|------|--------|
| 4 | `OTEL_LOG_TOOL_DETAILS` | 44+ consecutive ON HOLD runs since v2.1.107 (2026-04-14); still not on official env-vars page |
| 5 | `OTEL_LOG_ASSISTANT_RESPONSES` | Changelog-only since v2.1.193; not confirmed on official /en/env-vars page |
| 6 | `skillDirectories` | On official settings page but type/default/scope unconfirmed |

## Rejected Findings (INVALID per Rule 8A)

| # | Claim | Reason Rejected |
|---|-------|----------------|
| 7 | `sandbox.credentials` polarity wrong | Report's "block/strip" wording confirmed by v2.1.187 changelog + `mode: "deny"` examples |
| 8 | `sandbox.network.disableOutbound` missing | Only flagged at 0.7 confidence; not on official settings page |
| 9 | Wrong effort value names | Agent said `fast`/`balanced`/`thorough`; official docs confirm `low`/`medium`/`high`/`xhigh`/`max`/`auto` |

---

## Verification Log

| Rule | Category | Depth | Result |
|------|----------|-------|--------|
| 1A | Key Completeness | field-level | PASS |
| 1B | Key Types | content-match | PASS |
| 1C | Key Defaults | content-match | PASS |
| 1D | Key Descriptions | content-match | PASS — except CONNECT_TIMEOUT_MS (fixed) |
| 1E | Scope Column | content-match | PASS |
| 1F | Inverse Completeness | field-level | PASS |
| 1G | Edge-Case Semantics | content-match | PASS |
| 1H | File Scope Check | content-match | PASS |
| 1I | Skills Settings Keys | field-level | PASS |
| 2A | Priority Levels | field-level | PASS |
| 2B | File Locations | content-match | PASS |
| 2C | Merge Semantics | content-match | PASS |
| 2D | Managed Internals | field-level | PASS |
| 3A | Permission Modes | field-level | PASS |
| 3B | Tool Syntax Patterns | content-match | PASS |
| 3C | Bidirectional Mode Check | field-level | PASS |
| 3D | Evaluation Semantics | content-match | PASS |
| 4A | Hooks Redirect | exists | PASS |
| 5A | Env Var Completeness | field-level | FAIL → FIXED (MOUSE_CLICKS added) |
| 5B | Ownership Boundary | cross-file | PASS |
| 5C | Env Var Descriptions | content-match | FAIL → FIXED (CONNECT_TIMEOUT_MS marked REMOVED) |
| 5D | Inverse Env Var Check | field-level | PASS |
| 6A | Quick Reference Example | content-match | PASS |
| 6B | Example URL Validation | exists | PASS |
| 7A | CLAUDE.md Sync | cross-file | PASS |
| 8A | Source Credibility Guard | content-match | PASS (3 spurious claims rejected) |
| 9A | Local File Links | exists | PASS |
| 9B | External URL Links | exists | PASS |
| 9C | Anchor Links | exists | PASS |
| 10A | Version Metadata | content-match | FAIL → FIXED (badge/header updated) |
| 10B | Suspect Key Escalation | exists | ON HOLD (OTEL_LOG_TOOL_DETAILS at 44+ runs) |
| 10C | Bidirectional Completeness | field-level | PASS |

---

## Sources Verified

- [Claude Code Settings](https://code.claude.com/docs/en/settings) — OK
- [Claude Code CLI Reference](https://code.claude.com/docs/en/cli-reference) — OK
- [Claude Code Env Vars](https://code.claude.com/docs/en/env-vars) — OK
- [CHANGELOG.md](https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md) — OK (v2.1.195 confirmed)

---

*Generated by automated daily drift checker · 2026-06-28 · [claude-code-best-practice](https://github.com/shanraisshan/claude-code-best-practice)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6EQnW8veRxHHF9Gud3Fe8)_