### PR TITLE
Daily settings drift check — 2026-07-07 (Claude Code v2.1.202)

### DIFF
--- a/best-practice/claude-settings.md
+++ b/best-practice/claude-settings.md
@@ -1,9 +1,9 @@
 # Settings Best Practice
 
-![Last Updated](https://img.shields.io/badge/Last_Updated-Jul%2006%2C%202026%2010%3A43%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.201-blue?style=flat&labelColor=555)<br>
+![Last Updated](https://img.shields.io/badge/Last_Updated-Jul%2007%2C%202026%2010%3A44%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.202-blue?style=flat&labelColor=555)<br>
 [![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../.claude/settings.json)
 
-A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.201, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
+A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.202, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
 
 <table width="100%">
 <tr>
@@ -900,6 +900,7 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_BRIDGE_SESSION_ID` | Read-only. Set automatically in Bash tool and hook command subprocesses while the session has an active Remote Control connection. Value is the session ID in `session_` form (same identifier in the session's `claude.ai/code` URL). Removed when the connection ends. Allows scripts to link back to the session that ran them. In cloud sessions, read `CLAUDE_CODE_REMOTE_SESSION_ID` instead (v2.1.199) |
 | `CLAUDE_REMOTE_CONTROL_SESSION_NAME_PREFIX` | Prefix for auto-generated Remote Control session names. Defaults to the machine hostname |
 | `CLAUDE_CLIENT_PRESENCE_FILE` | Path to a file that, when present, signals an active client and suppresses mobile push notifications from Remote Control. Useful in environments where a desktop client is always running and mobile pings are unwanted |
+| `CLAUDE_CODE_DISABLE_NOTIFICATION_PRESENCE_CHECK` | Set to `1` to send push notifications even while the user is actively typing in the session. By default, notifications are suppressed when active user presence is detected (v2.1.193) |
 | `CLAUDE_CODE_ENABLE_TELEMETRY` | Enable/disable telemetry (`0` or `1`) |
 | `DISABLE_ERROR_REPORTING` | Disable error reporting (`1` to disable) |
 | `DISABLE_AUTOUPDATER` | Set to `1` to disable automatic update checks against the npm registry. Also configurable as a startup-only var — see [CLI Startup Flags](./claude-cli-startup-flags.md#environment-variables) |
@@ -1041,6 +1042,7 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_SCRIPT_CAPS` | JSON object limiting how many times specific scripts may be invoked per session when `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB` is set. Keys are substrings matched against the command text; values are integer call limits. For example, `{"deploy.sh": 2}` allows `deploy.sh` to be called at most twice. Matching is substring-based; runtime fan-out via `xargs` or `find -exec` is not detected — this is a defense-in-depth control |
 | `CLAUDE_CODE_PERFORCE_MODE` | Set to `1` to enable Perforce-aware write protection. When set, Edit, Write, and NotebookEdit fail with a `p4 edit <file>` hint if the target file lacks the owner-write bit, which Perforce clears on synced files until `p4 edit` opens them. Prevents Claude Code from bypassing Perforce change tracking (v2.1.98) |
 | `CLAUDE_CODE_MAX_RETRIES` | Override API request retry count (default: 10) |
+| `CLAUDE_CODE_RETRY_WATCHDOG` | Raise the retry count for non-capacity API errors to 300. The standard retry cap (`CLAUDE_CODE_MAX_RETRIES`, default: 10) still applies for capacity errors *(in v2.1.199 changelog, not on official env-vars page)* |
 | `CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY` | Max parallel read-only tools (default: 10) |
 | `CLAUDE_AGENT_SDK_DISABLE_BUILTIN_AGENTS` | Disable built-in subagent types in SDK mode (`1` to disable) |
 | `CLAUDE_AGENT_SDK_MCP_NO_PREFIX` | Skip `mcp__<server>__` prefix for MCP tools in SDK mode (`1` to enable) |

--- a/changelog/best-practice/claude-settings/changelog.md
+++ b/changelog/best-practice/claude-settings/changelog.md
@@ -1042,3 +1042,15 @@
 |---|----------|------|--------|--------|
 | 1 | LOW | Suspect Key Resolution | `OTEL_LOG_TOOL_DETAILS` — Rule 10B escalation at 49 consecutive ON HOLD runs: resolved. Variable IS already in report at line 1076 annotated "(in v2.1.85 changelog, not yet on official env-vars page)". Recurring action "Add to env vars table" was a false positive — variable added and annotated in an earlier run. Official /en/env-vars page still does not list it | ❌ INVALID (already in report with correct annotation; no action needed — RECURRING 49 runs) |
 | 2 | LOW | Suspect Key Recurrence | `CLAUDE_CODE_RETRY_WATCHDOG` — still NOT on official env-vars page per Rule 8A and live /en/env-vars verification this run | ✋ ON HOLD (4 consecutive runs; escalation threshold is 5 — recurring from 2026-07-03 v2.1.199) |
+
+---
+
+## [2026-07-07 10:44 AM PKT] Claude Code v2.1.202
+
+| # | Priority | Type | Action | Status |
+|---|----------|------|--------|--------|
+| 1 | HIGH | Version Bump | Update report version badge from v2.1.201 → v2.1.202 and header "As of v2.1.201" → "As of v2.1.202" | ✅ COMPLETE (badge and header updated in Phase 2.6) — NEW |
+| 2 | HIGH | Missing Env Var | Add `CLAUDE_CODE_DISABLE_NOTIFICATION_PRESENCE_CHECK` — set to `1` to send push notifications regardless of active user presence. Confirmed on official /en/env-vars page (v2.1.193). Added after `CLAUDE_CLIENT_PRESENCE_FILE` | ✅ COMPLETE (added after `CLAUDE_CLIENT_PRESENCE_FILE`) — NEW |
+| 3 | HIGH | Suspect Key Resolution (Rule 10B) | `CLAUDE_CODE_RETRY_WATCHDOG` — 5 consecutive ON HOLD runs; Rule 10B escalation threshold reached. Key confirmed in v2.1.199 changelog but NOT on official /en/env-vars page. Resolved by adding with annotation "*(in v2.1.199 changelog, not on official env-vars page)*" after `CLAUDE_CODE_MAX_RETRIES` | ✅ COMPLETE (added with changelog-only annotation) — RECURRING (5 runs) |
+| 4 | LOW | Unconfirmed Setting | "Dynamic workflow size" feature (v2.1.202 changelog) — exact `settings.json` key unconfirmed on official settings page per Rule 8A | ✋ ON HOLD (new; awaiting official settings page confirmation) |
+| 5 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 50+ consecutive runs; entry annotated "(in v2.1.85 changelog, not yet on official env-vars page)" | ✋ ON HOLD (recurring from 2026-04-14 v2.1.107) |


### PR DESCRIPTION
## Summary

Automated daily drift audit of `best-practice/claude-settings.md` against official Claude Code docs (settings page, CLI reference, env-vars page, GitHub CHANGELOG). Audited version: **Claude Code v2.1.202**.

- 3 HIGH action items applied ✅
- 2 LOW items remain ON HOLD (Rule 8A — unconfirmed by official sources)

---

## Verification Log

| Rule | Category | Result |
|------|----------|--------|
| 1A | Key Completeness | ✅ PASS — all settings keys present |
| 1B | Key Types | ✅ PASS |
| 1C | Key Defaults | ✅ PASS |
| 1D | Key Descriptions | ✅ PASS |
| 1E | Scope Column | ✅ PASS |
| 1F | Inverse Completeness | ✅ PASS |
| 1G | Edge-Case Semantics | ✅ PASS |
| 1H | File Scope Check | ✅ PASS |
| 1I | Skills Settings Keys | ✅ PASS — `skillOverrides`, `disableSkillShellExecution`, `maxSkillDescriptionChars`, `skillListingBudgetFraction` all present |
| 2A | Priority Levels | ✅ PASS |
| 2B | File Locations | ✅ PASS |
| 2C | Merge Semantics | ✅ PASS |
| 2D | Managed Internals | ✅ PASS |
| 3A | Permission Modes | ✅ PASS |
| 3B | Tool Syntax Patterns | ✅ PASS |
| 3C | Bidirectional Mode Check | ✅ PASS |
| 3D | Evaluation Semantics | ✅ PASS |
| 4A | Hooks Redirect | ✅ PASS — valid link to `claude-code-hooks` repo |
| **5A** | **Env Var Completeness** | **⚠️ DRIFT** — `CLAUDE_CODE_DISABLE_NOTIFICATION_PRESENCE_CHECK` missing from report; confirmed on official /en/env-vars page |
| 5B | Ownership Boundary | ✅ PASS — no cross-file duplication |
| 5C | Env Var Descriptions | ✅ PASS |
| 5D | Inverse Env Var Check | ✅ PASS |
| 6A | Quick Reference Example | ✅ PASS |
| 6B | Example URL Validation | ✅ PASS — `https://json.schemastore.org/claude-code-settings.json` valid |
| 7A | CLAUDE.md Sync | ✅ PASS |
| 8A | Source Credibility Guard | ✅ PASS — all items confirmed against official sources only |
| 9A | Local File Links | ✅ PASS |
| 9B | External URL Links | ✅ PASS — all 6 external links return valid pages |
| 9C | Anchor Links | ✅ PASS |
| **10A** | **Version Metadata** | **⚠️ DRIFT** — badge/header at v2.1.201; CHANGELOG shows v2.1.202 |
| **10B** | **Suspect Key Escalation** | **⚠️ ACTION** — `CLAUDE_CODE_RETRY_WATCHDOG` at 5 consecutive ON HOLD runs (threshold reached) |
| 10C | Bidirectional Completeness | ✅ PASS |

---

## Action Items

| # | Priority | Type | Action | Status |
|---|----------|------|--------|--------|
| 1 | HIGH | Version Bump | Update report version badge from v2.1.201 → v2.1.202 and header "As of v2.1.201" → "As of v2.1.202" | ✅ COMPLETE — NEW |
| 2 | HIGH | Missing Env Var | Add `CLAUDE_CODE_DISABLE_NOTIFICATION_PRESENCE_CHECK` — set to `1` to send push notifications regardless of active user presence. Confirmed on official /en/env-vars page (v2.1.193). Added after `CLAUDE_CLIENT_PRESENCE_FILE` | ✅ COMPLETE — NEW |
| 3 | HIGH | Suspect Key Resolution (Rule 10B) | `CLAUDE_CODE_RETRY_WATCHDOG` — 5 consecutive ON HOLD runs; escalation threshold reached. Key confirmed in v2.1.199 changelog but NOT on official /en/env-vars page. Resolved by adding with annotation "*(in v2.1.199 changelog, not on official env-vars page)*" after `CLAUDE_CODE_MAX_RETRIES` | ✅ COMPLETE — RECURRING (5 runs) |
| 4 | LOW | Unconfirmed Setting | "Dynamic workflow size" feature (v2.1.202 changelog) — exact `settings.json` key unconfirmed on official settings page per Rule 8A | ✋ ON HOLD — NEW |
| 5 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 50+ consecutive runs; annotated "(in v2.1.85 changelog, not yet on official env-vars page)" | ✋ ON HOLD — RECURRING |

---

## Changes Made

**`best-practice/claude-settings.md`** (4 changes):
1. Badge updated: `Last_Updated-Jul%2007%2C%202026%2010%3A44%20AM%20PKT` + version `v2.1.202`
2. Header updated: "As of v2.1.202"
3. Added `CLAUDE_CODE_DISABLE_NOTIFICATION_PRESENCE_CHECK` after `CLAUDE_CLIENT_PRESENCE_FILE`
4. Added `CLAUDE_CODE_RETRY_WATCHDOG` after `CLAUDE_CODE_MAX_RETRIES` (with changelog-only annotation)

**`changelog/best-practice/claude-settings/changelog.md`** (1 entry appended):
- New entry: `[2026-07-07 10:44 AM PKT] Claude Code v2.1.202` — 5 items (3 COMPLETE, 2 ON HOLD)

---

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01BouTbQktQBJkomz7HBf3jM

---
_Generated by [Claude Code](https://claude.ai/code/session_01BouTbQktQBJkomz7HBf3jM)_