### PR TITLE
Daily settings drift check — 2026-07-08 (Claude Code v2.1.204)

### DIFF
--- a/best-practice/claude-settings.md
+++ b/best-practice/claude-settings.md
@@ -1,9 +1,9 @@
 # Settings Best Practice
 
-![Last Updated](https://img.shields.io/badge/Last_Updated-Jul%2007%2C%202026%2010%3A44%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.202-blue?style=flat&labelColor=555)<br>
+![Last Updated](https://img.shields.io/badge/Last_Updated-Jul%2008%2C%202026%2010%3A46%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.204-blue?style=flat&labelColor=555)<br>
 [![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../.claude/settings.json)
 
-A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.202, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
+A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.204, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
 
 <table width="100%">
 <tr>
@@ -964,7 +964,7 @@ Set environment variables for all Claude Code sessions.
 | `ENABLE_CLAUDEAI_MCP_SERVERS` | Enable Claude.ai MCP servers |
 | `CLAUDE_CODE_EFFORT_LEVEL` | Set effort level: `low`, `medium`, `high`, `xhigh` (Opus 4.7 and 4.8, v2.1.111), `max` (Opus 4.6 only), or `auto` (use model default). Takes precedence over `/effort` and the `effortLevel` setting. Also configurable as a startup-only var — see [CLI Startup Flags](./claude-cli-startup-flags.md#environment-variables) |
 | `CLAUDE_EFFORT` | Read-only. Injected into Bash tool subprocesses and hook handlers with the active effort level so shell scripts and hooks can adapt to the current tier (companion to `CLAUDE_CODE_EFFORT_LEVEL`; v2.1.133). Inside skill files use `${CLAUDE_EFFORT}` *(in changelog, not on official env-vars page — read-only, not user-configurable)* |
-| `CLAUDE_CODE_ALWAYS_ENABLE_EFFORT` | Set to `1` to force-enable the effort parameter on all models, even those that do not normally support effort-level selection. Allows `/effort` and the `effortLevel` setting to take effect on models outside the standard effort-capable set (v2.1.154) *(in v2.1.154 changelog, not yet on official env-vars page)* |
+| `CLAUDE_CODE_ALWAYS_ENABLE_EFFORT` | Set to `1` to force-enable the effort parameter on all models, even those that do not normally support effort-level selection. Allows `/effort` and the `effortLevel` setting to take effect on models outside the standard effort-capable set (v2.1.154) |
 | `CLAUDE_CODE_MAX_TURNS` | Maximum agentic turns before stopping *(not in official docs — unverified)* |
 | `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` | Equivalent of setting `DISABLE_AUTOUPDATER`, `DISABLE_FEEDBACK_COMMAND`, `DISABLE_ERROR_REPORTING`, and `DISABLE_TELEMETRY` |
 | `CLAUDE_CODE_SKIP_SETTINGS_SETUP` | Skip first-run settings setup flow *(not in official docs — unverified)* |

--- a/changelog/best-practice/claude-settings/changelog.md
+++ b/changelog/best-practice/claude-settings/changelog.md
@@ -1054,3 +1054,15 @@
 | 3 | HIGH | Suspect Key Resolution (Rule 10B) | `CLAUDE_CODE_RETRY_WATCHDOG` — 5 consecutive ON HOLD runs; Rule 10B escalation threshold reached. Key confirmed in v2.1.199 changelog but NOT on official /en/env-vars page. Resolved by adding with annotation "*(in v2.1.199 changelog, not on official env-vars page)*" after `CLAUDE_CODE_MAX_RETRIES` | ✅ COMPLETE (added with changelog-only annotation) — RECURRING (5 runs) |
 | 4 | LOW | Unconfirmed Setting | "Dynamic workflow size" feature (v2.1.202 changelog) — exact `settings.json` key unconfirmed on official settings page per Rule 8A | ✋ ON HOLD (new; awaiting official settings page confirmation) |
 | 5 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 50+ consecutive runs; entry annotated "(in v2.1.85 changelog, not yet on official env-vars page)" | ✋ ON HOLD (recurring from 2026-04-14 v2.1.107) |
+
+---
+
+## [2026-07-08 10:46 AM PKT] Claude Code v2.1.204
+
+| # | Priority | Type | Action | Status |
+|---|----------|------|--------|--------|
+| 1 | HIGH | Version Bump | Update report version badge from v2.1.202 → v2.1.204 and header "As of v2.1.202" → "As of v2.1.204" | ✅ COMPLETE (badge and header updated in Phase 2.6) — NEW |
+| 2 | MED | Stale Annotation | Remove "(in v2.1.154 changelog, not yet on official env-vars page)" from `CLAUDE_CODE_ALWAYS_ENABLE_EFFORT` — confirmed on official /en/env-vars page | ✅ COMPLETE (annotation removed) — NEW |
+| 3 | LOW | Unconfirmed Setting | "Dynamic workflow size" feature (v2.1.202 changelog) — exact `settings.json` key unconfirmed on official settings page per Rule 8A | ✋ ON HOLD (RECURRING from 2026-07-07 v2.1.202; exact key not found on official settings page) |
+| 4 | LOW | Suspect Key Recurrence | `CLAUDE_CODE_RETRY_WATCHDOG` — still NOT on official /en/env-vars page; entry annotated "*(in v2.1.199 changelog, not on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-07-03 v2.1.199; not yet on official page) |
+| 5 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 51+ consecutive runs; entry annotated "*(in v2.1.85 changelog, not yet on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-04-14 v2.1.107; 51+ consecutive runs) |


### PR DESCRIPTION
## Summary

Automated daily drift check against the official Claude Code settings documentation. Audited last 10 versions (v2.1.195–v2.1.204). Two drift items confirmed and fixed; three items remain ON HOLD pending official documentation confirmation.

---

## Verification Log

| Rule | Category | Depth | Result | Notes |
|------|----------|-------|--------|-------|
| 1A | Key Completeness | field-level | PASS | All keys from official settings page present |
| 1B | Key Types | content-match | PASS | No type mismatches |
| 1C | Key Defaults | content-match | PASS | Defaults match official docs |
| 1D | Key Descriptions | content-match | PASS | Descriptions accurate |
| 1E | Scope Column | content-match | PASS | Scopes verified |
| 1F | Inverse Completeness | field-level | PASS | All report keys have official backing or annotation |
| 1G | Edge-Case Semantics | content-match | PASS | Boundary values documented |
| 1H | File Scope Check | content-match | PASS | Settings in correct scope files |
| 1I | Skills Settings Keys | field-level | PASS | `maxSkillDescriptionChars`, `skillListingBudgetFraction` present |
| 2A–2D | Settings Hierarchy | field-level | PASS | 5-level chain + managed tier accurate |
| 3A–3D | Permissions | field-level | PASS | All 6 modes, tool syntax, evaluation order accurate |
| 4A | Hooks Redirect | exists | PASS | Redirect link to `claude-code-hooks` present at line 368 |
| 5A | Env Var Completeness | field-level | PASS (after fix) | `CLAUDE_CODE_ALWAYS_ENABLE_EFFORT` annotation removed |
| 5B | Ownership Boundary | cross-file | PASS | No env var duplication between files |
| 5C | Env Var Descriptions | content-match | PASS | Descriptions accurate |
| 5D | Inverse Env Var Check | field-level | PASS | All unverified vars annotated |
| 6A–6B | Examples | content-match | PASS | Quick Reference valid; `$schema` URL resolves correctly |
| 7A | CLAUDE.md Sync | cross-file | PASS | Consistent |
| 8A | Source Credibility | content-match | PASS | Applied throughout; no third-party-only findings |
| 9A | Local File Links | exists | PASS | `../.claude/settings.json`, `./claude-cli-startup-flags.md` resolve |
| 9B | External URL Links | exists | PASS | All key external URLs load; `json.schemastore.org` redirects (→ `www.schemastore.org`, resolves OK) |
| 9C | Anchor Links | exists | PASS | All 13 anchors verified against headings |
| 10A | Version Metadata | content-match | PASS (after fix) | Badge and header updated v2.1.202 → v2.1.204 |
| 10B | Suspect Key Escalation | exists | PASS | `OTEL_LOG_TOOL_DETAILS` already annotated in report; no new escalation needed |
| 10C | Bidirectional Completeness | field-level | PASS | All keys traceable to official source or annotated |

---

## Changes Made

### 1. Version bump: v2.1.202 → v2.1.204 (HIGH — COMPLETE)

Updated the `Last Updated` badge, `Version` badge, and header line in `best-practice/claude-settings.md`:
- Badge: `Jul 08, 2026 10:46 AM PKT` / `v2.1.204`
- Header: `As of v2.1.204, Claude Code exposes 80+ settings and 200+ environment variables`

### 2. Remove stale annotation from `CLAUDE_CODE_ALWAYS_ENABLE_EFFORT` (MED — COMPLETE)

Removed `*(in v2.1.154 changelog, not yet on official env-vars page)*` — confirmed present on the official `/en/env-vars` page as of this run.

---

## ON HOLD Items (no changes made)

| # | Item | Consecutive Runs | Status |
|---|------|-----------------|--------|
| 3 | "Dynamic workflow size" — `settings.json` key from v2.1.202 changelog not found on official settings page | 2 | ON HOLD per Rule 8A |
| 4 | `CLAUDE_CODE_RETRY_WATCHDOG` — in report with changelog annotation; not yet on official `/en/env-vars` page | Recurring since 2026-07-03 | ON HOLD per Rule 8A |
| 5 | `OTEL_LOG_TOOL_DETAILS` — in report with changelog annotation; not yet on official `/en/env-vars` page | 51+ runs | ON HOLD per Rule 8A |

---

## Hyperlink Validation Summary

All links valid. Key results:
- Local: `../.claude/settings.json` ✅ · `./claude-cli-startup-flags.md` ✅
- Anchors: all 13 internal anchors resolve ✅
- External: `code.claude.com/docs/en/settings` ✅ · `code.claude.com/docs/en/env-vars` ✅ · `code.claude.com/docs/en/permissions` ✅
- `json.schemastore.org/claude-code-settings.json` → 301 redirect to `www.schemastore.org` (resolves OK) ✅
- `github.com/shanraisshan/claude-code-hooks` ✅ · `github.com/feiskyer/claude-code-settings` ✅

---

*Generated by the daily settings drift workflow. Do not merge — leave for human review.*

---
_Generated by [Claude Code](https://claude.ai/code/session_01X9t4U91WvQ8TUZmZSMdPNq)_