### PR TITLE
fix(skills): repair stale paths and dead links in local skills

### DIFF
--- a/.claude/skills/agent-browser/SKILL.md
+++ b/.claude/skills/agent-browser/SKILL.md
@@ -191,27 +191,6 @@ agent-browser find placeholder "Search" type "query"
 agent-browser find testid "submit-btn" click
 ```
 
-## Deep-Dive Documentation
+## Full Command Reference
 
-| Reference | When to Use |
-|-----------|-------------|
-| [references/commands.md](references/commands.md) | Full command reference with all options |
-| [references/snapshot-refs.md](references/snapshot-refs.md) | Ref lifecycle, invalidation rules, troubleshooting |
-| [references/session-management.md](references/session-management.md) | Parallel sessions, state persistence, concurrent scraping |
-| [references/authentication.md](references/authentication.md) | Login flows, OAuth, 2FA handling, state reuse |
-| [references/video-recording.md](references/video-recording.md) | Recording workflows for debugging and documentation |
-| [references/proxy-support.md](references/proxy-support.md) | Proxy configuration, geo-testing, rotating proxies |
-
-## Ready-to-Use Templates
-
-| Template | Description |
-|----------|-------------|
-| [templates/form-automation.sh](templates/form-automation.sh) | Form filling with validation |
-| [templates/authenticated-session.sh](templates/authenticated-session.sh) | Login once, reuse state |
-| [templates/capture-workflow.sh](templates/capture-workflow.sh) | Content extraction with screenshots |
-
-```bash
-./templates/form-automation.sh https://example.com/form
-./templates/authenticated-session.sh https://app.example.com/login
-./templates/capture-workflow.sh https://example.com ./output
-```
+For options not covered above, run `agent-browser --help` or `agent-browser <command> --help`.

--- a/.claude/skills/presentation/presentation-structure/SKILL.md
+++ b/.claude/skills/presentation/presentation-structure/SKILL.md
@@ -1,15 +1,16 @@
 ---
 name: presentation-structure
-description: Knowledge about the presentation slide format, weight system, navigation, and section structure
+description: Knowledge about the vibe-coding presentation's slide format, data-slide/data-level attributes, journey bar level system, navigation, renumbering rules, and section divider structure. Preloaded into the presentation-vibe-coding agent — use whenever adding, removing, reordering, or renumbering slides in presentation/vibe-coding-to-agentic-engineering/index.html.
+user-invocable: false
 ---
 
 # Presentation Structure Skill
 
-Knowledge about how the presentation at `presentation/index.html` is structured.
+Knowledge about how the presentation at `presentation/vibe-coding-to-agentic-engineering/index.html` is structured.
 
 ## File Location
 
-`presentation/index.html` — a single-file HTML presentation with inline CSS and JS.
+`presentation/vibe-coding-to-agentic-engineering/index.html` — a single-file HTML presentation with inline CSS and JS.
 
 ## Slide Format
 

--- a/.claude/skills/presentation/presentation-styling/SKILL.md
+++ b/.claude/skills/presentation/presentation-styling/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: presentation-styling
-description: Knowledge about CSS classes, component patterns, and syntax highlighting in the presentation
+description: Knowledge about the vibe-coding presentation's CSS classes, component patterns (cards, boxes, lists, tags), code-block syntax highlighting spans, and journey bar styling. Preloaded into the presentation-vibe-coding agent — use whenever writing or editing slide HTML/CSS in presentation/vibe-coding-to-agentic-engineering/index.html so new slides match existing styling.
+user-invocable: false
 ---
 
 # Presentation Styling Skill
 
-CSS classes and HTML patterns used in `presentation/index.html`.
+CSS classes and HTML patterns used in `presentation/vibe-coding-to-agentic-engineering/index.html`.
 
 ## CSS Component Classes
 

--- a/.claude/skills/presentation/vibe-to-agentic-framework/SKILL.md
+++ b/.claude/skills/presentation/vibe-to-agentic-framework/SKILL.md
@@ -167,4 +167,4 @@ When creating or modifying slides, consider:
 
 All other slides inherit the level from the last `data-level` attribute set before them. Slides 1–9 (Intro + Prerequisites) have no level and keep the bar hidden until slide 2 shows "Low" (slides 2–9 are below the first level transition at slide 10, so the bar shows empty/zero until slide 10).
 
-**Note:** The main presentation (`presentation/index.html`) caps at **High** level — `data-level="pro"` is not used. The Pro tick mark remains visible on the journey bar as the theoretical ceiling, but the fill never reaches it. The video presentation (`1-video-workflow.html`) caps at **Medium** level.
+**Note:** The main presentation (`presentation/vibe-coding-to-agentic-engineering/index.html`) caps at **High** level — `data-level="pro"` is not used. The Pro tick mark remains visible on the journey bar as the theoretical ceiling, but the fill never reaches it. The video presentation (`1-video-workflow.html`) caps at **Medium** level.


### PR DESCRIPTION
## Summary

An audit of the local `.claude/skills/` files found three defects that degrade skill performance at every invocation:

- **Stale presentation paths** — `presentation-structure`, `presentation-styling`, and `vibe-to-agentic-framework` still referenced `presentation/index.html`, which no longer exists. The deck lives at `presentation/vibe-coding-to-agentic-engineering/index.html`, so the `presentation-vibe-coding` agent (which preloads these skills) was pointed at a missing file.
- **Weak frontmatter descriptions** — the two knowledge skills had one-line descriptions; they now describe what they cover and when to use them, and are marked `user-invocable: false` since they are preloaded agent knowledge, not slash commands.
- **Dead links in `agent-browser`** — the SKILL.md linked 6 `references/*.md` and 3 `templates/*.sh` files that don't exist in the skill directory, breaking progressive disclosure. Replaced with a pointer to `agent-browser --help`.

## Changes

One commit per file, per the repo's commit convention:

1. `.claude/skills/presentation/presentation-structure/SKILL.md` — path fix + richer description
2. `.claude/skills/presentation/presentation-styling/SKILL.md` — path fix + richer description
3. `.claude/skills/presentation/vibe-to-agentic-framework/SKILL.md` — path fix in the level-cap note
4. `.claude/skills/agent-browser/SKILL.md` — removed 9 dead links

## Test plan

- `grep -rn "presentation/index.html" .claude/skills/` returns nothing
- `grep -c "references/\|templates/" .claude/skills/agent-browser/SKILL.md` returns 0
- All SKILL.md frontmatter still parses (single YAML block each)

Generated with [Claude Code](https://claude.ai/code)