### PR TITLE
Daily settings drift check — 2026-07-12 (Claude Code v2.1.207)

### DIFF
--- a/best-practice/claude-settings.md
+++ b/best-practice/claude-settings.md
@@ -1,6 +1,6 @@
 # Settings Best Practice
 
-![Last Updated](https://img.shields.io/badge/Last_Updated-Jul%2011%2C%202026%2010%3A43%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.207-blue?style=flat&labelColor=555)<br>
+![Last Updated](https://img.shields.io/badge/Last_Updated-Jul%2012%2C%202026%2010%3A45%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.207-blue?style=flat&labelColor=555)<br>
 [![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../.claude/settings.json)
 
 A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.207, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
@@ -514,7 +514,7 @@ Configure Claude Code plugins and marketplaces.
 | `pluginSuggestionMarketplaces` | array | Managed only | Allowlist of marketplace names whose plugins may appear as contextual install suggestions during a session. Restricts which marketplaces can surface "you might want this plugin" prompts (v2.1.152) |
 | `skippedMarketplaces` | array | Any | Marketplaces user declined to install *(in JSON schema, not on official settings page)* |
 | `skippedPlugins` | array | Any | Plugins user declined to install *(in JSON schema, not on official settings page)* |
-| `pluginConfigs` | object | Any | Per-plugin MCP server configs (keyed by `plugin@marketplace`) *(in JSON schema, not on official settings page)* |
+| `pluginConfigs` | object | Any | Per-plugin MCP server configs (keyed by `plugin@marketplace`). As of v2.1.207, no longer read from project-level `.claude/settings.json` or `.claude/settings.local.json`; only user, `--settings`, and managed settings are honored *(in JSON schema, not on official settings page)* |
 | `blockedMarketplaces` | array | Managed only | Block specific plugin marketplaces. Each entry can match by source string, `hostPattern`, or `pathPattern` — as of v2.1.119 the `hostPattern` and `pathPattern` matchers are correctly enforced before any download touches the filesystem, so blocked marketplaces never reach disk |
 | `pluginTrustMessage` | string | Managed only | Custom message displayed when prompting users to trust plugins |
 | `disableSideloadFlags` | boolean | Managed only | Reject the `--plugin-dir`, `--plugin-url`, `--agents`, and `--mcp-config` startup flags. When `true`, users cannot bypass `strictKnownMarketplaces` by passing sideload flags at launch. Use in managed environments to enforce marketplace-only plugin distribution (v2.1.193) |
@@ -997,6 +997,7 @@ Set environment variables for all Claude Code sessions.
 | `ANTHROPIC_FOUNDRY_API_KEY` | API key for Microsoft Foundry authentication |
 | `ANTHROPIC_FOUNDRY_BASE_URL` | Base URL for Foundry resource |
 | `ANTHROPIC_FOUNDRY_RESOURCE` | Foundry resource name |
+| `ANTHROPIC_FOUNDRY_AUTH_TOKEN` | Azure authentication token for Foundry (alternative to service principal auth, v2.1.203+) |
 | `AWS_BEARER_TOKEN_BEDROCK` | Bedrock API key for authentication |
 | `ANTHROPIC_SMALL_FAST_MODEL` | **DEPRECATED** — Use `ANTHROPIC_DEFAULT_HAIKU_MODEL` instead |
 | `ANTHROPIC_SMALL_FAST_MODEL_AWS_REGION` | AWS region for deprecated Haiku-class model override |

--- a/changelog/best-practice/claude-settings/changelog.md
+++ b/changelog/best-practice/claude-settings/changelog.md
@@ -1093,3 +1093,14 @@
 | 7 | MED | Example Update | Remove `CLAUDE_CODE_ENABLE_AUTO_MODE: "1"` from Quick Reference complete example — no longer needed as of v2.1.207 | ✅ COMPLETE (removed from env block in Quick Reference example) — NEW |
 | 8 | LOW | Suspect Key Recurrence | `CLAUDE_CODE_RETRY_WATCHDOG` — still NOT on official /en/env-vars page; entry annotated "*(in v2.1.199 changelog, not on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-07-03 v2.1.199; not yet on official page) |
 | 9 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 53+ consecutive runs; entry annotated "*(in v2.1.85 changelog, not yet on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-04-14 v2.1.107; 53+ consecutive runs) |
+
+---
+
+## [2026-07-12 10:45 AM PKT] Claude Code v2.1.207
+
+| # | Priority | Type | Action | Status |
+|---|----------|------|--------|--------|
+| 1 | HIGH | Missing Env Var | Add `ANTHROPIC_FOUNDRY_AUTH_TOKEN` to env vars table — Azure authentication token for Foundry (alternative to service principal auth, v2.1.203+). Confirmed on official /en/env-vars page. Inserted after `ANTHROPIC_FOUNDRY_RESOURCE` | ✅ COMPLETE (added to env vars table) — NEW |
+| 2 | MED | Behavioral Change | Update `pluginConfigs` description: as of v2.1.207, no longer read from project-level `.claude/settings.json` or `.claude/settings.local.json`; only user, `--settings`, and managed settings honored. Mirrors `autoMode` project-scope restriction from previous run | ✅ COMPLETE (description updated with v2.1.207 restriction note) — NEW |
+| 3 | LOW | Suspect Key Recurrence | `CLAUDE_CODE_RETRY_WATCHDOG` — still NOT on official /en/env-vars page; entry annotated "*(in v2.1.199 changelog, not on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-07-03 v2.1.199; not yet on official page) |
+| 4 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 54+ consecutive runs; entry annotated "*(in v2.1.85 changelog, not yet on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-04-14 v2.1.107; 54+ consecutive runs) |


### PR DESCRIPTION
## Summary

Daily automated drift check against official Claude Code settings documentation for v2.1.207.

### Changes Applied

- **Add `ANTHROPIC_FOUNDRY_AUTH_TOKEN`** (HIGH) — Azure authentication token for Foundry; alternative to service principal auth, introduced v2.1.203+. Confirmed on official `/en/env-vars` page. Inserted after `ANTHROPIC_FOUNDRY_RESOURCE` in the env vars table.
- **Update `pluginConfigs` description** (MED) — As of v2.1.207, this setting is no longer read from project-level `.claude/settings.json` or `.claude/settings.local.json`; only user, `--settings`, and managed settings are honored. Mirrors the `autoMode` scope restriction documented in the 2026-07-11 run.
- **Badge update** — Last Updated advanced to `Jul 12, 2026 10:45 AM PKT`.

### Verification Log Summary

All 30+ checklist rules executed (1A–1I, 2A–D, 3A–D, 4A, 5A–D, 6A–B, 7A, 8A, 9A–C, 10A–C). Key results:
- **PASS** — Settings hierarchy, permission syntax, MCP settings, sandbox settings, plugin settings, model aliases, display settings all match official docs
- **PASS** — All hyperlinks valid (feiskyer repo OK, schemastore redirect OK, all ToC anchors resolve)
- **FAIL → FIXED** — `ANTHROPIC_FOUNDRY_AUTH_TOKEN` missing from env vars table
- **FAIL → FIXED** — `pluginConfigs` scope description stale post-v2.1.207

### ON HOLD Items (carried forward)

| Key | Status | Consecutive Runs |
|-----|--------|-----------------|
| `OTEL_LOG_TOOL_DETAILS` | Not on official /en/env-vars page; annotated in report | 54+ |
| `CLAUDE_CODE_RETRY_WATCHDOG` | Not on official /en/env-vars page; annotated in report | ~8 |

### Commits

- `docs(settings)` — `best-practice/claude-settings.md`: drift fixes + badge
- `chore(changelog)` — `changelog/best-practice/claude-settings/changelog.md`: append 2026-07-12 entry

> Do not merge without human review. Automated run — leave open for approval.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U1i3BghVWcbjRa78i9EeY2)_