### PR TITLE
Daily settings drift check — 2026-07-15 (Claude Code v2.1.210)

### DIFF
--- a/best-practice/claude-settings.md
+++ b/best-practice/claude-settings.md
@@ -1,9 +1,9 @@
 # Settings Best Practice
 
-![Last Updated](https://img.shields.io/badge/Last_Updated-Jul%2013%2C%202026%2010%3A46%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.207-blue?style=flat&labelColor=555)<br>
+![Last Updated](https://img.shields.io/badge/Last_Updated-Jul%2015%2C%202026%2010%3A45%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.210-blue?style=flat&labelColor=555)<br>
 [![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../.claude/settings.json)
 
-A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.207, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
+A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.210, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
 
 <table width="100%">
 <tr>
@@ -92,6 +92,7 @@ Within the managed tier, precedence is: server-managed > MDM/OS-level policies >
 | `availableModels` | array | - | Restrict which models users can select via `/model`, `--model`, Config tool, or `ANTHROPIC_MODEL`. Does not affect the Default option. As of v2.1.172, also constrains the model picker for subagent dispatching and the `advisorModel` picker. Use `enforceAvailableModels: true` to additionally constrain the Default model option. Example: `["sonnet", "haiku"]` |
 | `enforceAvailableModels` | boolean | `false` | **(Managed only)** When `true`, the `availableModels` allowlist also constrains the Default model option — users cannot select a model outside the allowlist even via the Default slot. Without this flag, `availableModels` leaves the Default option unrestricted. Pair with `availableModels` for full model lockdown (v2.1.175) |
 | `fastModePerSessionOptIn` | boolean | `false` | Require users to opt in to fast mode each session |
+| `fastMode` | boolean | `false` | Enable fast mode for all sessions. When `true`, Claude Code uses the faster model tier by default. Users can also toggle fast mode per session with `/fast`. Pairs with `fastModePerSessionOptIn` |
 | `defaultShell` | string | `"bash"` | Default shell for input-box `!` commands. Accepts `"bash"` (default) or `"powershell"`. Setting `"powershell"` routes interactive `!` commands through PowerShell on Windows. Requires `CLAUDE_CODE_USE_POWERSHELL_TOOL=1` (v2.1.84). **v2.1.120:** When PowerShell is available, it is used as the fallback shell on Windows even without Git for Windows installed. **v2.1.126:** When PowerShell is enabled, it is treated as the *primary* shell instead of defaulting to Bash. PowerShell 7 detection now also covers Microsoft Store installs, MSI installs not on PATH, and `.NET` global tool installs |
 | `includeGitInstructions` | boolean | `true` | Include built-in commit and PR workflow instructions and the git status snapshot in Claude's system prompt. The `CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS` environment variable takes precedence over this setting when set |
 | `voice` | object | - | Voice dictation configuration. Object with three fields: `enabled` (boolean — push-to-talk on/off), `mode` (string — `"hold"` for hold-to-talk or `"tap"` for tap-to-toggle), and `autoSubmit` (boolean — submit transcript immediately when dictation ends). Written automatically when you run `/voice`. Requires a Claude.ai account (v2.1.118 expanded structure) |
@@ -310,6 +311,8 @@ Control what tools and operations Claude can perform.
 | `MCP` | `mcp__server__tool` or `MCP(server:tool)` | `mcp__memory__*`, `MCP(github:*)` |
 | `Tool` | `Tool(param:value)` | `Agent(model:opus)`, `Bash(cmd:npm run *)` — match permission rules against a tool's input parameters; supports `*` wildcards in the value position (v2.1.178) |
 | `Cd` | `Cd(path pattern)` | `Cd(/home/*)`, `Cd(~/projects/*)` — controls which directories the `/cd` command may navigate to |
+
+> **v2.1.210:** `Write(path)`, `NotebookEdit(path)`, and `Glob(path)` permission rules generate a startup warning recommending the more targeted `Edit(path)` or `Read(path)` alternatives. Existing settings continue to work; the warning is a nudge to tighten permissions.
 
 **Evaluation order:** Rules are evaluated in order: deny rules first, then ask, then allow. The first matching rule wins.
 
@@ -656,6 +659,7 @@ Configure via `env` key:
 | `fileSuggestion` | object | - | Custom file suggestion command (see File Suggestion Configuration below) |
 | `autoScrollEnabled` | boolean | `true` | Auto-scroll the conversation in fullscreen mode. Set to `false` to disable automatic scrolling (v2.1.110). Versions before v2.1.119 stored this in `~/.claude.json` |
 | `editorMode` | string | `"normal"` | Key binding mode for the input prompt: `"normal"` or `"vim"`. Appears in `/config` as **Editor mode**. Versions before v2.1.119 stored this in `~/.claude.json` |
+| `vimInsertModeRemaps` | object | - | Custom key remappings applied in vim insert mode. Object where keys are input sequences and values are the replacement sequences. Only applies when `editorMode` is `"vim"`. Example: `{"jk": "<Esc>", "jj": "<Esc>"}` (v2.1.208) |
 | `showTurnDuration` | boolean | `true` | Show turn duration messages after responses (e.g., "Cooked for 1m 6s"). Versions before v2.1.119 stored this in `~/.claude.json` |
 | `teammateMode` | string | `"in-process"` | How [agent team](https://code.claude.com/docs/en/agent-teams) teammates display: `"auto"` (picks split panes in tmux or iTerm2, in-process otherwise), `"in-process"` (default since v2.1.179), `"tmux"`, or `"iterm2"` (force iTerm2 split panes regardless of auto-detection, v2.1.186). See [choose a display mode](https://code.claude.com/docs/en/agent-teams#choose-a-display-mode). Versions before v2.1.119 stored this in `~/.claude.json` |
 | `terminalProgressBarEnabled` | boolean | `true` | Show the terminal progress bar in supported terminals (ConEmu, Ghostty 1.2.0+, and iTerm2 3.6.6+). Appears in `/config` as **Terminal progress bar**. Versions before v2.1.119 stored this in `~/.claude.json` |
@@ -1044,6 +1048,7 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB` | Set to `1` to strip Anthropic and cloud provider credentials from subprocess environments (Bash tool, hooks, MCP stdio servers). Use for defense-in-depth when subprocesses should not inherit API keys (v2.1.83) |
 | `CLAUDE_CODE_SCRIPT_CAPS` | JSON object limiting how many times specific scripts may be invoked per session when `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB` is set. Keys are substrings matched against the command text; values are integer call limits. For example, `{"deploy.sh": 2}` allows `deploy.sh` to be called at most twice. Matching is substring-based; runtime fan-out via `xargs` or `find -exec` is not detected — this is a defense-in-depth control |
 | `CLAUDE_CODE_PERFORCE_MODE` | Set to `1` to enable Perforce-aware write protection. When set, Edit, Write, and NotebookEdit fail with a `p4 edit <file>` hint if the target file lacks the owner-write bit, which Perforce clears on synced files until `p4 edit` opens them. Prevents Claude Code from bypassing Perforce change tracking (v2.1.98) |
+| `CLAUDE_CODE_PROCESS_WRAPPER` | Wrap the Claude Code process at startup. Specify the wrapper executable and arguments; Claude Code is appended as the final argument. Useful for profiling tools, sandboxes, or tracing (e.g., `CLAUDE_CODE_PROCESS_WRAPPER="strace -e trace=file"`). *(in v2.1.208 changelog, not yet on official env-vars page)* |
 | `CLAUDE_CODE_MAX_RETRIES` | Override API request retry count (default: 10) |
 | `CLAUDE_CODE_RETRY_WATCHDOG` | Raise the retry count for non-capacity API errors to 300. The standard retry cap (`CLAUDE_CODE_MAX_RETRIES`, default: 10) still applies for capacity errors *(in v2.1.199 changelog, not on official env-vars page)* |
 | `CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY` | Max parallel read-only tools (default: 10) |

--- a/changelog/best-practice/claude-settings/changelog.md
+++ b/changelog/best-practice/claude-settings/changelog.md
@@ -1114,3 +1114,16 @@
 | 1 | MED | Changed Type | Fix `strictKnownMarketplaces` type: `array` → `boolean`; update description to "When `true`, only the official Anthropic marketplace is permitted; no additional or custom marketplaces may be installed". Confirmed boolean on official settings page by two independent sources (workflow agent + direct doc fetch) | ✅ COMPLETE (type and description updated in Plugin Settings table) — NEW |
 | 2 | LOW | Suspect Key Recurrence | `CLAUDE_CODE_RETRY_WATCHDOG` — still NOT on official /en/env-vars page; entry annotated "*(in v2.1.199 changelog, not on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-07-03 v2.1.199; 10 consecutive runs) |
 | 3 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 55+ consecutive runs; entry annotated "*(in v2.1.85 changelog, not yet on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-04-14 v2.1.107; 55+ consecutive runs) |
+
+---
+
+## [2026-07-15 10:45 AM PKT] Claude Code v2.1.210
+
+| # | Priority | Type | Action | Status |
+|---|----------|------|--------|--------|
+| 1 | HIGH | Missing Setting | Add `fastMode` (boolean, default `false`) to Core Configuration table after `fastModePerSessionOptIn`. Confirmed on official settings page | ✅ COMPLETE (added to Core Configuration table) — NEW |
+| 2 | HIGH | Missing Setting | Add `vimInsertModeRemaps` (object, v2.1.208) to Display & UX table after `editorMode`. Confirmed in v2.1.208 changelog | ✅ COMPLETE (added to Display Settings table) — NEW |
+| 3 | HIGH | Missing Env Var | Add `CLAUDE_CODE_PROCESS_WRAPPER` to env vars table after `CLAUDE_CODE_PERFORCE_MODE`. Confirmed in v2.1.208 changelog (not yet on official env-vars page) | ✅ COMPLETE (added with "not yet on official env-vars page" annotation) — NEW |
+| 4 | MED | Behavioral Note | Add v2.1.210 startup warning note for `Write(path)`, `NotebookEdit(path)`, `Glob(path)` permission rules suggesting `Edit(path)`/`Read(path)` alternatives. Confirmed in v2.1.210 changelog | ✅ COMPLETE (added blockquote note after Tool Permission Syntax table) — NEW |
+| 5 | LOW | Suspect Key Recurrence | `CLAUDE_CODE_RETRY_WATCHDOG` — still NOT on official /en/env-vars page; entry annotated "*(in v2.1.199 changelog, not on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-07-03 v2.1.199; 11 consecutive runs) |
+| 6 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 56+ consecutive runs; entry annotated "*(in v2.1.85 changelog, not yet on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-04-14 v2.1.107; 56+ consecutive runs) |


### PR DESCRIPTION
## Summary

Daily automated drift check for `best-practice/claude-settings.md` against Claude Code v2.1.210 official docs.

**3 HIGH + 1 MED items resolved, 2 LOW items remain ON HOLD.**

---

## Changes

### `best-practice/claude-settings.md`

| # | Priority | Type | Change |
|---|----------|------|--------|
| 1 | HIGH | Missing Setting | Added `fastMode` (boolean, `false`) to Core Configuration table — enable fast mode for all sessions; confirmed on official settings page |
| 2 | HIGH | Missing Setting | Added `vimInsertModeRemaps` (object) to Display Settings table after `editorMode` — custom key remaps in vim insert mode (v2.1.208) |
| 3 | HIGH | Missing Env Var | Added `CLAUDE_CODE_PROCESS_WRAPPER` to env vars table — wrap Claude Code process at startup for profiling/sandboxing (v2.1.208 changelog, annotated "not yet on official env-vars page") |
| 4 | MED | Behavioral Note | Added v2.1.210 startup warning blockquote after Tool Permission Syntax table: `Write(path)`, `NotebookEdit(path)`, `Glob(path)` rules warn at startup suggesting `Edit(path)`/`Read(path)` alternatives |
| 5 | META | Badge/Version | Bumped version badge and header from v2.1.207 → v2.1.210; updated Last Updated badge to Jul 15, 2026 10:45 AM PKT |

### `changelog/best-practice/claude-settings/changelog.md`

Appended new dated entry `[2026-07-15 10:45 AM PKT] Claude Code v2.1.210` with all 4 resolved actions marked `COMPLETE` and 2 recurring suspect keys (`CLAUDE_CODE_RETRY_WATCHDOG`, `OTEL_LOG_TOOL_DETAILS`) updated to `ON HOLD`.

---

## Ongoing ON HOLD Items

| Key | Status | Runs |
|-----|--------|------|
| `CLAUDE_CODE_RETRY_WATCHDOG` | Not on official env-vars page; annotated in report | 11 consecutive runs since v2.1.199 (2026-07-03) |
| `OTEL_LOG_TOOL_DETAILS` | Not on official env-vars page; annotated in report | 56+ consecutive runs since v2.1.107 (2026-04-14) |

---

## Verification Log

| Rule | Category | Depth | Result |
|------|----------|-------|--------|
| 1A | Key Completeness | field-level | PASS (after additions) |
| 1B | Key Types | content-match | PASS |
| 1C | Key Defaults | content-match | PASS |
| 1D | Key Descriptions | content-match | PASS |
| 1E | Scope Column | content-match | PASS |
| 1F | Inverse Completeness | field-level | PASS |
| 1G | Edge-Case Semantics | content-match | PASS |
| 1H | File Scope Check | content-match | PASS |
| 1I | Skills Settings Keys | field-level | PASS |
| 2A–2D | Settings Hierarchy | field-level | PASS |
| 3A–3D | Permissions | field-level | PASS (warning note added for v2.1.210) |
| 4A | Hooks Redirect | exists | PASS |
| 5A–5D | Environment Variables | field-level | PASS (after addition) |
| 6A–6B | Examples | content-match | PASS |
| 7A | CLAUDE.md Sync | cross-file | PASS |
| 8A | Source Credibility Guard | content-match | PASS (all changes confirmed via official docs/changelog) |
| 9A–9C | Hyperlinks | exists | PASS (schemastore 301 redirects to valid content) |
| 10A | Version Metadata | content-match | PASS (updated to v2.1.210) |
| 10B | Suspect Key Escalation | exists | PASS (both keys annotated; RETRY_WATCHDOG at 11 runs, OTEL at 56+) |
| 10C | Bidirectional Completeness | field-level | PASS |

---

> **Do not merge** — leave open for human review.

---
_Generated by [Claude Code](https://claude.ai/code/session_016gSiN5PtmKzJV5sygwKvHP)_