### PR TITLE
Daily settings drift check — 2026-07-11 (Claude Code v2.1.207)

### DIFF
--- a/best-practice/claude-settings.md
+++ b/best-practice/claude-settings.md
@@ -1,9 +1,9 @@
 # Settings Best Practice
 
-![Last Updated](https://img.shields.io/badge/Last_Updated-Jul%2009%2C%202026%2010%3A47%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.205-blue?style=flat&labelColor=555)<br>
+![Last Updated](https://img.shields.io/badge/Last_Updated-Jul%2011%2C%202026%2010%3A43%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.207-blue?style=flat&labelColor=555)<br>
 [![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../.claude/settings.json)
 
-A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.205, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
+A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.207, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
 
 <table width="100%">
 <tr>
@@ -62,6 +62,7 @@ Within the managed tier, precedence is: server-managed > MDM/OS-level policies >
 | `policyHelper` | object | - | Admin-deployed executable that computes managed settings dynamically at startup. Object shape: `{path: string}` pointing at the helper binary. Only honored from MDM or a system `managed-settings.json` file (never from user/project settings). Helper output is merged into the managed tier on every startup. Requires v2.1.136+ |
 | `requiredMinimumVersion` | string | - | **(Managed only)** Prevents Claude Code from starting if the installed version is below this floor. CLI exits with an error prompting the user to upgrade. Complements `minimumVersion` (which controls auto-update floor) — this one enforces at startup. Example: `"2.1.163"` |
 | `requiredMaximumVersion` | string | - | **(Managed only)** Prevents Claude Code from starting if the installed version exceeds this ceiling. CLI exits with an error if the version is too new. Use alongside `requiredMinimumVersion` to pin a specific version range in managed environments. Example: `"2.1.165"` |
+| `browserExternalPageTools` | string | - | **(Managed only)** Set to `"disabled"` to prevent Claude from using tools to read or act on external pages in the desktop app's Browser pane. Users can still navigate to external sites themselves, and local dev server previews are unaffected |
 
 **Important**:
 - `deny` rules have highest safety precedence and cannot be overridden by lower-priority allow/ask rules.
@@ -275,7 +276,7 @@ Control what tools and operations Claude can perform.
 | `permissions.disableBypassPermissionsMode` | string | Prevent bypass mode activation |
 | `permissions.skipDangerousModePermissionPrompt` | boolean | Skip the confirmation prompt shown before entering bypass permissions mode via `--dangerously-skip-permissions` or `defaultMode: "bypassPermissions"`. Ignored when set in project settings (`.claude/settings.json`) to prevent untrusted repositories from auto-bypassing the prompt |
 | `allowManagedPermissionRulesOnly` | boolean | **(Managed only)** Only managed permission rules apply; user/project `allow`, `ask`, `deny` rules are ignored |
-| `autoMode` | object | Customize what the [auto mode](https://code.claude.com/docs/en/permission-modes#eliminate-prompts-with-auto-mode) classifier blocks and allows. Contains `environment` (trusted infrastructure descriptions), `allow` (exceptions to block rules), `soft_deny` (block rules), and `hard_deny` (unconditional block rules — cannot be overridden by `allow` exceptions or the `$defaults` sentinel, v2.1.136) — all arrays of prose strings. Also accepts `classifyAllShell` (boolean, default `false`): when `true`, routes all Bash/PowerShell commands through the auto-mode classifier instead of only arbitrary-code-execution patterns, giving stricter coverage at the cost of more classifier calls (v2.1.193). **Not read from shared project settings** (`.claude/settings.json`) to prevent repo injection. Available in user, local, and managed settings. Setting `allow` or `soft_deny` **replaces** the entire default list for that section unless you include the literal string `"$defaults"` in the array — the sentinel inherits the built-in rules at that position so custom entries are added alongside them (v2.1.118). Run `claude auto-mode defaults` to see built-in rules before customizing |
+| `autoMode` | object | Customize what the [auto mode](https://code.claude.com/docs/en/permission-modes#eliminate-prompts-with-auto-mode) classifier blocks and allows. Contains `environment` (trusted infrastructure descriptions), `allow` (exceptions to block rules), `soft_deny` (block rules), and `hard_deny` (unconditional block rules — cannot be overridden by `allow` exceptions or the `$defaults` sentinel, v2.1.136) — all arrays of prose strings. Also accepts `classifyAllShell` (boolean, default `false`): when `true`, routes all Bash/PowerShell commands through the auto-mode classifier instead of only arbitrary-code-execution patterns, giving stricter coverage at the cost of more classifier calls (v2.1.193). **Not read from shared project settings** (`.claude/settings.json`) **or local settings** (`.claude/settings.local.json`) to prevent repo injection (v2.1.207 removed local-settings scope). Available in user and managed settings only; configure in `~/.claude/settings.json`. Setting `allow` or `soft_deny` **replaces** the entire default list for that section unless you include the literal string `"$defaults"` in the array — the sentinel inherits the built-in rules at that position so custom entries are added alongside them (v2.1.118). Run `claude auto-mode defaults` to see built-in rules before customizing |
 | `disableAutoMode` | string | Set to `"disable"` to prevent [auto mode](https://code.claude.com/docs/en/permission-modes#eliminate-prompts-with-auto-mode) from being activated. Removes `auto` from the `Shift+Tab` cycle and rejects `--permission-mode auto` at startup. Can be set at any settings level; most useful in managed settings where users cannot override it |
 | `useAutoModeDuringPlan` | boolean | Whether plan mode uses auto mode semantics when auto mode is available. Default: `true`. Not read from shared project settings (`.claude/settings.json`). Appears in `/config` as "Use auto mode during plan" |
 
@@ -561,7 +562,7 @@ Configure Claude Code plugins and marketplaces.
 |-------|-------------|
 | `"default"` | Recommended for your account type |
 | `"sonnet"` | Latest Sonnet model (Claude Sonnet 5 on the Anthropic API — native 1M-token context, introduced v2.1.197; Claude Sonnet 4.6 on Bedrock/Vertex/Foundry) |
-| `"opus"` | Latest Opus model (Claude Opus 4.8 on the Anthropic API as of v2.1.154; 4.6 on Bedrock/Vertex/Foundry). Also the fast-mode default since v2.1.142. Opus 4.8 defaults to `high` effort and supports `/effort xhigh` |
+| `"opus"` | Latest Opus model (Claude Opus 4.8 on the Anthropic API as of v2.1.154; Opus 4.8 also now default on Bedrock, Vertex, and Claude Platform on AWS as of v2.1.207 — was 4.6 before). Also the fast-mode default since v2.1.142. Opus 4.8 defaults to `high` effort and supports `/effort xhigh` |
 | `"haiku"` | Fast Haiku model |
 | `"sonnet[1m]"` | Sonnet with 1M token context |
 | `"opus[1m]"` | Opus with 1M token context (default on Max, Team, and Enterprise since v2.1.75) |
@@ -645,7 +646,7 @@ Configure via `env` key:
 |-----|------|---------|-------------|
 | `statusLine` | object | - | Custom status line configuration |
 | `outputStyle` | string | `"default"` | Output style (e.g., `"Explanatory"`) |
-| `spinnerTipsEnabled` | boolean | `true` | Show tips while waiting *(in JSON schema, not on official settings page)* |
+| `spinnerTipsEnabled` | boolean | `true` | Show tips while waiting |
 | `spinnerVerbs` | object | - | Custom spinner verbs with `mode` ("append" or "replace") and `verbs` array |
 | `spinnerTipsOverride` | object | - | Custom spinner tips with `tips` (string array) and optional `excludeDefault` (boolean). When `excludeDefault` is `true`, only custom tips show; when `false` or absent, custom tips merge with built-in tips. As of v2.1.121, `excludeDefault: true` also suppresses time-based spinner tips |
 | `respectGitignore` | boolean | `true` | Respect .gitignore in file picker |
@@ -931,7 +932,7 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_DISABLE_EXPLORE_PLAN_AGENTS` | Set to `1` to disable the built-in Explore and Plan subagents. Claude explores with search tools or the general-purpose subagent instead. Plan mode reads files directly rather than launching Explore and Plan agents (v2.1.198) |
 | `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` | Enable the experimental agent teams feature (`1` to enable). Allows spawning coordinated teams of subagents within a session. Also configurable as a startup-only var — see [CLI Startup Flags](./claude-cli-startup-flags.md#environment-variables) |
 | `CLAUDE_CODE_DISABLE_WORKFLOWS` | Set to `1` to disable [dynamic workflows](https://code.claude.com/docs/en/workflows) (`/workflows`) and the bundled workflow slash commands. Env-var equivalent of the `disableWorkflows` setting |
-| `CLAUDE_CODE_ENABLE_AUTO_MODE` | Set to `1` to make [auto mode](https://code.claude.com/docs/en/permission-modes#eliminate-prompts-with-auto-mode) available on Amazon Bedrock, Google Cloud Vertex AI, and Microsoft Foundry. Has no effect on the Anthropic API, where auto mode is available by default (v2.1.158) |
+| `CLAUDE_CODE_ENABLE_AUTO_MODE` | **As of v2.1.207, auto mode is available on Bedrock, Vertex AI, and Foundry by default — this opt-in is no longer required.** Previously (v2.1.158–v2.1.206): set to `1` to make [auto mode](https://code.claude.com/docs/en/permission-modes#eliminate-prompts-with-auto-mode) available on those providers. Use `disableAutoMode: "disable"` in settings to turn auto mode off |
 | `CLAUDE_CODE_DISABLE_BUNDLED_SKILLS` | Set to `1` to conceal Claude Code's built-in capabilities (bundled skills) from the model. Env-var equivalent of the `disableBundledSkills` setting (v2.1.169) |
 | `CLAUDE_CODE_DISABLE_ARTIFACT` | Set to `1` to disable the [Artifact](https://code.claude.com/docs/en/artifacts) tool, which publishes session output as a private web page on claude.ai. Equivalent to the `disableArtifact` setting |
 | `CLAUDE_CODE_ARTIFACT_AUTO_OPEN` | Set to `0` to stop Claude Code from opening the browser automatically when a new artifact is published. Republishing an existing artifact does not open the browser regardless of this setting |
@@ -1274,8 +1275,7 @@ Set environment variables for all Claude Code sessions.
   "env": {
     "NODE_ENV": "development",
     "CLAUDE_CODE_EFFORT_LEVEL": "medium",
-    "ANTHROPIC_BEDROCK_SERVICE_TIER": "priority",
-    "CLAUDE_CODE_ENABLE_AUTO_MODE": "1"
+    "ANTHROPIC_BEDROCK_SERVICE_TIER": "priority"
   }
 }
 ```

--- a/changelog/best-practice/claude-settings/changelog.md
+++ b/changelog/best-practice/claude-settings/changelog.md
@@ -1077,3 +1077,19 @@
 | 2 | HIGH | MCP Setting Change | Update reserved MCP server names callout (line ~382) to add `Claude Browser` and `Claude Preview` alongside existing `workspace`. Confirmed on official settings page and v2.1.205 changelog | ✅ COMPLETE (callout updated to list all three reserved names) — NEW |
 | 3 | LOW | Suspect Key Recurrence | `CLAUDE_CODE_RETRY_WATCHDOG` — still NOT on official /en/env-vars page; entry annotated "*(in v2.1.199 changelog, not on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-07-03 v2.1.199; not yet on official page) |
 | 4 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 52+ consecutive runs; entry annotated "*(in v2.1.85 changelog, not yet on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-04-14 v2.1.107; 52+ consecutive runs) |
+
+---
+
+## [2026-07-11 10:43 AM PKT] Claude Code v2.1.207
+
+| # | Priority | Type | Action | Status |
+|---|----------|------|--------|--------|
+| 1 | HIGH | Version Bump | Update report version badge from v2.1.205 → v2.1.207 and header "As of v2.1.205" → "As of v2.1.207" | ✅ COMPLETE (badge and header updated in Phase 2.6) — NEW |
+| 2 | HIGH | New Setting | Add `browserExternalPageTools` to Managed-only policy keys table. Managed-only string setting; set to `"disabled"` to prevent Claude from using tools to read or act on external pages in the desktop app's Browser pane. Users can still navigate externally; local dev server previews are unaffected. Confirmed on official settings page | ✅ COMPLETE (added to Managed-only policy keys table after `requiredMaximumVersion`) — NEW |
+| 3 | MED | Behavioral Change | Update `autoMode` description: v2.1.207 removed `.claude/settings.local.json` scope to prevent repo injection. Now only available in user (`~/.claude/settings.json`) and managed settings | ✅ COMPLETE (updated scope note in autoMode row) — NEW |
+| 4 | MED | Model Alias Change | Update `"opus"` alias description: Bedrock, Vertex, and Claude Platform on AWS now default to Opus 4.8 (was 4.6). Confirmed in v2.1.207 changelog: "Changed default model across Bedrock, Vertex, and Claude Platform on AWS to Claude Opus 4.8" | ✅ COMPLETE (opus alias description updated) — NEW |
+| 5 | MED | Stale Annotation | Remove "*(in JSON schema, not on official settings page)*" annotation from `spinnerTipsEnabled` — confirmed on official /en/settings page | ✅ COMPLETE (annotation removed from Display Settings table) — NEW |
+| 6 | MED | Env Var Update | Update `CLAUDE_CODE_ENABLE_AUTO_MODE`: v2.1.207 makes auto mode available on Bedrock/Vertex/Foundry by default — opt-in no longer required. Note: official /en/permission-modes docs page still shows opt-in as required (likely not updated for v2.1.207 yet); updated per raw changelog which is authoritative for version-specific changes | ✅ COMPLETE (env var entry updated with v2.1.207 note) — NEW |
+| 7 | MED | Example Update | Remove `CLAUDE_CODE_ENABLE_AUTO_MODE: "1"` from Quick Reference complete example — no longer needed as of v2.1.207 | ✅ COMPLETE (removed from env block in Quick Reference example) — NEW |
+| 8 | LOW | Suspect Key Recurrence | `CLAUDE_CODE_RETRY_WATCHDOG` — still NOT on official /en/env-vars page; entry annotated "*(in v2.1.199 changelog, not on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-07-03 v2.1.199; not yet on official page) |
+| 9 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 53+ consecutive runs; entry annotated "*(in v2.1.85 changelog, not yet on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-04-14 v2.1.107; 53+ consecutive runs) |


### PR DESCRIPTION
## Summary

Automated daily drift check against Claude Code v2.1.207 (up from v2.1.205). All 7 HIGH/MED action items applied; 2 LOW suspect keys remain ON HOLD.

## Changes Applied

### HIGH Priority
| # | Change | Details |
|---|--------|---------|
| 1 | Version bump | Badge and header updated: v2.1.205 → v2.1.207, Last Updated → Jul 11, 2026 10:43 AM PKT |
| 2 | New setting added | `browserExternalPageTools` — managed-only string; set to `"disabled"` to block Browser pane from reading external pages. Added to Managed-only policy keys table |

### MED Priority
| # | Change | Details |
|---|--------|---------|
| 3 | `autoMode` scope fix | v2.1.207 removed `.claude/settings.local.json` scope to prevent repo injection. Now only readable from user (`~/.claude/settings.json`) and managed settings |
| 4 | Model alias update | `"opus"` on Bedrock, Vertex, and Claude Platform on AWS now defaults to Opus 4.8 (was 4.6) — v2.1.207 |
| 5 | Stale annotation removed | `spinnerTipsEnabled` had "*(in JSON schema, not on official settings page)*" — it IS on the official settings page |
| 6 | Env var update | `CLAUDE_CODE_ENABLE_AUTO_MODE` — auto mode is now on by default for Bedrock/Vertex/Foundry in v2.1.207; opt-in no longer required |
| 7 | Example cleanup | Removed `CLAUDE_CODE_ENABLE_AUTO_MODE: "1"` from Quick Reference example — deprecated by v2.1.207 |

## ON HOLD (unchanged)
- `CLAUDE_CODE_RETRY_WATCHDOG` — still not on official `/en/env-vars` page (RECURRING from 2026-07-03 v2.1.199)
- `OTEL_LOG_TOOL_DETAILS` — still not on official `/en/env-vars` page (53+ consecutive runs, RECURRING from 2026-04-14 v2.1.107)

## Verification Checklist Results

All 25 rules (1A–10C) executed. Notable results:
- **1A/1B/1C/1D** PASS — `browserExternalPageTools` was the only missing key; now added
- **1E Scope** PASS — no scope mismatches found
- **1I Skills Keys** PASS — `maxSkillDescriptionChars` and `skillListingBudgetFraction` present
- **2A–2D Hierarchy** PASS — 5-level chain + managed policy accurate
- **3A–3D Permissions** PASS — all modes, syntax, and evaluation semantics correct
- **5A–5D Env Vars** PASS — no new vars missing; `CLAUDE_CODE_ENABLE_AUTO_MODE` updated
- **6A Quick Reference** PASS — example updated to remove deprecated env var
- **9A–9C Hyperlinks** PASS — all local files exist; `json.schemastore.org` redirects correctly to `www.schemastore.org` (valid schema); all external docs URLs return 200
- **10A Version Metadata** PASS — badge, header, and counts consistent

## v2.1.206 Notes
No new persisted settings keys in v2.1.206. Changes: `/cd` directory suggestions, `EnterWorktree` confirmation for worktrees outside `.claude/worktrees/`, MCP per-server timeout fix.

---
*Do not merge — leave open for human review.*

Generated with [Claude Code](https://claude.ai/code)
https://claude.ai/code/session_01T1SQiii6CjGM4aV1Bfzxry

---
_Generated by [Claude Code](https://claude.ai/code/session_01T1SQiii6CjGM4aV1Bfzxry)_