### PR TITLE
Daily settings drift check — 2026-07-14 (Claude Code v2.1.208)

### DIFF
--- a/best-practice/claude-settings.md
+++ b/best-practice/claude-settings.md
@@ -1,9 +1,9 @@
 # Settings Best Practice
 
-![Last Updated](https://img.shields.io/badge/Last_Updated-Jul%2013%2C%202026%2010%3A46%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.207-blue?style=flat&labelColor=555)<br>
+![Last Updated](https://img.shields.io/badge/Last_Updated-Jul%2014%2C%202026%2010%3A46%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.208-blue?style=flat&labelColor=555)<br>
 [![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../.claude/settings.json)
 
-A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.207, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
+A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.208, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
 
 <table width="100%">
 <tr>
@@ -656,6 +656,7 @@ Configure via `env` key:
 | `fileSuggestion` | object | - | Custom file suggestion command (see File Suggestion Configuration below) |
 | `autoScrollEnabled` | boolean | `true` | Auto-scroll the conversation in fullscreen mode. Set to `false` to disable automatic scrolling (v2.1.110). Versions before v2.1.119 stored this in `~/.claude.json` |
 | `editorMode` | string | `"normal"` | Key binding mode for the input prompt: `"normal"` or `"vim"`. Appears in `/config` as **Editor mode**. Versions before v2.1.119 stored this in `~/.claude.json` |
+| `vimInsertModeRemaps` | object | - | Map two-key sequences (e.g., `jj` to Escape) in vim insert mode for the input prompt. Each entry maps a source key sequence to a target key sequence; only active when `editorMode: "vim"` is set (v2.1.208) |
 | `showTurnDuration` | boolean | `true` | Show turn duration messages after responses (e.g., "Cooked for 1m 6s"). Versions before v2.1.119 stored this in `~/.claude.json` |
 | `teammateMode` | string | `"in-process"` | How [agent team](https://code.claude.com/docs/en/agent-teams) teammates display: `"auto"` (picks split panes in tmux or iTerm2, in-process otherwise), `"in-process"` (default since v2.1.179), `"tmux"`, or `"iterm2"` (force iTerm2 split panes regardless of auto-detection, v2.1.186). See [choose a display mode](https://code.claude.com/docs/en/agent-teams#choose-a-display-mode). Versions before v2.1.119 stored this in `~/.claude.json` |
 | `terminalProgressBarEnabled` | boolean | `true` | Show the terminal progress bar in supported terminals (ConEmu, Ghostty 1.2.0+, and iTerm2 3.6.6+). Appears in `/config` as **Terminal progress bar**. Versions before v2.1.119 stored this in `~/.claude.json` |
@@ -897,6 +898,7 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_USE_MANTLE` | Use the Bedrock [Mantle endpoint](https://code.claude.com/docs/en/amazon-bedrock#use-the-mantle-endpoint) (`1` to enable) |
 | `CLAUDE_CODE_USE_POWERSHELL_TOOL` | Set to `1` to enable the PowerShell tool on Windows (opt-in preview). When enabled, Claude can run PowerShell commands natively instead of routing through Git Bash. Only supported on native Windows, not WSL (v2.1.84) |
 | `CLAUDE_CODE_POWERSHELL_RESPECT_EXECUTION_POLICY` | Set to `1` to stop Claude Code from passing `-ExecutionPolicy Bypass` when spawning PowerShell for tool calls, hooks, and status line commands, respecting the machine's effective execution policy instead. By default Claude Code bypasses execution policy at process scope so `.ps1` scripts and module imports work on default-Restricted Windows. Never overrides Group Policy `MachinePolicy`/`UserPolicy` (v2.1.143) |
+| `CLAUDE_CODE_PROCESS_WRAPPER` | Path to a required wrapper executable; Claude Code routes all self-spawns (agent view and background service) through this binary. Enables organizations to intercept or mediate child Claude Code processes *(in v2.1.208 changelog, not on official env-vars page)* |
 | `CLAUDE_CODE_REMOTE` | Read-only. Set automatically to `true` when Claude Code is running as a cloud session. Read this from a hook or setup script to detect whether you are in a cloud environment |
 | `CLAUDE_CODE_REMOTE_SESSION_ID` | Read-only. Set automatically in cloud sessions to the current session's ID. Read this to construct a link back to the session transcript |
 | `CLAUDE_CODE_BRIDGE_SESSION_ID` | Read-only. Set automatically in Bash tool and hook command subprocesses while the session has an active Remote Control connection. Value is the session ID in `session_` form (same identifier in the session's `claude.ai/code` URL). Removed when the connection ends. Allows scripts to link back to the session that ran them. In cloud sessions, read `CLAUDE_CODE_REMOTE_SESSION_ID` instead (v2.1.199) |

--- a/changelog/best-practice/claude-settings/changelog.md
+++ b/changelog/best-practice/claude-settings/changelog.md
@@ -1114,3 +1114,14 @@
 | 1 | MED | Changed Type | Fix `strictKnownMarketplaces` type: `array` → `boolean`; update description to "When `true`, only the official Anthropic marketplace is permitted; no additional or custom marketplaces may be installed". Confirmed boolean on official settings page by two independent sources (workflow agent + direct doc fetch) | ✅ COMPLETE (type and description updated in Plugin Settings table) — NEW |
 | 2 | LOW | Suspect Key Recurrence | `CLAUDE_CODE_RETRY_WATCHDOG` — still NOT on official /en/env-vars page; entry annotated "*(in v2.1.199 changelog, not on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-07-03 v2.1.199; 10 consecutive runs) |
 | 3 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 55+ consecutive runs; entry annotated "*(in v2.1.85 changelog, not yet on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-04-14 v2.1.107; 55+ consecutive runs) |
+
+---
+
+## [2026-07-14 10:46 AM PKT] Claude Code v2.1.208
+
+| # | Priority | Type | Action | Status |
+|---|----------|------|--------|--------|
+| 1 | HIGH | New Setting | Add `vimInsertModeRemaps` to Display Settings table after `editorMode` row. Maps two-key sequences (e.g., `jj` to Escape) in vim insert mode for the input prompt. Confirmed in v2.1.208 changelog | ✅ COMPLETE (added to Display Settings table) — NEW |
+| 2 | HIGH | New Env Var | Add `CLAUDE_CODE_PROCESS_WRAPPER` to env vars table after `CLAUDE_CODE_POWERSHELL_RESPECT_EXECUTION_POLICY`. Routes Claude Code self-spawns through a required wrapper executable for both agent view and background service contexts. In v2.1.208 changelog only, not on official env-vars page | ✅ COMPLETE (added with changelog-only annotation) — NEW |
+| 3 | LOW | Suspect Key Recurrence | `CLAUDE_CODE_RETRY_WATCHDOG` — still NOT on official /en/env-vars page; entry annotated "*(in v2.1.199 changelog, not on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-07-03 v2.1.199; 11 consecutive runs) |
+| 4 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 56+ consecutive runs; entry annotated "*(in v2.1.85 changelog, not yet on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-04-14 v2.1.107; 56+ consecutive runs) |


### PR DESCRIPTION
## Summary

Automated daily drift check for `best-practice/claude-settings.md` against Claude Code v2.1.208. Two HIGH-priority gaps found and applied.

- Add `vimInsertModeRemaps` to Display Settings table — new v2.1.208 setting for mapping two-key vim insert-mode sequences (e.g., `jj` → Escape)
- Add `CLAUDE_CODE_PROCESS_WRAPPER` to env vars table — new v2.1.208 corporate launcher env var (changelog-only, annotated)
- Bump version badge and header: `v2.1.207` → `v2.1.208`
- Update Last Updated badge to `Jul 14, 2026 10:46 AM PKT`

## Verification Log

| Rule | Category | Depth | Result | Notes |
|------|----------|-------|--------|-------|
| 1A | Key Completeness | field-level | FAIL→FIXED | `vimInsertModeRemaps` was missing; added |
| 1B | Key Types | content-match | PASS | All types verified |
| 1C | Key Defaults | content-match | PASS | All defaults verified |
| 1D | Key Descriptions | content-match | PASS | All descriptions match |
| 1E | Scope Column | content-match | PASS | No scope changes |
| 1F | Inverse Completeness | field-level | PASS | All report keys traceable to official source or annotated |
| 1G | Edge-Case Semantics | content-match | PASS | No boundary changes |
| 1H | File Scope Check | content-match | PASS | No file-scope mismatches |
| 1I | Skills Settings Keys | field-level | PASS | `maxSkillDescriptionChars` and `skillListingBudgetFraction` present |
| 2A | Priority Levels | field-level | PASS | 5-level chain + managed policy intact |
| 2B | File Locations | content-match | PASS | All paths verified |
| 2C | Merge Semantics | content-match | PASS | "concatenated and deduplicated" wording matches |
| 2D | Managed Internals | field-level | PASS | Delivery methods and precedence verified |
| 3A | Permission Modes | field-level | PASS | All modes present |
| 3B | Tool Syntax Patterns | content-match | PASS | No changes |
| 3C | Bidirectional Mode Check | field-level | PASS | No orphaned modes |
| 3D | Evaluation Semantics | content-match | PASS | Deny-first, path-prefix patterns verified |
| 4A | Hooks Redirect | exists | PASS | Redirect link to claude-code-hooks repo valid |
| 5A | Env Var Completeness | field-level | FAIL→FIXED | `CLAUDE_CODE_PROCESS_WRAPPER` was missing; added |
| 5B | Ownership Boundary | cross-file | PASS | No overlap with cli-startup-flags.md |
| 5C | Env Var Descriptions | content-match | PASS | All descriptions verified |
| 5D | Inverse Env Var Check | field-level | PASS | All vars traceable or annotated |
| 6A | Quick Reference Example | content-match | PASS | Example uses current settings |
| 6B | Example URL Validation | exists | PASS | `$schema` URL resolves |
| 7A | CLAUDE.md Sync | cross-file | PASS | Config hierarchy consistent |
| 8A | Source Credibility Guard | content-match | PASS | Both changes confirmed by official changelog |
| 9A | Local File Links | exists | PASS | All relative links resolve |
| 9B | External URL Links | exists | PASS | `https://code.claude.com/docs/en/settings` returns HTTP 200 |
| 9C | Anchor Links | exists | PASS | All anchors verified |
| 10A | Version Metadata | content-match | FAIL→FIXED | Badge bumped to v2.1.208 |
| 10B | Suspect Key Escalation | exists | PASS | ON HOLD items tracked; none at 5-run threshold |
| 10C | Bidirectional Completeness | field-level | PASS | All entries traceable |

## Action Items

| # | Priority | Type | Action | Status |
|---|----------|------|--------|--------|
| 1 | HIGH | New Setting | Add `vimInsertModeRemaps` to Display Settings table | ✅ COMPLETE — NEW |
| 2 | HIGH | New Env Var | Add `CLAUDE_CODE_PROCESS_WRAPPER` with changelog-only annotation | ✅ COMPLETE — NEW |
| 3 | LOW | Suspect Key | `CLAUDE_CODE_RETRY_WATCHDOG` — 11 consecutive ON HOLD runs | ✋ ON HOLD — RECURRING (first seen: 2026-07-03) |
| 4 | LOW | Suspect Key | `OTEL_LOG_TOOL_DETAILS` — 56+ consecutive ON HOLD runs | ✋ ON HOLD — RECURRING (first seen: 2026-04-14) |

## Resolved Since Last Run

No items from the 2026-07-13 run were resolved this cycle (the `strictKnownMarketplaces` type fix from that run was already applied).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rb5W1yxg1fECFbTcYG8YZH)_