### PR TITLE
Daily settings drift check — 2026-07-03 (Claude Code v2.1.199)

### DIFF
--- a/best-practice/claude-settings.md
+++ b/best-practice/claude-settings.md
@@ -1,9 +1,9 @@
 # Settings Best Practice
 
-![Last Updated](https://img.shields.io/badge/Last_Updated-Jul%2001%2C%202026%2010%3A40%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.197-blue?style=flat&labelColor=555)<br>
+![Last Updated](https://img.shields.io/badge/Last_Updated-Jul%2003%2C%202026%2010%3A42%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.199-blue?style=flat&labelColor=555)<br>
 [![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../.claude/settings.json)
 
-A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.197, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
+A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.199, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
 
 <table width="100%">
 <tr>
@@ -557,7 +557,7 @@ Configure Claude Code plugins and marketplaces.
 | Alias | Description |
 |-------|-------------|
 | `"default"` | Recommended for your account type |
-| `"sonnet"` | Latest Sonnet model (Claude Sonnet 4.6 on the Anthropic API; 4.5 on third-party providers) |
+| `"sonnet"` | Latest Sonnet model (Claude Sonnet 5 on the Anthropic API — native 1M-token context, introduced v2.1.197; Claude Sonnet 4.6 on Bedrock/Vertex/Foundry) |
 | `"opus"` | Latest Opus model (Claude Opus 4.8 on the Anthropic API as of v2.1.154; 4.6 on Bedrock/Vertex/Foundry). Also the fast-mode default since v2.1.142. Opus 4.8 defaults to `high` effort and supports `/effort xhigh` |
 | `"haiku"` | Fast Haiku model |
 | `"sonnet[1m]"` | Sonnet with 1M token context |
@@ -895,6 +895,7 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_POWERSHELL_RESPECT_EXECUTION_POLICY` | Set to `1` to stop Claude Code from passing `-ExecutionPolicy Bypass` when spawning PowerShell for tool calls, hooks, and status line commands, respecting the machine's effective execution policy instead. By default Claude Code bypasses execution policy at process scope so `.ps1` scripts and module imports work on default-Restricted Windows. Never overrides Group Policy `MachinePolicy`/`UserPolicy` (v2.1.143) |
 | `CLAUDE_CODE_REMOTE` | Read-only. Set automatically to `true` when Claude Code is running as a cloud session. Read this from a hook or setup script to detect whether you are in a cloud environment |
 | `CLAUDE_CODE_REMOTE_SESSION_ID` | Read-only. Set automatically in cloud sessions to the current session's ID. Read this to construct a link back to the session transcript |
+| `CLAUDE_CODE_BRIDGE_SESSION_ID` | Read-only. Set automatically in Bash tool and hook command subprocesses while the session has an active Remote Control connection. Value is the session ID in `session_` form (same identifier in the session's `claude.ai/code` URL). Removed when the connection ends. Allows scripts to link back to the session that ran them. In cloud sessions, read `CLAUDE_CODE_REMOTE_SESSION_ID` instead (v2.1.199) |
 | `CLAUDE_REMOTE_CONTROL_SESSION_NAME_PREFIX` | Prefix for auto-generated Remote Control session names. Defaults to the machine hostname |
 | `CLAUDE_CLIENT_PRESENCE_FILE` | Path to a file that, when present, signals an active client and suppresses mobile push notifications from Remote Control. Useful in environments where a desktop client is always running and mobile pings are unwanted |
 | `CLAUDE_CODE_ENABLE_TELEMETRY` | Enable/disable telemetry (`0` or `1`) |
@@ -911,6 +912,8 @@ Set environment variables for all Claude Code sessions.
 | `API_TIMEOUT_MS` | Timeout in ms for API requests (default: 600000) |
 | `API_FORCE_IDLE_TIMEOUT` | Override the 5-minute idle timeout for streaming connections. Set to `0` to disable the idle timeout entirely, `1` to enforce it on all connections, or leave unset for the default (auto-enabled on slow or unreliable gateways that frequently stall). Useful for slow API gateways (v2.1.169) |
 | `CLAUDE_CODE_CONNECT_TIMEOUT_MS` | Timeout in milliseconds for the connect, TLS, and response-header phase of a streaming API request (default: `60000` / 60 seconds). If no response headers arrive within this window, the request is aborted and retried. Set to `0` to disable and rely on `API_TIMEOUT_MS` alone |
+| `CLAUDE_AFK_TIMEOUT_MS` | How many milliseconds of idle time before an unanswered AskUserQuestion dialog auto-continues without you (default: `60000` / 60 seconds). To keep questions open while away, set a large value such as `86400000` (24 hours). Setting to `0` closes the dialog immediately (does not disable the timeout) (v2.1.198) |
+| `CLAUDE_AFK_COUNTDOWN_MS` | How many milliseconds before auto-continue the on-screen countdown appears on an unanswered AskUserQuestion dialog (default: `20000` / 20 seconds) (v2.1.198) |
 | `BASH_MAX_TIMEOUT_MS` | Bash command timeout |
 | `BASH_MAX_OUTPUT_LENGTH` | Max bash output length |
 | `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` | Auto-compact threshold percentage (1-100). Default is ~95%. Set lower (e.g., `50`) to trigger compaction earlier. Values above 95% have no effect. Use `/context` to monitor current usage. Example: `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=50 claude` |
@@ -918,8 +921,10 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR` | Keep cwd between bash calls (`1` to enable) |
 | `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS` | Disable background tasks (`1` to disable) |
 | `CLAUDE_CODE_DISABLE_BG_SHELL_PRESSURE_REAP` | Set to `1` to disable automatic memory-pressure reaping of idle background shell commands. When unset, Claude Code automatically reaps idle background shells under memory pressure to free resources (v2.1.193 changelog, not yet on official env-vars page) |
+| `CLAUDE_CODE_DISABLE_BG_EXIT_HANDOFF` | Set to `1` to stop a background session's running background shell commands, dynamic workflows, and background subagents when the supervisor stops, restarts, or updates that session's process. By default they are handed off to the session's next process (v2.1.198) |
 | `CLAUDE_CODE_DISABLE_ADVISOR_TOOL` | Set to `1` to disable the advisor tool and the `/advisor` command. Env-var equivalent of omitting advisor usage. Pair with `advisorModel` for advisor configuration (min v2.1.98) |
 | `CLAUDE_CODE_DISABLE_AGENT_VIEW` | Set to `1` to turn off background agents and agent view (`claude agents`, `--bg`, `/background`, on-demand supervisor). Env-var equivalent of the `disableAgentView` setting *(referenced on official settings page; not listed on the env-vars page)* |
+| `CLAUDE_CODE_DISABLE_EXPLORE_PLAN_AGENTS` | Set to `1` to disable the built-in Explore and Plan subagents. Claude explores with search tools or the general-purpose subagent instead. Plan mode reads files directly rather than launching Explore and Plan agents (v2.1.198) |
 | `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` | Enable the experimental agent teams feature (`1` to enable). Allows spawning coordinated teams of subagents within a session. Also configurable as a startup-only var — see [CLI Startup Flags](./claude-cli-startup-flags.md#environment-variables) |
 | `CLAUDE_CODE_DISABLE_WORKFLOWS` | Set to `1` to disable [dynamic workflows](https://code.claude.com/docs/en/workflows) (`/workflows`) and the bundled workflow slash commands. Env-var equivalent of the `disableWorkflows` setting |
 | `CLAUDE_CODE_ENABLE_AUTO_MODE` | Set to `1` to make [auto mode](https://code.claude.com/docs/en/permission-modes#eliminate-prompts-with-auto-mode) available on Amazon Bedrock, Google Cloud Vertex AI, and Microsoft Foundry. Has no effect on the Anthropic API, where auto mode is available by default (v2.1.158) |

--- a/changelog/best-practice/claude-settings/changelog.md
+++ b/changelog/best-practice/claude-settings/changelog.md
@@ -994,3 +994,19 @@
 | 10 | LOW | MCP Security | Add v2.1.196 `.mcp.json` self-approval security hardening note to `enableAllProjectMcpServers` description | ✅ COMPLETE (security note added to `enableAllProjectMcpServers` description in MCP Settings table) — NEW |
 | 11 | LOW | Model Alias | Update `"sonnet"` alias to point to Claude Sonnet 5 per v2.1.197 changelog | ✋ ON HOLD (claude-code-guide agent returned `claude-sonnet-4-6` contradicting workflow-claude-settings-agent finding; per Rule 8A skipping until confirmed by official settings docs) — NEW |
 | 12 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official env-vars page after 45+ consecutive runs | ✋ ON HOLD (kept — recurring from 2026-04-14 v2.1.107) |
+
+---
+
+## [2026-07-03 10:42 AM PKT] Claude Code v2.1.199
+
+| # | Priority | Type | Action | Status |
+|---|----------|------|--------|--------|
+| 1 | HIGH | Version Bump | Update report version badge from v2.1.197 → v2.1.199 and header "As of v2.1.197" → "As of v2.1.199" | ✅ COMPLETE (badge and header updated in Phase 2.6) — NEW |
+| 2 | HIGH | Model Alias | Update `"sonnet"` alias to point to Claude Sonnet 5 on the Anthropic API (native 1M-token context, v2.1.197); Claude Sonnet 4.6 on Bedrock/Vertex/Foundry | ✅ COMPLETE (Model Aliases table updated; both agents confirm Sonnet 5 this run) — RECURRING (first seen 2026-07-01 #11) |
+| 3 | HIGH | Missing Env Var | Add `CLAUDE_AFK_TIMEOUT_MS` (v2.1.198) — AskUserQuestion dialog auto-continue timeout (default 60000ms) | ✅ COMPLETE (added after `CLAUDE_CODE_CONNECT_TIMEOUT_MS`) — NEW |
+| 4 | HIGH | Missing Env Var | Add `CLAUDE_AFK_COUNTDOWN_MS` (v2.1.198) — countdown display delay before auto-continue (default 20000ms) | ✅ COMPLETE (added after `CLAUDE_AFK_TIMEOUT_MS`) — NEW |
+| 5 | HIGH | Missing Env Var | Add `CLAUDE_CODE_DISABLE_BG_EXIT_HANDOFF` (v2.1.198) — prevent background task handoff when supervisor restarts | ✅ COMPLETE (added after `CLAUDE_CODE_DISABLE_BG_SHELL_PRESSURE_REAP`) — NEW |
+| 6 | HIGH | Missing Env Var | Add `CLAUDE_CODE_DISABLE_EXPLORE_PLAN_AGENTS` (v2.1.198) — disable built-in Explore and Plan subagents | ✅ COMPLETE (added after `CLAUDE_CODE_DISABLE_AGENT_VIEW`) — NEW |
+| 7 | HIGH | Missing Env Var | Add `CLAUDE_CODE_BRIDGE_SESSION_ID` (v2.1.199) — read-only Remote Control session ID in Bash/hook subprocesses | ✅ COMPLETE (added after `CLAUDE_CODE_REMOTE_SESSION_ID`) — NEW |
+| 8 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official env-vars page after 46+ consecutive runs | ✋ ON HOLD (kept — recurring from 2026-04-14 v2.1.107) |
+| 9 | LOW | Unconfirmed Env Var | `CLAUDE_CODE_RETRY_WATCHDOG` — flagged by workflow agent at 0.85 confidence but NOT found on official env-vars page per Rule 8A | ✋ ON HOLD (not on official env-vars page; will re-check next run) — NEW |


### PR DESCRIPTION
## Summary

Automated daily drift check against [official settings docs](https://code.claude.com/docs/en/settings) and [env-vars page](https://code.claude.com/docs/en/env-vars). Two research agents (workflow-claude-settings-agent + claude-code-guide) ran in parallel; all findings verified against official sources per Rule 8A before applying.

**Claude Code version audited:** v2.1.199

### Changes applied

| # | Priority | Type | Action |
|---|----------|------|--------|
| 1 | HIGH | Version Bump | Badge + intro text updated v2.1.197 → v2.1.199 |
| 2 | HIGH | Model Alias | `"sonnet"` alias updated to Claude Sonnet 5 on Anthropic API (1M-token context, v2.1.197); Sonnet 4.6 on Bedrock/Vertex/Foundry |
| 3 | HIGH | New Env Var | `CLAUDE_AFK_TIMEOUT_MS` (v2.1.198) — AskUserQuestion auto-continue timeout, default 60s |
| 4 | HIGH | New Env Var | `CLAUDE_AFK_COUNTDOWN_MS` (v2.1.198) — countdown display delay before auto-continue, default 20s |
| 5 | HIGH | New Env Var | `CLAUDE_CODE_DISABLE_BG_EXIT_HANDOFF` (v2.1.198) — prevent background task handoff on supervisor restart |
| 6 | HIGH | New Env Var | `CLAUDE_CODE_DISABLE_EXPLORE_PLAN_AGENTS` (v2.1.198) — disable built-in Explore and Plan subagents |
| 7 | HIGH | New Env Var | `CLAUDE_CODE_BRIDGE_SESSION_ID` (v2.1.199) — read-only Remote Control session ID available in Bash/hook subprocesses |

### Items kept ON HOLD (not applied)

- `OTEL_LOG_TOOL_DETAILS` — 46+ consecutive runs, still not on official env-vars page
- `CLAUDE_CODE_RETRY_WATCHDOG` — flagged by workflow agent at 0.85 confidence, NOT confirmed on official env-vars page per Rule 8A
- Sandbox sub-field changes (`mask` mode, `tlsTerminate`, `allowPlaintextInject`) — reported by claude-code-guide only, not confirmed by official settings page fetch; held per Rule 8A

### Verification checklist

All rules 1A–10C executed. Results:
- Rules 1A (env vars), 1D (sonnet alias), 5A (env var completeness), 10A (badge) → **FAIL → FIXED**
- All remaining rules → **PASS**
- Hyperlinks: all 6 external links valid; `json.schemastore.org` 301 redirect retained (standing v2.1.119 #8 decision)

### Files changed

- `best-practice/claude-settings.md` — 5 new env var rows, sonnet alias, badge/version update
- `changelog/best-practice/claude-settings/changelog.md` — new dated entry appended

---
_Generated by [Claude Code](https://claude.ai/code/session_01EXQEFvYBKoBTMSTUZXnNpF)_