### PR TITLE
Daily settings drift check — 2026-07-10 (Claude Code v2.1.206)

### DIFF
--- a/best-practice/claude-settings.md
+++ b/best-practice/claude-settings.md
@@ -1,9 +1,9 @@
 # Settings Best Practice
 
-![Last Updated](https://img.shields.io/badge/Last_Updated-Jul%2009%2C%202026%2010%3A47%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.205-blue?style=flat&labelColor=555)<br>
+![Last Updated](https://img.shields.io/badge/Last_Updated-Jul%2010%2C%202026%2010%3A48%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.206-blue?style=flat&labelColor=555)<br>
 [![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../.claude/settings.json)
 
-A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.205, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
+A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.206, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
 
 <table width="100%">
 <tr>
@@ -915,7 +915,7 @@ Set environment variables for all Claude Code sessions.
 | `MAX_MCP_OUTPUT_TOKENS` | Max MCP output tokens (default: 25000). Warning displayed when output exceeds 10,000 tokens |
 | `API_TIMEOUT_MS` | Timeout in ms for API requests (default: 600000) |
 | `API_FORCE_IDLE_TIMEOUT` | Override the 5-minute idle timeout for streaming connections. Set to `0` to disable the idle timeout entirely, `1` to enforce it on all connections, or leave unset for the default (auto-enabled on slow or unreliable gateways that frequently stall). Useful for slow API gateways (v2.1.169) |
-| `CLAUDE_CODE_CONNECT_TIMEOUT_MS` | Timeout in milliseconds for the connect, TLS, and response-header phase of a streaming API request (default: `60000` / 60 seconds). If no response headers arrive within this window, the request is aborted and retried. Set to `0` to disable and rely on `API_TIMEOUT_MS` alone |
+| ~~`CLAUDE_CODE_CONNECT_TIMEOUT_MS`~~ | **REMOVED in v2.1.186.** Previously controlled the connect, TLS, and response-header phase timeout of streaming API requests (default 60 s). Use `API_TIMEOUT_MS` or `API_FORCE_IDLE_TIMEOUT` instead |
 | `CLAUDE_AFK_TIMEOUT_MS` | How many milliseconds before an unanswered AskUserQuestion dialog auto-continues, when `askUserQuestionTimeout` is set to a duration. As of v2.1.200, the default is `"never"` (no auto-continue) controlled by `askUserQuestionTimeout`; this env var applies only when a timeout duration is active. Setting to `0` closes the dialog immediately. To keep questions open, prefer `askUserQuestionTimeout: "never"` (v2.1.198; default changed v2.1.200) |
 | `CLAUDE_AFK_COUNTDOWN_MS` | How many milliseconds before auto-continue the on-screen countdown appears on an unanswered AskUserQuestion dialog (default: `20000` / 20 seconds) (v2.1.198) |
 | `BASH_MAX_TIMEOUT_MS` | Bash command timeout |
@@ -924,7 +924,7 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_MAX_CONTEXT_TOKENS` | Override the context window size Claude Code assumes for the active model. Only takes effect when `DISABLE_COMPACT` is also set. Use when routing to a model through `ANTHROPIC_BASE_URL` whose context window does not match the built-in size for its name |
 | `CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR` | Keep cwd between bash calls (`1` to enable) |
 | `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS` | Disable background tasks (`1` to disable) |
-| `CLAUDE_CODE_DISABLE_BG_SHELL_PRESSURE_REAP` | Set to `1` to disable automatic memory-pressure reaping of idle background shell commands. When unset, Claude Code automatically reaps idle background shells under memory pressure to free resources (v2.1.193 changelog, not yet on official env-vars page) |
+| `CLAUDE_CODE_DISABLE_BG_SHELL_PRESSURE_REAP` | Set to `1` to disable automatic memory-pressure reaping of idle background shell commands. When unset, Claude Code automatically reaps idle background shells under memory pressure to free resources (v2.1.193) |
 | `CLAUDE_CODE_DISABLE_BG_EXIT_HANDOFF` | Set to `1` to stop a background session's running background shell commands, dynamic workflows, and background subagents when the supervisor stops, restarts, or updates that session's process. By default they are handed off to the session's next process (v2.1.198) |
 | `CLAUDE_CODE_DISABLE_ADVISOR_TOOL` | Set to `1` to disable the advisor tool and the `/advisor` command. Env-var equivalent of omitting advisor usage. Pair with `advisorModel` for advisor configuration (min v2.1.98) |
 | `CLAUDE_CODE_DISABLE_AGENT_VIEW` | Set to `1` to turn off background agents and agent view (`claude agents`, `--bg`, `/background`, on-demand supervisor). Env-var equivalent of the `disableAgentView` setting *(referenced on official settings page; not listed on the env-vars page)* |
@@ -994,6 +994,7 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_EXTRA_BODY` | JSON object to merge into the top level of every API request body. Use to inject vendor-specific fields (e.g., routing hints for a custom gateway) |
 | `CLAUDE_CODE_PROPAGATE_TRACEPARENT` | Set to `1` to propagate the W3C `traceparent` header through requests when routing through a custom proxy, linking Claude Code traces to your upstream telemetry |
 | `ANTHROPIC_FOUNDRY_API_KEY` | API key for Microsoft Foundry authentication |
+| `ANTHROPIC_FOUNDRY_AUTH_TOKEN` | Bearer token for Microsoft Foundry authentication. Takes precedence over `ANTHROPIC_FOUNDRY_API_KEY` when set |
 | `ANTHROPIC_FOUNDRY_BASE_URL` | Base URL for Foundry resource |
 | `ANTHROPIC_FOUNDRY_RESOURCE` | Foundry resource name |
 | `AWS_BEARER_TOKEN_BEDROCK` | Bedrock API key for authentication |
@@ -1043,7 +1044,7 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_SCRIPT_CAPS` | JSON object limiting how many times specific scripts may be invoked per session when `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB` is set. Keys are substrings matched against the command text; values are integer call limits. For example, `{"deploy.sh": 2}` allows `deploy.sh` to be called at most twice. Matching is substring-based; runtime fan-out via `xargs` or `find -exec` is not detected — this is a defense-in-depth control |
 | `CLAUDE_CODE_PERFORCE_MODE` | Set to `1` to enable Perforce-aware write protection. When set, Edit, Write, and NotebookEdit fail with a `p4 edit <file>` hint if the target file lacks the owner-write bit, which Perforce clears on synced files until `p4 edit` opens them. Prevents Claude Code from bypassing Perforce change tracking (v2.1.98) |
 | `CLAUDE_CODE_MAX_RETRIES` | Override API request retry count (default: 10) |
-| `CLAUDE_CODE_RETRY_WATCHDOG` | Raise the retry count for non-capacity API errors to 300. The standard retry cap (`CLAUDE_CODE_MAX_RETRIES`, default: 10) still applies for capacity errors *(in v2.1.199 changelog, not on official env-vars page)* |
+| `CLAUDE_CODE_RETRY_WATCHDOG` | Raise the retry count for non-capacity API errors to 300. The standard retry cap (`CLAUDE_CODE_MAX_RETRIES`, default: 10) still applies for capacity errors (v2.1.199) |
 | `CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY` | Max parallel read-only tools (default: 10) |
 | `CLAUDE_AGENT_SDK_DISABLE_BUILTIN_AGENTS` | Disable built-in subagent types in SDK mode (`1` to disable) |
 | `CLAUDE_AGENT_SDK_MCP_NO_PREFIX` | Skip `mcp__<server>__` prefix for MCP tools in SDK mode (`1` to enable) |
@@ -1061,7 +1062,7 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_SCROLL_SPEED` | Mouse wheel scroll multiplier for fullscreen rendering. Increase for faster scrolling, decrease for finer control |
 | `CLAUDE_CODE_DISABLE_VIRTUAL_SCROLL` | Set to `1` to disable virtual scrolling in fullscreen rendering and render every message in the transcript. Use if scrolling in fullscreen mode shows blank regions where messages should appear |
 | `CLAUDE_CODE_DISABLE_MOUSE` | Set to `1` to disable mouse tracking in fullscreen rendering. Useful when mouse events interfere with terminal multiplexers or accessibility tools |
-| `CLAUDE_CODE_DISABLE_MOUSE_CLICKS` | Set to `1` to disable mouse click interactions in fullscreen rendering while preserving wheel scroll. Distinguishes click-event suppression from full mouse tracking disable (`CLAUDE_CODE_DISABLE_MOUSE`). Useful when terminal selection or external accessibility tools conflict with in-app mouse clicks *(in v2.1.195 changelog, not yet on official env-vars page)* |
+| `CLAUDE_CODE_DISABLE_MOUSE_CLICKS` | Set to `1` to disable mouse click interactions in fullscreen rendering while preserving wheel scroll. Distinguishes click-event suppression from full mouse tracking disable (`CLAUDE_CODE_DISABLE_MOUSE`). Useful when terminal selection or external accessibility tools conflict with in-app mouse clicks (v2.1.195) |
 | `CLAUDE_CODE_HIDE_CWD` | Set to `1` to hide the current working directory in the Claude Code startup logo banner. Useful in screen recordings, demos, or shared sessions where the CWD path leaks information about the host or project layout (v2.1.119) |
 | `CLAUDE_CODE_ACCESSIBILITY` | Set to `1` to keep native terminal cursor visible for screen readers and accessibility tools |
 | `CLAUDE_AX_SCREEN_READER` | Set to `1` to render screen-reader friendly output: flat text without decorative borders or animations. Set to `0` to force screen-reader mode off even when the `axScreenReader` setting is `true`. The `--ax-screen-reader` CLI flag takes precedence (v2.1.181+) |
@@ -1080,7 +1081,7 @@ Set environment variables for all Claude Code sessions.
 | `OTEL_LOG_RAW_API_BODIES` | Set to `1` to emit full API request and response bodies as OpenTelemetry log events. Omitted by default for privacy and payload size. Useful for debugging at a gateway or proxy *(in v2.1.111 changelog, not yet on official env-vars page)* |
 | `OTEL_RESOURCE_ATTRIBUTES` | Comma-separated `key=value` pairs added as resource attributes on all OpenTelemetry metric data points emitted by Claude Code. Use to attach environment or deployment labels (e.g., `environment=production,team=platform`) that appear on every metric for filtering in your collector (v2.1.162) |
 | `OTEL_LOG_USER_PROMPTS` | Set to `1` to include the `user_system_prompt` field in OpenTelemetry LLM request spans. Omitted by default for privacy — user prompts can contain sensitive data, so opt in only when you control the OTel collector and have policies in place *(in v2.1.121 changelog, not yet on official env-vars page)* |
-| `OTEL_LOG_ASSISTANT_RESPONSES` | Set to `1` to include model response text in OpenTelemetry log events. Omitted by default for privacy and payload size. Use only when you control the OTel collector and have policies for handling model output *(in v2.1.193 changelog, not yet on official env-vars page)* |
+| `OTEL_LOG_ASSISTANT_RESPONSES` | Set to `1` to include model response text in OpenTelemetry log events. Omitted by default for privacy and payload size. Use only when you control the OTel collector and have policies for handling model output (v2.1.193) |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | OpenTelemetry collector endpoint URL for metrics and logs. See [Monitoring](https://code.claude.com/docs/en/monitoring-usage) |
 | `OTEL_EXPORTER_OTLP_HEADERS` | OpenTelemetry exporter headers (`Name=Value` format, comma-separated) for authenticating with your collector |
 | `OTEL_LOG_TOOL_CONTENT` | Set to `1` to emit full tool inputs and outputs as OpenTelemetry log events. Omitted by default for privacy |

--- a/changelog/best-practice/claude-settings/changelog.md
+++ b/changelog/best-practice/claude-settings/changelog.md
@@ -1077,3 +1077,18 @@
 | 2 | HIGH | MCP Setting Change | Update reserved MCP server names callout (line ~382) to add `Claude Browser` and `Claude Preview` alongside existing `workspace`. Confirmed on official settings page and v2.1.205 changelog | ✅ COMPLETE (callout updated to list all three reserved names) — NEW |
 | 3 | LOW | Suspect Key Recurrence | `CLAUDE_CODE_RETRY_WATCHDOG` — still NOT on official /en/env-vars page; entry annotated "*(in v2.1.199 changelog, not on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-07-03 v2.1.199; not yet on official page) |
 | 4 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 52+ consecutive runs; entry annotated "*(in v2.1.85 changelog, not yet on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-04-14 v2.1.107; 52+ consecutive runs) |
+
+---
+
+## [2026-07-10 10:48 AM PKT] Claude Code v2.1.206
+
+| # | Priority | Type | Action | Status |
+|---|----------|------|--------|--------|
+| 1 | HIGH | Version Bump | Update report version badge v2.1.205 → v2.1.206 and header "As of v2.1.205" → "As of v2.1.206" | ✅ COMPLETE (badge and header updated in Phase 2.6) — NEW |
+| 2 | HIGH | Changed Behavior | Mark `CLAUDE_CODE_CONNECT_TIMEOUT_MS` as REMOVED in v2.1.186 per official /en/env-vars page; strikethrough name, replace description with pointer to `API_TIMEOUT_MS` / `API_FORCE_IDLE_TIMEOUT` | ✅ COMPLETE (marked REMOVED in env vars table) — RECURRING (added 2026-06-21 v2.1.185 #2; removed in v2.1.186) |
+| 3 | MED | Missing Env Var | Add `ANTHROPIC_FOUNDRY_AUTH_TOKEN` — bearer token for Microsoft Foundry; takes precedence over `ANTHROPIC_FOUNDRY_API_KEY`; confirmed on official /en/env-vars page | ✅ COMPLETE (added after `ANTHROPIC_FOUNDRY_API_KEY`) — NEW |
+| 4 | MED | Stale Annotation | Remove "not yet on official env-vars page" annotation from `CLAUDE_CODE_DISABLE_BG_SHELL_PRESSURE_REAP` — now confirmed on official /en/env-vars page | ✅ COMPLETE (annotation removed; version note retained as "(v2.1.193)") — RECURRING (first annotated 2026-06-26 v2.1.193 #4) |
+| 5 | MED | Stale Annotation | Remove "not on official env-vars page" annotation from `CLAUDE_CODE_RETRY_WATCHDOG` — now confirmed on official /en/env-vars page | ✅ COMPLETE (annotation removed; version note retained as "(v2.1.199)") — RECURRING (first seen 2026-07-03 v2.1.199 #9; Rule 10B escalation resolved) |
+| 6 | MED | Stale Annotation | Remove "not yet on official env-vars page" annotation from `CLAUDE_CODE_DISABLE_MOUSE_CLICKS` — now confirmed on official /en/env-vars page | ✅ COMPLETE (annotation removed; version note retained as "(v2.1.195)") — RECURRING (first annotated 2026-06-29 v2.1.195 #1) |
+| 7 | MED | Stale Annotation | Remove "not yet on official env-vars page" annotation from `OTEL_LOG_ASSISTANT_RESPONSES` — now confirmed on official /en/env-vars page | ✅ COMPLETE (annotation removed; version note retained as "(v2.1.193)") — RECURRING (first annotated 2026-06-26 v2.1.193 #6) |
+| 8 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 53+ consecutive runs; entry annotated "*(in v2.1.85 changelog, not yet on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-04-14 v2.1.107; 53+ consecutive runs) |


### PR DESCRIPTION
## Summary

Automated daily drift check against official Claude Code docs for **v2.1.206**. All changes confirmed against `code.claude.com/docs/en/settings` and `code.claude.com/docs/en/env-vars` per Rule 8A (source credibility guard).

---

## Drift Findings (v2.1.205 → v2.1.206)

### 1. New Settings Keys
No new `settings.json` keys found for v2.1.206.

### 2. Changed Setting Behavior
No changed setting behavior for v2.1.206.

### 3. Deprecated / Removed Settings
| Variable | Change |
|----------|--------|
| `CLAUDE_CODE_CONNECT_TIMEOUT_MS` | **REMOVED in v2.1.186** per official env-vars page. Entry now shows strikethrough with pointer to `API_TIMEOUT_MS` / `API_FORCE_IDLE_TIMEOUT`. Was added to the report in the v2.1.185 run. |

### 4. Missing Environment Variable
| Variable | Description | Confirmed |
|----------|-------------|-----------|
| `ANTHROPIC_FOUNDRY_AUTH_TOKEN` | Bearer token for Microsoft Foundry auth; takes precedence over `ANTHROPIC_FOUNDRY_API_KEY` | official /en/env-vars page |

### 5. Stale Annotations Resolved
Four env vars previously annotated "not yet on official env-vars page" are now confirmed on the official page — annotations removed:

| Variable | First Annotated | Version Added |
|----------|----------------|---------------|
| `CLAUDE_CODE_DISABLE_BG_SHELL_PRESSURE_REAP` | 2026-06-26 v2.1.193 run | v2.1.193 |
| `CLAUDE_CODE_RETRY_WATCHDOG` | 2026-07-03 v2.1.199 run | v2.1.199 |
| `CLAUDE_CODE_DISABLE_MOUSE_CLICKS` | 2026-06-29 v2.1.195 run | v2.1.195 |
| `OTEL_LOG_ASSISTANT_RESPONSES` | 2026-06-26 v2.1.193 run | v2.1.193 |

### 6. Recurring Suspects
| Variable | Status | Run Count |
|----------|--------|-----------|
| `OTEL_LOG_TOOL_DETAILS` | Still NOT on official /en/env-vars page; annotation retained | 53+ consecutive runs ON HOLD |

---

## Verification Log

| Rule | Category | Depth | Result | Notes |
|------|----------|-------|--------|-------|
| 1A | Key Completeness | field-level | PASS | No new settings keys missing |
| 1B | Key Types | content-match | PASS | |
| 1C | Key Defaults | content-match | PASS | |
| 1D | Key Descriptions | content-match | PASS | CONNECT_TIMEOUT_MS now correctly marked REMOVED |
| 1E | Scope Column | content-match | PASS | |
| 1F | Inverse Completeness | field-level | PASS | All keys annotated or traceable |
| 1G | Edge-Case Semantics | content-match | PASS | |
| 1H | File Scope Check | content-match | PASS | |
| 1I | Skills Settings Keys | field-level | PASS | `maxSkillDescriptionChars`, `skillListingBudgetFraction` present |
| 2A | Priority Levels | field-level | PASS | 5-level chain + managed intact |
| 2B | File Locations | content-match | PASS | |
| 2C | Merge Semantics | content-match | PASS | |
| 2D | Managed Internals | field-level | PASS | |
| 3A | Permission Modes | field-level | PASS | |
| 3B | Tool Syntax Patterns | content-match | PASS | |
| 3C | Bidirectional Mode Check | field-level | PASS | |
| 3D | Evaluation Semantics | content-match | PASS | |
| 4A | Hooks Redirect | exists | PASS | Redirect to claude-code-hooks repo present |
| 5A | Env Var Completeness | field-level | FAIL → FIXED | `ANTHROPIC_FOUNDRY_AUTH_TOKEN` was missing; added this run |
| 5B | Ownership Boundary | cross-file | PASS | `CLAUDE_CODE_SAFE_MODE` confirmed out-of-scope (CLI flags file) |
| 5C | Env Var Descriptions | content-match | FAIL → FIXED | REMOVED var corrected; 4 stale annotations cleaned |
| 5D | Inverse Env Var Check | field-level | PASS | All vars annotated or on official page |
| 6A | Quick Reference Example | content-match | PASS | |
| 6B | Example URL Validation | exists | PASS | `json.schemastore.org` schema URL returns 301→valid content |
| 7A | CLAUDE.md Sync | cross-file | PASS | |
| 8A | Source Credibility Guard | content-match | PASS | All findings verified against official docs only |
| 9A | Local File Links | exists | PASS | `../.claude/settings.json` exists |
| 9B | External URL Links | exists | PASS | All `code.claude.com` links validated; GitHub CHANGELOG reachable |
| 9C | Anchor Links | exists | PASS | Internal anchors verified |
| 10A | Version Metadata | content-match | FAIL → FIXED | Badge bumped v2.1.205 → v2.1.206 |
| 10B | Suspect Key Escalation | exists | PASS | `OTEL_LOG_TOOL_DETAILS` at 53+ runs (annotated, no escalation needed); RETRY_WATCHDOG resolved |
| 10C | Bidirectional Completeness | field-level | PASS | |

---

## Hyperlink Validation Log (Phase 2.7)

| # | Type | Link | Status |
|---|------|------|--------|
| 1 | Local | `../.claude/settings.json` | OK |
| 2 | External | `https://code.claude.com/docs/en/settings` | OK |
| 3 | External | `https://code.claude.com/docs/en/env-vars` | OK |
| 4 | External | `https://code.claude.com/docs/en/permissions` | OK |
| 5 | External | `https://code.claude.com/docs/en/artifacts` | OK |
| 6 | External | `https://code.claude.com/docs/en/monitoring-usage` | OK |
| 7 | External | `https://json.schemastore.org/claude-code-settings.json` | OK (301 → www.schemastore.org, valid) |
| 8 | External | `https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md` | OK |
| 9 | External | `https://github.com/shanraisshan/claude-code-hooks` | OK |

---

## Action Items

| # | Priority | Type | Action | Status |
|---|----------|------|--------|--------|
| 1 | HIGH | Version Bump | Badge + header v2.1.205 → v2.1.206 | ✅ COMPLETE |
| 2 | HIGH | Changed Behavior | `CLAUDE_CODE_CONNECT_TIMEOUT_MS` marked REMOVED in v2.1.186 | ✅ COMPLETE |
| 3 | MED | Missing Env Var | Added `ANTHROPIC_FOUNDRY_AUTH_TOKEN` | ✅ COMPLETE |
| 4 | MED | Stale Annotation | Removed annotation from `CLAUDE_CODE_DISABLE_BG_SHELL_PRESSURE_REAP` | ✅ COMPLETE |
| 5 | MED | Stale Annotation | Removed annotation from `CLAUDE_CODE_RETRY_WATCHDOG` | ✅ COMPLETE |
| 6 | MED | Stale Annotation | Removed annotation from `CLAUDE_CODE_DISABLE_MOUSE_CLICKS` | ✅ COMPLETE |
| 7 | MED | Stale Annotation | Removed annotation from `OTEL_LOG_ASSISTANT_RESPONSES` | ✅ COMPLETE |
| 8 | LOW | Suspect Key | `OTEL_LOG_TOOL_DETAILS` — 53+ runs ON HOLD, annotation retained | ✋ ON HOLD |

## Resolved Since Last Run (v2.1.205)
- `CLAUDE_CODE_RETRY_WATCHDOG` annotation (ON HOLD since v2.1.199) — now confirmed on official page; annotation removed this run

---

*Automated by `workflows:best-practice:workflow-claude-settings` — do not merge without human review.*

---
_Generated by [Claude Code](https://claude.ai/code/session_019aM5nvwd8AyyPa1BRnbUVt)_