### PR TITLE
Daily settings drift check — 2026-07-02 (Claude Code v2.1.198)

### DIFF
--- a/best-practice/claude-settings.md
+++ b/best-practice/claude-settings.md
@@ -1,9 +1,9 @@
 # Settings Best Practice
 
-![Last Updated](https://img.shields.io/badge/Last_Updated-Jul%2001%2C%202026%2010%3A40%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.197-blue?style=flat&labelColor=555)<br>
+![Last Updated](https://img.shields.io/badge/Last_Updated-Jul%2002%2C%202026%2010%3A44%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.198-blue?style=flat&labelColor=555)<br>
 [![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../.claude/settings.json)
 
-A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.197, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
+A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.198, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
 
 <table width="100%">
 <tr>
@@ -557,10 +557,10 @@ Configure Claude Code plugins and marketplaces.
 | Alias | Description |
 |-------|-------------|
 | `"default"` | Recommended for your account type |
-| `"sonnet"` | Latest Sonnet model (Claude Sonnet 4.6 on the Anthropic API; 4.5 on third-party providers) |
+| `"sonnet"` | Latest Sonnet model (Claude Sonnet 5 on the Anthropic API as of v2.1.197, with native 1M-token context; 4.6/4.5 on third-party providers depending on version) |
 | `"opus"` | Latest Opus model (Claude Opus 4.8 on the Anthropic API as of v2.1.154; 4.6 on Bedrock/Vertex/Foundry). Also the fast-mode default since v2.1.142. Opus 4.8 defaults to `high` effort and supports `/effort xhigh` |
 | `"haiku"` | Fast Haiku model |
-| `"sonnet[1m]"` | Sonnet with 1M token context |
+| `"sonnet[1m]"` | Sonnet with 1M token context. Redundant on Sonnet 5 (v2.1.197+) since Sonnet 5 has native 1M context — retained for compatibility with older Sonnet versions on third-party providers |
 | `"opus[1m]"` | Opus with 1M token context (default on Max, Team, and Enterprise since v2.1.75) |
 | `"opusplan"` | Opus for planning, Sonnet for execution |
 | `"fable"` | Claude Fable 5 — long-horizon reasoning model. Anthropic API only (v2.1.170+). Fable 5 includes 1M context by default; the `[1m]` suffix is auto-stripped, so `fable[1m]` is redundant (v2.1.173) |
@@ -1066,7 +1066,7 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_OTEL_SHUTDOWN_TIMEOUT_MS` | Timeout in ms for OpenTelemetry shutdown |
 | `CLAUDE_ENABLE_BYTE_WATCHDOG` | Set to `1` to force-enable the byte-level streaming idle watchdog, or `0` to force-disable it. When unset, the watchdog is enabled by default for Anthropic API connections. The byte watchdog aborts a connection when no bytes arrive on the wire for the duration set by `CLAUDE_STREAM_IDLE_TIMEOUT_MS` (minimum 5 minutes), independent of the event-level watchdog |
 | `CLAUDE_STREAM_IDLE_TIMEOUT_MS` | Timeout in ms for the streaming idle watchdog. Two watchdogs apply: **byte-level** (default and minimum `300000` / 5 minutes, aborts when no bytes arrive on the wire) and **event-level** (default `90000` / 90 seconds, no minimum, aborts when no SSE events arrive). The byte watchdog is enabled by default for Anthropic API connections; control it via `CLAUDE_ENABLE_BYTE_WATCHDOG`. Increase the event timeout if long-running tools or slow networks cause premature timeout errors |
-| `OTEL_LOG_TOOL_DETAILS` | Set to `1` to include `tool_parameters` in OpenTelemetry events. Omitted by default for privacy *(in v2.1.85 changelog, not yet on official env-vars page)* |
+| `OTEL_LOG_TOOL_DETAILS` | Set to `1` to include tool names, Bash command text, MCP server/tool names, and skill names in OpenTelemetry events. Omitted by default for privacy — arguments may contain sensitive values; configure your OTel backend to filter/redact as needed (v2.1.85; officially documented in [Monitoring](https://code.claude.com/docs/en/monitoring-usage) as of v2.1.198) |
 | `OTEL_LOG_RAW_API_BODIES` | Set to `1` to emit full API request and response bodies as OpenTelemetry log events. Omitted by default for privacy and payload size. Useful for debugging at a gateway or proxy *(in v2.1.111 changelog, not yet on official env-vars page)* |
 | `OTEL_RESOURCE_ATTRIBUTES` | Comma-separated `key=value` pairs added as resource attributes on all OpenTelemetry metric data points emitted by Claude Code. Use to attach environment or deployment labels (e.g., `environment=production,team=platform`) that appear on every metric for filtering in your collector (v2.1.162) |
 | `OTEL_LOG_USER_PROMPTS` | Set to `1` to include the `user_system_prompt` field in OpenTelemetry LLM request spans. Omitted by default for privacy — user prompts can contain sensitive data, so opt in only when you control the OTel collector and have policies in place *(in v2.1.121 changelog, not yet on official env-vars page)* |

--- a/changelog/best-practice/claude-settings/changelog.md
+++ b/changelog/best-practice/claude-settings/changelog.md
@@ -994,3 +994,14 @@
 | 10 | LOW | MCP Security | Add v2.1.196 `.mcp.json` self-approval security hardening note to `enableAllProjectMcpServers` description | ✅ COMPLETE (security note added to `enableAllProjectMcpServers` description in MCP Settings table) — NEW |
 | 11 | LOW | Model Alias | Update `"sonnet"` alias to point to Claude Sonnet 5 per v2.1.197 changelog | ✋ ON HOLD (claude-code-guide agent returned `claude-sonnet-4-6` contradicting workflow-claude-settings-agent finding; per Rule 8A skipping until confirmed by official settings docs) — NEW |
 | 12 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official env-vars page after 45+ consecutive runs | ✋ ON HOLD (kept — recurring from 2026-04-14 v2.1.107) |
+
+---
+
+## [2026-07-02 10:44 AM PKT] Claude Code v2.1.198
+
+| # | Priority | Type | Action | Status |
+|---|----------|------|--------|--------|
+| 1 | HIGH | Version Bump | Update report version badge from v2.1.197 → v2.1.198 and header "As of v2.1.197" → "As of v2.1.198" | ✅ COMPLETE (badge and header updated in Phase 2.6) — NEW |
+| 2 | HIGH | Model Alias | Update `"sonnet"` alias to Claude Sonnet 5 — confirmed by v2.1.197 CHANGELOG ("Introducing Claude Sonnet 5: now the default model") and both research agents; resolves #11 from previous run | ✅ COMPLETE (description updated in Model Aliases table) — RECURRING (first seen: 2026-07-01 v2.1.197 #11, now resolved) |
+| 3 | MED | Model Alias | Update `"sonnet[1m]"` to note redundancy on Sonnet 5 (native 1M context since v2.1.197) — analogous to `"fable[1m]"` which already carries this note | ✅ COMPLETE (note added to sonnet[1m] row) — NEW |
+| 4 | MED | Env Var | Resolve `OTEL_LOG_TOOL_DETAILS` ON HOLD — now officially documented in Monitoring docs (code.claude.com/docs/en/monitoring-usage) as of v2.1.198; confirmed by both research agents | ✅ COMPLETE (description updated, changelog caveat replaced with official monitoring docs reference) — RECURRING (first seen: 2026-04-14 v2.1.107, now resolved after 45+ ON HOLD runs) |


### PR DESCRIPTION
## Summary

Automated daily drift check for `best-practice/claude-settings.md` against Claude Code v2.1.198 official docs, CHANGELOG, and CLI reference. Ran full verification checklist (23 rules) and applied all confirmed HIGH/MED items.

## Drift Found

| # | Priority | Type | Action | Status |
|---|----------|------|--------|--------|
| 1 | HIGH | Version Bump | Update version badge and intro from v2.1.197 → v2.1.198 | ✅ COMPLETE |
| 2 | HIGH | Model Alias | `"sonnet"` alias now resolves to **Claude Sonnet 5** (native 1M-token context) as of v2.1.197 — confirmed by CHANGELOG and both research agents. Resolves ON HOLD from previous run. | ✅ COMPLETE |
| 3 | MED | Model Alias | `"sonnet[1m]"` is now redundant on Sonnet 5 (native 1M context) — added note, analogous to existing `"fable[1m]"` note | ✅ COMPLETE |
| 4 | MED | Env Var | `OTEL_LOG_TOOL_DETAILS` is now officially documented in [Monitoring docs](https://code.claude.com/docs/en/monitoring-usage) — resolved ON HOLD that had persisted for **45+ consecutive runs** (since v2.1.85 / 2026-04-14) | ✅ COMPLETE |

## Resolved Since Last Run

- **#11 (ON HOLD → COMPLETE):** `"sonnet"` alias update was deferred last run due to agent contradiction. This run: CHANGELOG v2.1.197 ("Introducing Claude Sonnet 5: now the default model in Claude Code") + both independent research agents confirmed → promoted to HIGH and applied.
- **#12 (ON HOLD → COMPLETE):** `OTEL_LOG_TOOL_DETAILS` had been ON HOLD for 45+ runs. This run: officially documented in `code.claude.com/docs/en/monitoring-usage` as of v2.1.198 → description updated, caveat removed.

## Verification Checklist Results

All 23 rules executed. Summary:

| Rule | Category | Result | Notes |
|------|----------|--------|-------|
| 1A | Key Completeness | PASS | No confirmed missing keys in v2.1.198 |
| 1B | Key Types | PASS | No type changes |
| 1C | Key Defaults | PASS | No default changes |
| 1D | Key Descriptions | FIXED | `"sonnet"` alias, `OTEL_LOG_TOOL_DETAILS` updated |
| 1E | Scope Column | PASS | No scope changes |
| 1F | Inverse Completeness | PASS | All keys traceable |
| 1G | Edge-Case Semantics | PASS | No new edge cases |
| 1H | File Scope Check | PASS | No scope mismatches |
| 1I | Skills Keys | PASS | No new skill keys in v2.1.198 |
| 2A–2D | Settings Hierarchy | PASS | 5-level chain and managed tier accurate |
| 3A–3D | Permissions | PASS | All modes, syntax, and semantics accurate |
| 4A | Hooks Redirect | PASS | `github.com/shanraisshan/claude-code-hooks` resolves (461 stars) |
| 5A–5D | Env Variables | FIXED | `OTEL_LOG_TOOL_DETAILS` description updated with official source |
| 6A–6B | Examples | PASS | Quick Reference example valid; schema URL redirects correctly |
| 7A | CLAUDE.md Sync | PASS | Configuration hierarchy consistent |
| 9A | Local File Links | PASS | `../.claude/settings.json` exists |
| 9B | External URL Links | PASS | All 6 source URLs valid; json.schemastore.org → 301 redirect → OK |
| 9C | Anchor Links | PASS | TOC anchors intact |
| 10A | Version Metadata | FIXED | Badge and header updated to v2.1.198 |
| 10B | Suspect Key Escalation | RESOLVED | `OTEL_LOG_TOOL_DETAILS` resolved after 45+ ON HOLD runs |
| 10C | Bidirectional Completeness | PASS | All items traceable to official sources |

## Checklist Rule Changes

None. No new drift types were discovered that require a new rule.

## Files Changed

- `best-practice/claude-settings.md` — 5 targeted edits (badge, version, alias ×2, env var)
- `changelog/best-practice/claude-settings/changelog.md` — new dated entry appended

## Sources

- Claude Code Settings Docs: https://code.claude.com/docs/en/settings
- Claude Code Monitoring Docs: https://code.claude.com/docs/en/monitoring-usage
- CHANGELOG: https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md (latest: v2.1.198)

Generated with [Claude Code](https://claude.ai/code)
https://claude.ai/code/session_01LXCmecECabG49SHnGY2GoX

---
_Generated by [Claude Code](https://claude.ai/code/session_01LXCmecECabG49SHnGY2GoX)_