### PR TITLE
chore(commands): no-drift run v2.1.206 — badge + changelog update

### DIFF
--- a/best-practice/claude-commands.md
+++ b/best-practice/claude-commands.md
@@ -1,6 +1,6 @@
 # Commands Best Practice
 
-![Last Updated](https://img.shields.io/badge/Last_Updated-Jul%2009%2C%202026%2011%3A08%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.205-blue?style=flat&labelColor=555)<br>
+![Last Updated](https://img.shields.io/badge/Last_Updated-Jul%2010%2C%202026%2011%3A09%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.206-blue?style=flat&labelColor=555)<br>
 [![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../implementation/claude-commands-implementation.md)
 
 Claude Code commands — frontmatter fields and official built-in slash commands.

--- a/changelog/best-practice/claude-commands/changelog.md
+++ b/changelog/best-practice/claude-commands/changelog.md
@@ -617,3 +617,9 @@ No priority action items — report is fully in sync with official documentation
 ## [2026-07-09 11:08 AM PKT] Claude Code v2.1.205
 
 No priority action items — report is fully in sync with official documentation (16 frontmatter fields, 86 built-in commands).
+
+---
+
+## [2026-07-10 11:09 AM PKT] Claude Code v2.1.206
+
+No priority action items — report is fully in sync with official documentation (16 frontmatter fields, 86 built-in commands).


### PR DESCRIPTION
## Summary

- No frontmatter or command drift found against official docs at v2.1.206 (16 fields, 86 commands remain in sync)
- Bumped `Last Updated` badge from Jul 09 → Jul 10, 2026 and version badge from v2.1.205 → v2.1.206 in `best-practice/claude-commands.md`
- Appended a no-drift changelog entry for 2026-07-10 11:09 AM PKT to `changelog/best-practice/claude-commands/changelog.md`

## Research findings

The research agent checked 10 versions (v2.1.197–v2.1.206) and the live slash-commands reference page:

| Check | Result |
|-------|--------|
| Frontmatter fields | ✅ 16/16 match — no additions or removals |
| Built-in commands | ✅ 86/86 match — no additions, removals, or tag changes |
| Version bump | v2.1.205 → v2.1.206 (one patch; no command changes in release) |

One informational note: `/doctor` was reclassified internally as a bundled skill in v2.1.205 but remains typable as a first-class command; no table change needed per the report's existing scoping stance.

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01As8ePy7hyJkZxWKsaPg27K

---
_Generated by [Claude Code](https://claude.ai/code/session_01As8ePy7hyJkZxWKsaPg27K)_