### PR TITLE
Daily settings drift check — 2026-07-04 (Claude Code v2.1.201)

### DIFF
--- a/best-practice/claude-settings.md
+++ b/best-practice/claude-settings.md
@@ -1,9 +1,9 @@
 # Settings Best Practice
 
-![Last Updated](https://img.shields.io/badge/Last_Updated-Jul%2003%2C%202026%2010%3A42%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.199-blue?style=flat&labelColor=555)<br>
+![Last Updated](https://img.shields.io/badge/Last_Updated-Jul%2004%2C%202026%2010%3A47%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.201-blue?style=flat&labelColor=555)<br>
 [![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../.claude/settings.json)
 
-A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.199, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
+A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.201, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
 
 <table width="100%">
 <tr>
@@ -122,6 +122,7 @@ Within the managed tier, precedence is: server-managed > MDM/OS-level policies >
 | `feedbackSurveyRate` | number | - | Probability (0–1) that the session quality survey appears when eligible. Enterprise admins can control how often the survey is shown. Example: `0.05` = 5% of eligible sessions |
 | `advisorModel` | string | - | Model for the server-side advisor tool. Accepts a model alias (`opus`, `sonnet`, `fable`) or a full model ID. When unset, the advisor uses the session model. Requires v2.1.98+ |
 | `respondToBashCommands` | boolean | `true` | Whether Claude automatically responds after a `!` shell command completes. Set to `false` to disable the automatic follow-up response when a `!` bash command finishes (v2.1.186) |
+| `askUserQuestionTimeout` | string | `"never"` | How long to wait before an unanswered AskUserQuestion dialog auto-continues without the user. Values: `"60s"`, `"5m"`, `"10m"`, `"never"` (no auto-continue — the default). Set via `/config` as **Ask user question timeout**. Pairs with the `CLAUDE_AFK_TIMEOUT_MS` env var; the env var applies only when this setting is set to a duration. (v2.1.200) |
 
 **Example:**
 ```json
@@ -206,7 +207,7 @@ Scripts for dynamic authentication token generation.
 
 | Key | Type | Description |
 |-----|------|-------------|
-| `apiKeyHelper` | string | Shell script path that outputs auth token (sent as `X-Api-Key` header) |
+| `apiKeyHelper` | string | Shell script path that outputs auth token (sent as both `X-Api-Key` and `Authorization: Bearer` headers) |
 | `forceLoginMethod` | string | Restrict login to `"claudeai"`, `"console"`, or `"gateway"` accounts. Use `"gateway"` for organization-managed Claude gateway deployments. **(Managed only)** |
 | `forceLoginOrgUUID` | string \| array | Require login to belong to a specific organization. Accepts a single UUID string (which also pre-selects that organization during login) or an array of UUIDs where any listed organization is accepted without pre-selection. When set in managed settings, login fails if the authenticated account does not belong to a listed organization; an empty array fails closed and blocks login with a misconfiguration message |
 | `forceLoginGatewayUrl` | string | **(Managed only)** Pre-fill the Claude gateway URL on the login screen when `forceLoginMethod` is `"gateway"`. Avoids requiring users to manually enter the gateway URL. Typically set alongside `forceLoginMethod: "gateway"` |
@@ -269,7 +270,7 @@ Control what tools and operations Claude can perform.
 | `permissions.ask` | array | Rules requiring user confirmation |
 | `permissions.deny` | array | Rules blocking tool use (highest precedence) |
 | `permissions.additionalDirectories` | array | Extra directories Claude can access |
-| `permissions.defaultMode` | string | Default permission mode. In Remote environments, only `acceptEdits` and `plan` are honored (v2.1.70+) |
+| `permissions.defaultMode` | string | Default permission mode. Valid values: `"default"`, `"manual"` (alias for `"default"`, v2.1.200), `"acceptEdits"`, `"dontAsk"`, `"bypassPermissions"`, `"auto"`, `"plan"`. In Remote environments, only `acceptEdits` and `plan` are honored (v2.1.70+) |
 | `permissions.disableBypassPermissionsMode` | string | Prevent bypass mode activation |
 | `permissions.skipDangerousModePermissionPrompt` | boolean | Skip the confirmation prompt shown before entering bypass permissions mode via `--dangerously-skip-permissions` or `defaultMode: "bypassPermissions"`. Ignored when set in project settings (`.claude/settings.json`) to prevent untrusted repositories from auto-bypassing the prompt |
 | `allowManagedPermissionRulesOnly` | boolean | **(Managed only)** Only managed permission rules apply; user/project `allow`, `ask`, `deny` rules are ignored |
@@ -282,6 +283,7 @@ Control what tools and operations Claude can perform.
 | Mode | Behavior |
 |------|----------|
 | `"default"` | Standard permission checking with prompts |
+| `"manual"` | Alias for `"default"` introduced in v2.1.200 — same standard permission checking with prompts. The rename improves clarity across the CLI, VS Code, and JetBrains UIs. Accepted wherever `"default"` is accepted |
 | `"acceptEdits"` | Automatically accepts file edits **and common filesystem commands** (`mkdir`, `touch`, `mv`, `cp`, etc.) for paths in the working directory or `additionalDirectories`. **v2.1.160:** Always prompts before writing build-tool config files that grant code execution (`.npmrc`, `.yarnrc*`, `bunfig.toml`, `.bazelrc`, `.pre-commit-config.yaml`, `.devcontainer/`, etc.) and before writing to shell startup files (`.zshenv`, `.zlogin`, `.bash_login`) and `~/.config/git/` |
 | `"dontAsk"` | Auto-denies tools unless pre-approved via `/permissions` or `permissions.allow` rules |
 | `"bypassPermissions"` | Skip all permission checks (dangerous). All path-based prompts are skipped — writes to `.git`, `.config/git`, `.claude`, `.vscode`, `.idea`, `.husky`, `.cargo`, `.devcontainer`, `.yarn`, and `.mvn` no longer prompt (**v2.1.121** exempted `.claude/commands/`, `.claude/agents/`, `.claude/skills/`, and `.claude/worktrees/`; **v2.1.126** removed all remaining path-based prompts). Only removals targeting the filesystem root or home directory (`rm -rf /`, `rm -rf ~`) still prompt as a circuit breaker against model error |
@@ -912,7 +914,7 @@ Set environment variables for all Claude Code sessions.
 | `API_TIMEOUT_MS` | Timeout in ms for API requests (default: 600000) |
 | `API_FORCE_IDLE_TIMEOUT` | Override the 5-minute idle timeout for streaming connections. Set to `0` to disable the idle timeout entirely, `1` to enforce it on all connections, or leave unset for the default (auto-enabled on slow or unreliable gateways that frequently stall). Useful for slow API gateways (v2.1.169) |
 | `CLAUDE_CODE_CONNECT_TIMEOUT_MS` | Timeout in milliseconds for the connect, TLS, and response-header phase of a streaming API request (default: `60000` / 60 seconds). If no response headers arrive within this window, the request is aborted and retried. Set to `0` to disable and rely on `API_TIMEOUT_MS` alone |
-| `CLAUDE_AFK_TIMEOUT_MS` | How many milliseconds of idle time before an unanswered AskUserQuestion dialog auto-continues without you (default: `60000` / 60 seconds). To keep questions open while away, set a large value such as `86400000` (24 hours). Setting to `0` closes the dialog immediately (does not disable the timeout) (v2.1.198) |
+| `CLAUDE_AFK_TIMEOUT_MS` | How many milliseconds before an unanswered AskUserQuestion dialog auto-continues, when `askUserQuestionTimeout` is set to a duration. As of v2.1.200, the default is `"never"` (no auto-continue) controlled by `askUserQuestionTimeout`; this env var applies only when a timeout duration is active. Setting to `0` closes the dialog immediately. To keep questions open, prefer `askUserQuestionTimeout: "never"` (v2.1.198; default changed v2.1.200) |
 | `CLAUDE_AFK_COUNTDOWN_MS` | How many milliseconds before auto-continue the on-screen countdown appears on an unanswered AskUserQuestion dialog (default: `20000` / 20 seconds) (v2.1.198) |
 | `BASH_MAX_TIMEOUT_MS` | Bash command timeout |
 | `BASH_MAX_OUTPUT_LENGTH` | Max bash output length |

--- a/changelog/best-practice/claude-settings/changelog.md
+++ b/changelog/best-practice/claude-settings/changelog.md
@@ -1010,3 +1010,17 @@
 | 7 | HIGH | Missing Env Var | Add `CLAUDE_CODE_BRIDGE_SESSION_ID` (v2.1.199) — read-only Remote Control session ID in Bash/hook subprocesses | ✅ COMPLETE (added after `CLAUDE_CODE_REMOTE_SESSION_ID`) — NEW |
 | 8 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official env-vars page after 46+ consecutive runs | ✋ ON HOLD (kept — recurring from 2026-04-14 v2.1.107) |
 | 9 | LOW | Unconfirmed Env Var | `CLAUDE_CODE_RETRY_WATCHDOG` — flagged by workflow agent at 0.85 confidence but NOT found on official env-vars page per Rule 8A | ✋ ON HOLD (not on official env-vars page; will re-check next run) — NEW |
+
+---
+
+## [2026-07-04 10:47 AM PKT] Claude Code v2.1.201
+
+| # | Priority | Type | Action | Status |
+|---|----------|------|--------|--------|
+| 1 | HIGH | Version Bump | Update report version badge from v2.1.199 → v2.1.201 and header "As of v2.1.199" → "As of v2.1.201" | ✅ COMPLETE (badge and header updated in Phase 2.6) — NEW |
+| 2 | HIGH | New Setting | Add `askUserQuestionTimeout` to General Settings table — string, default `"never"`, values `"60s"/"5m"/"10m"/"never"`. Controls auto-continue behavior for unanswered AskUserQuestion dialogs. Confirmed on official settings page (v2.1.200) | ✅ COMPLETE (added after `respondToBashCommands` in General Settings table) — NEW |
+| 3 | HIGH | New Permission Mode | Add `"manual"` alias row to Permission Modes table and update `permissions.defaultMode` description — v2.1.200 introduced `"manual"` as an alias for `"default"` for UI clarity across CLI, VS Code, and JetBrains. Confirmed in v2.1.200 changelog | ✅ COMPLETE (added to Permission Modes table; defaultMode description updated) — NEW |
+| 4 | MED | Changed Description | Update `CLAUDE_AFK_TIMEOUT_MS` — v2.1.200 changed the default behavior: AskUserQuestion dialogs no longer auto-continue by default (`askUserQuestionTimeout: "never"` is the new default). `CLAUDE_AFK_TIMEOUT_MS` now applies only when `askUserQuestionTimeout` is explicitly set to a duration | ✅ COMPLETE (description updated to clarify v2.1.200 semantics) — NEW |
+| 5 | LOW | Changed Description | Update `apiKeyHelper` — description said only `X-Api-Key`; official docs confirm the script output is also sent as `Authorization: Bearer` header. Completed. | ✅ COMPLETE (description updated in Authentication Helpers table) — NEW |
+| 6 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 47+ consecutive runs | ✋ ON HOLD (recurring from 2026-04-14 v2.1.107) |
+| 7 | LOW | Suspect Key Recurrence | `CLAUDE_CODE_RETRY_WATCHDOG` — still NOT on official env-vars page per Rule 8A verification | ✋ ON HOLD (recurring from 2026-07-03 v2.1.199) |


### PR DESCRIPTION
## Settings Drift Report — 2026-07-04 (Claude Code v2.1.201)

Two-agent parallel research (workflow-claude-settings-agent + claude-code-guide). All findings confirmed against official sources per Rule 8A before applying.

---

## Verification Log

| Rule | Category | Depth | Result | Notes |
|------|----------|-------|--------|-------|
| 1A | Key Completeness | field-level | PASS (1 FAIL) | `askUserQuestionTimeout` was missing — added |
| 1B | Key Types | content-match | PASS | All types match official docs |
| 1C | Key Defaults | content-match | PASS | All defaults verified |
| 1D | Key Descriptions | content-match | PASS (2 FAIL) | `apiKeyHelper` and `CLAUDE_AFK_TIMEOUT_MS` descriptions updated |
| 1E | Scope Column | content-match | PASS | All scope values verified |
| 1F | Inverse Completeness | field-level | PASS | All report keys traceable to official docs or annotated |
| 1G | Edge-Case Semantics | content-match | PASS | `askUserQuestionTimeout: "never"` boundary behavior documented |
| 1H | File Scope Check | content-match | PASS | No `~/.claude.json` keys misplaced in settings.json tables |
| 1I | Skills Settings Keys | field-level | PASS | `maxSkillDescriptionChars`, `skillListingBudgetFraction` present |
| 2A | Priority Levels | field-level | PASS | 5-level chain + managed policy intact |
| 2B | File Locations | content-match | PASS | All file paths correct |
| 2C | Merge Semantics | content-match | PASS | "concatenated and deduplicated" wording matches docs |
| 2D | Managed Internals | field-level | PASS | All delivery methods and precedence documented |
| 3A | Permission Modes | field-level | PASS (1 FAIL) | `"manual"` alias was missing — added |
| 3B | Tool Syntax Patterns | content-match | PASS | All patterns verified |
| 3C | Bidirectional Mode Check | field-level | PASS | All modes traceable both ways |
| 3D | Evaluation Semantics | content-match | PASS | Deny-first, path prefixes documented |
| 4A | Hooks Redirect | exists | PASS | Redirect to claude-code-hooks repo present |
| 5A | Env Var Completeness | field-level | PASS | All official env vars present |
| 5B | Ownership Boundary | cross-file | PASS | No duplication between settings and CLI flags files |
| 5C | Env Var Descriptions | content-match | PASS (1 FAIL) | `CLAUDE_AFK_TIMEOUT_MS` description updated for v2.1.200 |
| 5D | Inverse Env Var Check | field-level | PASS | All report vars traceable or annotated |
| 6A | Quick Reference Example | content-match | PASS | Example reflects current settings |
| 6B | Example URL Validation | exists | PASS | `$schema` URL resolves correctly |
| 7A | CLAUDE.md Sync | cross-file | PASS | Hierarchy sections consistent |
| 8A | Source Credibility Guard | content-match | PASS | All findings confirmed via official docs only |
| 9A | Local File Links | exists | PASS | All relative links resolve |
| 9B | External URL Links | exists | PASS | All external URLs return valid pages |
| 9C | Anchor Links | exists | PASS | All internal anchors point to existing headings |
| 10A | Version Metadata | content-match | PASS | Badge, header, and counts updated to v2.1.201 |
| 10B | Suspect Key Escalation | exists | ON HOLD | `OTEL_LOG_TOOL_DETAILS` at 47+ runs; `CLAUDE_CODE_RETRY_WATCHDOG` at 2nd run |
| 10C | Bidirectional Completeness | field-level | PASS | All keys traced both directions |

---

## Hyperlink Validation Log

| # | Type | Link | Status |
|---|------|------|--------|
| 1 | Local | `../` (Back to repo) | OK |
| 2 | Local | `../.claude/settings.json` | OK |
| 3 | External | https://code.claude.com/docs/en/settings | OK |
| 4 | External | https://code.claude.com/docs/en/cli-reference | OK |
| 5 | External | https://code.claude.com/docs/en/env-vars | OK |
| 6 | External | https://github.com/shanraisshan/claude-code-hooks | OK (hooks redirect) |
| 7 | External | https://json.schemastore.org/claude-code-settings.json | OK |

---

## Priority Actions Applied

| # | Priority | Type | Action | Status |
|---|----------|------|--------|--------|
| 1 | HIGH | Version Bump | Updated badge and header v2.1.199 → v2.1.201 | ✅ COMPLETE — NEW |
| 2 | HIGH | New Setting | Added `askUserQuestionTimeout` to General Settings (string, default `"never"`, v2.1.200) | ✅ COMPLETE — NEW |
| 3 | HIGH | New Permission Mode | Added `"manual"` alias to Permission Modes table; updated `permissions.defaultMode` description (v2.1.200) | ✅ COMPLETE — NEW |
| 4 | MED | Changed Description | Updated `CLAUDE_AFK_TIMEOUT_MS` — v2.1.200 made `"never"` the default; env var now applies only when a duration is set | ✅ COMPLETE — NEW |
| 5 | LOW | Changed Description | Updated `apiKeyHelper` — adds `Authorization: Bearer` alongside `X-Api-Key` | ✅ COMPLETE — NEW |
| 6 | LOW | Suspect Key | `OTEL_LOG_TOOL_DETAILS` — 47+ consecutive runs, not on official env-vars page | ✋ ON HOLD — RECURRING (first seen 2026-04-14) |
| 7 | LOW | Suspect Key | `CLAUDE_CODE_RETRY_WATCHDOG` — not on official env-vars page per Rule 8A | ✋ ON HOLD — RECURRING (first seen 2026-07-03) |

---

## Resolved Since Last Run

No items from the previous run (v2.1.199) were resolved in this run. The model alias update for `"sonnet"` (v2.1.197 #11, ON HOLD) was already resolved in v2.1.199. Both ON HOLD suspect keys persist.

---

*Generated by workflow-claude-settings / claude-code-guide agents. All findings verified against official Claude Code docs per Rule 8A before applying.*

---
_Generated by [Claude Code](https://claude.ai/code/session_01VdmewJbJErtFpLsbA3ci1k)_