### PR TITLE
Daily settings drift check — 2026-06-29 (Claude Code v2.1.195)

### DIFF
--- a/best-practice/claude-settings.md
+++ b/best-practice/claude-settings.md
@@ -1,9 +1,9 @@
 # Settings Best Practice
 
-![Last Updated](https://img.shields.io/badge/Last_Updated-Jun%2026%2C%202026%2010%3A46%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.193-blue?style=flat&labelColor=555)<br>
+![Last Updated](https://img.shields.io/badge/Last_Updated-Jun%2029%2C%202026%2010%3A37%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.195-blue?style=flat&labelColor=555)<br>
 [![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../.claude/settings.json)
 
-A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.193, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
+A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.195, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
 
 <table width="100%">
 <tr>
@@ -638,7 +638,7 @@ Configure via `env` key:
 |-----|------|---------|-------------|
 | `statusLine` | object | - | Custom status line configuration |
 | `outputStyle` | string | `"default"` | Output style (e.g., `"Explanatory"`) |
-| `spinnerTipsEnabled` | boolean | `true` | Show tips while waiting |
+| `spinnerTipsEnabled` | boolean | `true` | Show tips while waiting *(in JSON schema, not on official settings page)* |
 | `spinnerVerbs` | object | - | Custom spinner verbs with `mode` ("append" or "replace") and `verbs` array |
 | `spinnerTipsOverride` | object | - | Custom spinner tips with `tips` (string array) and optional `excludeDefault` (boolean). When `excludeDefault` is `true`, only custom tips show; when `false` or absent, custom tips merge with built-in tips. As of v2.1.121, `excludeDefault: true` also suppresses time-based spinner tips |
 | `respectGitignore` | boolean | `true` | Respect .gitignore in file picker |
@@ -1047,6 +1047,7 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_SCROLL_SPEED` | Mouse wheel scroll multiplier for fullscreen rendering. Increase for faster scrolling, decrease for finer control |
 | `CLAUDE_CODE_DISABLE_VIRTUAL_SCROLL` | Set to `1` to disable virtual scrolling in fullscreen rendering and render every message in the transcript. Use if scrolling in fullscreen mode shows blank regions where messages should appear |
 | `CLAUDE_CODE_DISABLE_MOUSE` | Set to `1` to disable mouse tracking in fullscreen rendering. Useful when mouse events interfere with terminal multiplexers or accessibility tools |
+| `CLAUDE_CODE_DISABLE_MOUSE_CLICKS` | Set to `1` to disable mouse click interactions in fullscreen rendering while preserving wheel scroll. Distinguishes click-event suppression from full mouse tracking disable (`CLAUDE_CODE_DISABLE_MOUSE`). Useful when terminal selection or external accessibility tools conflict with in-app mouse clicks *(in v2.1.195 changelog, not yet on official env-vars page)* |
 | `CLAUDE_CODE_HIDE_CWD` | Set to `1` to hide the current working directory in the Claude Code startup logo banner. Useful in screen recordings, demos, or shared sessions where the CWD path leaks information about the host or project layout (v2.1.119) |
 | `CLAUDE_CODE_ACCESSIBILITY` | Set to `1` to keep native terminal cursor visible for screen readers and accessibility tools |
 | `CLAUDE_AX_SCREEN_READER` | Set to `1` to render screen-reader friendly output: flat text without decorative borders or animations. Set to `0` to force screen-reader mode off even when the `axScreenReader` setting is `true`. The `--ax-screen-reader` CLI flag takes precedence (v2.1.181+) |
@@ -1065,6 +1066,7 @@ Set environment variables for all Claude Code sessions.
 | `OTEL_LOG_RAW_API_BODIES` | Set to `1` to emit full API request and response bodies as OpenTelemetry log events. Omitted by default for privacy and payload size. Useful for debugging at a gateway or proxy *(in v2.1.111 changelog, not yet on official env-vars page)* |
 | `OTEL_RESOURCE_ATTRIBUTES` | Comma-separated `key=value` pairs added as resource attributes on all OpenTelemetry metric data points emitted by Claude Code. Use to attach environment or deployment labels (e.g., `environment=production,team=platform`) that appear on every metric for filtering in your collector (v2.1.162) |
 | `OTEL_LOG_USER_PROMPTS` | Set to `1` to include the `user_system_prompt` field in OpenTelemetry LLM request spans. Omitted by default for privacy — user prompts can contain sensitive data, so opt in only when you control the OTel collector and have policies in place *(in v2.1.121 changelog, not yet on official env-vars page)* |
+| `OTEL_LOG_ASSISTANT_RESPONSES` | Set to `1` to include model response text in OpenTelemetry log events. Omitted by default for privacy and payload size. Use only when you control the OTel collector and have policies for handling model output *(in v2.1.193 changelog, not yet on official env-vars page)* |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | OpenTelemetry collector endpoint URL for metrics and logs. See [Monitoring](https://code.claude.com/docs/en/monitoring-usage) |
 | `OTEL_EXPORTER_OTLP_HEADERS` | OpenTelemetry exporter headers (`Name=Value` format, comma-separated) for authenticating with your collector |
 | `OTEL_LOG_TOOL_CONTENT` | Set to `1` to emit full tool inputs and outputs as OpenTelemetry log events. Omitted by default for privacy |

--- a/changelog/best-practice/claude-settings/changelog.md
+++ b/changelog/best-practice/claude-settings/changelog.md
@@ -962,3 +962,16 @@
 | 5 | LOW | Suspect Key | `OTEL_LOG_TOOL_DETAILS` — 43+ consecutive ON HOLD runs (since v2.1.107, 2026-04-14); Rule 10B escalation threshold exceeded but still not on official env-vars page or JSON schema | ✋ ON HOLD (recurring from 2026-04-14 v2.1.107) |
 | 6 | LOW | Suspect Key | `OTEL_LOG_ASSISTANT_RESPONSES` — possible new OTEL env var for `claude_code.assistant_response` event added in v2.1.193, not confirmed on official env-vars page | ✋ ON HOLD (new — pending official confirmation) |
 | 7 | LOW | Potential New Setting | `skillDirectories` — listed on official settings page but description truncated; type, default, and scope unconfirmed | ✋ ON HOLD (new — pending official confirmation) |
+
+---
+
+## [2026-06-29 10:37 AM PKT] Claude Code v2.1.195
+
+| # | Priority | Type | Action | Status |
+|---|----------|------|--------|--------|
+| 1 | HIGH | Missing Env Var | Add `CLAUDE_CODE_DISABLE_MOUSE_CLICKS` to Common Environment Variables table — disables mouse interactions in fullscreen while preserving wheel scroll (v2.1.195 changelog; not on official env-vars page — annotated per Rule 5D/8A) | ✅ COMPLETE (added after `CLAUDE_CODE_DISABLE_MOUSE` with changelog annotation) — NEW |
+| 2 | HIGH | Version Bump | Update report version badge from v2.1.193 → v2.1.195 and header "As of v2.1.193" → "As of v2.1.195" | ✅ COMPLETE (badge and header updated in Phase 2.6) — NEW |
+| 3 | MED | Missing Env Var | Add `OTEL_LOG_ASSISTANT_RESPONSES` to OTEL env vars section — controls logging of model responses to telemetry (v2.1.193 changelog; not on official env-vars page — annotated per Rule 5D/8A) | ✅ COMPLETE (added after `OTEL_LOG_USER_PROMPTS` with changelog annotation) — RECURRING (first seen 2026-06-26 v2.1.193 #6) |
+| 4 | LOW | Annotation | Annotate `spinnerTipsEnabled` as "in JSON schema, not on official settings page" per Rule 1F — key has been in report without official backing annotation | ✅ COMPLETE (annotation added to description) — NEW |
+| 5 | LOW | Resolve ON HOLD | `skillDirectories` (ON HOLD from 2026-06-26 v2.1.193 #7) — NOT found on official settings page per direct verification this run; prior run finding was based on truncated fetch | ❌ INVALID (not on official settings page per direct check) — RECURRING (first seen 2026-06-26) |
+| 6 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official env-vars page after 44+ consecutive runs | ✋ ON HOLD (kept — recurring from 2026-04-14 v2.1.107) |


### PR DESCRIPTION
## Summary

Automated daily drift check for `best-practice/claude-settings.md` against Claude Code v2.1.195 official docs. Two agents ran in parallel (workflow-claude-settings-agent + claude-code-guide), findings cross-validated against official settings page, env-vars page, and GitHub CHANGELOG.

---

## Drift Report — Claude Code v2.1.195

**Report audited:** `best-practice/claude-settings.md`
**Previous version:** v2.1.193 | **Current version:** v2.1.195
**Run date:** 2026-06-29 10:37 AM PKT

### 1. New Settings Keys
No new `settings.json` keys found in v2.1.194–v2.1.195 changelog vs report.

### 2. Changed Setting Behavior
No type/default/description changes confirmed.

### 3. Deprecated/Removed Settings
None confirmed.

### 4. Permission Syntax Changes
None confirmed.

### 5–9. MCP / Sandbox / Plugin / Model / Display Changes
None confirmed for this version window.

### 10. Environment Variable Completeness

| Var | Finding | Source |
|-----|---------|--------|
| `CLAUDE_CODE_DISABLE_MOUSE_CLICKS` | **Missing** — new in v2.1.195, distinguishes click suppression from full mouse tracking disable | v2.1.195 CHANGELOG |
| `OTEL_LOG_ASSISTANT_RESPONSES` | **Missing** — new in v2.1.193, logs model response text to OTel events (opt-in, privacy-sensitive) | v2.1.193 CHANGELOG |

### 11. Settings Hierarchy Accuracy
No changes detected. 5-level chain + managed policy layer matches official docs.

### 12. Example Accuracy
Quick Reference example remains valid for v2.1.195.

### 13. Sources Accuracy
All 6 source links in the report verified working (HTTP 200).

### 14. claude-code-guide Agent Unique Findings
- Independently confirmed both missing env vars from the CHANGELOG.
- No contradictions between agents.

---

## Verification Log

| Rule | Category | Depth | Result | Notes |
|------|----------|-------|--------|-------|
| 1A | Key Completeness | field-level | PASS | All keys present |
| 1B | Key Types | content-match | PASS | Types match official docs |
| 1C | Key Defaults | content-match | PASS | Defaults match |
| 1D | Key Descriptions | content-match | PASS | Descriptions accurate |
| 1E | Scope Column | content-match | PASS | Scope values correct |
| 1F | Inverse Completeness | field-level | PASS | `spinnerTipsEnabled` annotated *(in JSON schema, not on official settings page)* |
| 1G | Edge-Case Semantics | content-match | PASS | No new edge-case behavior found |
| 1H | File Scope Check | content-match | PASS | No scope mismatches |
| 1I | Skills Settings Keys | field-level | PASS | `maxSkillDescriptionChars`, `skillListingBudgetFraction`, `skillOverrides` all present |
| 2A | Priority Levels | field-level | PASS | 5-level hierarchy correct |
| 2B | File Locations | content-match | PASS | Paths match official docs |
| 2C | Merge Semantics | content-match | PASS | "concatenated and deduplicated" wording correct |
| 2D | Managed Internals | field-level | PASS | Platform-specific paths and deprecation notes present |
| 3A | Permission Modes | field-level | PASS | All modes present |
| 3B | Tool Syntax Patterns | content-match | PASS | Syntax patterns accurate |
| 3C | Bidirectional Mode Check | field-level | PASS | No orphaned modes |
| 3D | Evaluation Semantics | content-match | PASS | Deny-first + path prefix patterns documented |
| 4A | Hooks Redirect | exists | PASS | Redirect link present and valid |
| 5A | Env Var Completeness | field-level | FAIL → FIXED | `CLAUDE_CODE_DISABLE_MOUSE_CLICKS` and `OTEL_LOG_ASSISTANT_RESPONSES` added |
| 5B | Ownership Boundary | cross-file | PASS | No duplication with `claude-cli-startup-flags.md` |
| 5C | Env Var Descriptions | content-match | PASS | Descriptions match official page for confirmed vars |
| 5D | Inverse Env Var Check | field-level | PASS | All unannotated vars traceable to official docs |
| 6A | Quick Reference Example | content-match | PASS | Example valid |
| 6B | Example URL Validation | exists | PASS | `$schema` URL resolves correctly |
| 7A | CLAUDE.md Sync | cross-file | PASS | Configuration hierarchy consistent |
| 8A | Source Credibility Guard | content-match | PASS | Only CHANGELOG-sourced items annotated as "not yet on official env-vars page" |
| 9A | Local File Links | exists | PASS | All relative links resolve |
| 9B | External URL Links | exists | PASS | All 6 external URLs return valid pages |
| 9C | Anchor Links | exists | PASS | All internal anchors resolve |
| 10A | Version Metadata | content-match | PASS → FIXED | Badge and header updated v2.1.193 → v2.1.195 |
| 10B | Suspect Key Escalation | exists | PASS | `skillDirectories` resolved as INVALID; `OTEL_LOG_TOOL_DETAILS` continues ON HOLD (escalated per 10B after 6+ runs — kept pending schema confirmation) |
| 10C | Bidirectional Completeness | field-level | PASS | All keys traceable or annotated |

---

## Priority Actions

| # | Priority | Type | Action | Status |
|---|----------|------|--------|--------|
| 1 | HIGH | Missing Env Var | Add `CLAUDE_CODE_DISABLE_MOUSE_CLICKS` to env vars table | ✅ COMPLETE — NEW |
| 2 | HIGH | Version Bump | Update badge and header v2.1.193 → v2.1.195 | ✅ COMPLETE — NEW |
| 3 | MED | Missing Env Var | Add `OTEL_LOG_ASSISTANT_RESPONSES` to env vars table | ✅ COMPLETE — RECURRING (first seen 2026-06-26 v2.1.193) |
| 4 | LOW | Annotation | Annotate `spinnerTipsEnabled` as *(in JSON schema, not on official settings page)* | ✅ COMPLETE — NEW |
| 5 | LOW | Resolve ON HOLD | `skillDirectories` — not on official settings page, INVALID finding | ❌ INVALID — RECURRING (first seen 2026-06-26) |

## Resolved Since Last Run

| Item | Resolution |
|------|-----------|
| `skillDirectories` ON HOLD | Confirmed NOT on official settings page — removed from unresolved list |
| `OTEL_LOG_ASSISTANT_RESPONSES` ON HOLD | Escalated and added to report with changelog annotation |

---

## Files Changed

| File | Change |
|------|--------|
| `best-practice/claude-settings.md` | Badge v2.1.193→v2.1.195, header version bump, +2 env vars, `spinnerTipsEnabled` annotation |
| `changelog/best-practice/claude-settings/changelog.md` | Appended [2026-06-29] v2.1.195 entry |

---

## Hyperlink Validation Log

| # | Type | Link | Status |
|---|------|------|--------|
| 1 | Local | `../` (Back to root) | OK |
| 2 | External | `https://code.claude.com/docs/en/settings` | OK |
| 3 | External | `https://code.claude.com/docs/en/permissions` | OK |
| 4 | External | `https://code.claude.com/docs/en/monitoring-usage` | OK |
| 5 | External | `https://json.schemastore.org/claude-code-settings.json` | OK |
| 6 | Local | `../.claude/settings.json` (Implemented badge) | OK |

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7cd9AzgW23JtrTJnmRXpV)_