### PR TITLE
Daily settings drift check — 2026-07-16 (Claude Code v2.1.211)

### DIFF
--- a/best-practice/claude-settings.md
+++ b/best-practice/claude-settings.md
@@ -1,9 +1,9 @@
 # Settings Best Practice
 
-![Last Updated](https://img.shields.io/badge/Last_Updated-Jul%2015%2C%202026%2010%3A45%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.210-blue?style=flat&labelColor=555)<br>
+![Last Updated](https://img.shields.io/badge/Last_Updated-Jul%2016%2C%202026%2010%3A45%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.211-blue?style=flat&labelColor=555)<br>
 [![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../.claude/settings.json)
 
-A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.210, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
+A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.211, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
 
 <table width="100%">
 <tr>
@@ -855,6 +855,8 @@ Set environment variables for all Claude Code sessions.
 }
 ```
 
+> **Note (v2.1.211):** Integer environment variables (e.g., `CLAUDE_CODE_MAX_OUTPUT_TOKENS`, `MAX_THINKING_TOKENS`, `MCP_TOOL_TIMEOUT`) now accept scientific notation and digit-separator spellings: `1e6`, `64_000`, `1_000_000`. All three forms are equivalent to their decimal value.
+
 ### Common Environment Variables
 
 | Variable | Description |
@@ -934,6 +936,7 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_DISABLE_ADVISOR_TOOL` | Set to `1` to disable the advisor tool and the `/advisor` command. Env-var equivalent of omitting advisor usage. Pair with `advisorModel` for advisor configuration (min v2.1.98) |
 | `CLAUDE_CODE_DISABLE_AGENT_VIEW` | Set to `1` to turn off background agents and agent view (`claude agents`, `--bg`, `/background`, on-demand supervisor). Env-var equivalent of the `disableAgentView` setting *(referenced on official settings page; not listed on the env-vars page)* |
 | `CLAUDE_CODE_DISABLE_EXPLORE_PLAN_AGENTS` | Set to `1` to disable the built-in Explore and Plan subagents. Claude explores with search tools or the general-purpose subagent instead. Plan mode reads files directly rather than launching Explore and Plan agents (v2.1.198) |
+| `CLAUDE_CODE_FORWARD_SUBAGENT_TEXT` | Set to `1` to include subagent text and thinking blocks in stream-json (`-p --output-format stream-json`) output. When enabled, text and thinking content from spawned subagents is forwarded to the outer stream alongside tool-result events. Equivalent to the `--forward-subagent-text` CLI flag *(in v2.1.211 changelog, not yet on official env-vars page)* |
 | `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` | Enable the experimental agent teams feature (`1` to enable). Allows spawning coordinated teams of subagents within a session. Also configurable as a startup-only var — see [CLI Startup Flags](./claude-cli-startup-flags.md#environment-variables) |
 | `CLAUDE_CODE_DISABLE_WORKFLOWS` | Set to `1` to disable [dynamic workflows](https://code.claude.com/docs/en/workflows) (`/workflows`) and the bundled workflow slash commands. Env-var equivalent of the `disableWorkflows` setting |
 | `CLAUDE_CODE_ENABLE_AUTO_MODE` | **As of v2.1.207, auto mode is available on Bedrock, Vertex AI, and Foundry by default — this opt-in is no longer required.** Previously (v2.1.158–v2.1.206): set to `1` to make [auto mode](https://code.claude.com/docs/en/permission-modes#eliminate-prompts-with-auto-mode) available on those providers. Use `disableAutoMode: "disable"` in settings to turn auto mode off |

--- a/changelog/best-practice/claude-settings/changelog.md
+++ b/changelog/best-practice/claude-settings/changelog.md
@@ -1127,3 +1127,16 @@
 | 4 | MED | Behavioral Note | Add v2.1.210 startup warning note for `Write(path)`, `NotebookEdit(path)`, `Glob(path)` permission rules suggesting `Edit(path)`/`Read(path)` alternatives. Confirmed in v2.1.210 changelog | ✅ COMPLETE (added blockquote note after Tool Permission Syntax table) — NEW |
 | 5 | LOW | Suspect Key Recurrence | `CLAUDE_CODE_RETRY_WATCHDOG` — still NOT on official /en/env-vars page; entry annotated "*(in v2.1.199 changelog, not on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-07-03 v2.1.199; 11 consecutive runs) |
 | 6 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 56+ consecutive runs; entry annotated "*(in v2.1.85 changelog, not yet on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-04-14 v2.1.107; 56+ consecutive runs) |
+
+---
+
+## [2026-07-16 10:41 AM PKT] Claude Code v2.1.211
+
+| # | Priority | Type | Action | Status |
+|---|----------|------|--------|--------|
+| 1 | MED | Missing Env Var | Add `CLAUDE_CODE_FORWARD_SUBAGENT_TEXT` to Common Environment Variables table — include subagent text and thinking blocks in stream-json output (v2.1.211 changelog; not yet on official /en/env-vars page). Inserted after `CLAUDE_CODE_DISABLE_EXPLORE_PLAN_AGENTS` | ✅ COMPLETE (added with changelog-only annotation) — NEW |
+| 2 | LOW | Version Bump | Update report version badge v2.1.210 → v2.1.211 and header "As of v2.1.210" → "As of v2.1.211"; Last Updated date Jul 15, 2026 → Jul 16, 2026 | ✅ COMPLETE (badge, header, and body text updated in Phase 2.6) — NEW |
+| 3 | LOW | Behavior Note | Add note that integer env vars accept scientific notation (`1e6`) and digit-separator spellings (`64_000`) (v2.1.211 changelog). Added as a callout above the Common Environment Variables table | ✅ COMPLETE (note added to env section intro) — NEW |
+| 4 | LOW | Unconfirmed Env Var | `CLAUDE_CODE_AWS_CHAIN_RESOLVE_TIMEOUT_MS` — surfaced by /en/env-vars page WebFetch but NOT confirmed by either research agent's thorough sweep. Per Rule 8A, defer to next run | ✋ ON HOLD (new — pending official confirmation by independent agent) |
+| 5 | LOW | Suspect Key Recurrence | `CLAUDE_CODE_RETRY_WATCHDOG` — still NOT on official /en/env-vars page; entry annotated "*(in v2.1.199 changelog, not on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-07-03 v2.1.199; 12 consecutive runs) |
+| 6 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 57+ consecutive runs; entry annotated "*(in v2.1.85 changelog, not yet on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-04-14 v2.1.107; 57+ consecutive runs) |


### PR DESCRIPTION
## Drift Report — Settings — 2026-07-16

**Audited version:** v2.1.210 → **v2.1.211** (1 version behind at run start)
**Sources:** [settings docs](https://code.claude.com/docs/en/settings) · [CLI reference](https://code.claude.com/docs/en/cli-reference) · [changelog](https://raw.githubusercontent.com/anthropics/claude-code/refs/heads/main/CHANGELOG.md) · [env-vars](https://code.claude.com/docs/en/env-vars)

---

## Verification Log (all 31 rules)

| Rule | Result | Detail |
|------|--------|--------|
| 1A Key Completeness | ✅ PASS | All settings.json keys present |
| 1B Key Types | ✅ PASS | Types accurate |
| 1C Key Defaults | ✅ PASS | Defaults accurate |
| 1D Key Descriptions | ✅ PASS | Descriptions accurate |
| 1E Scope Column | ✅ PASS | Scopes correct |
| 1F Inverse Completeness | ✅ PASS | All entries traceable to official source |
| 1G Edge-Case Semantics | ✅ PASS | Edge cases documented |
| 1H File Scope Check | ✅ PASS | `~/.claude.json` keys correctly separated |
| 1I Skills Settings Keys | ✅ PASS | `maxSkillDescriptionChars`, `skillListingBudgetFraction`, `disableSkillShellExecution` all present |
| 2A Priority Levels | ✅ PASS | 5-level hierarchy accurate |
| 2B File Locations | ✅ PASS | Paths correct |
| 2C Merge Semantics | ✅ PASS | "concatenated and deduplicated" wording matches |
| 2D Managed Internals | ✅ PASS | Drop-in dir, precedence, Windows paths accurate |
| 3A Permission Modes | ✅ PASS | Includes `"manual"` from v2.1.200 |
| 3B Tool Syntax Patterns | ✅ PASS | `Tool(param:value)` from v2.1.178 present |
| 3C Bidirectional Mode Check | ✅ PASS | No unverified modes |
| 3D Evaluation Semantics | ✅ PASS | Deny-first, path-prefix semantics documented |
| 4A Hooks Redirect | ✅ PASS | Link to claude-code-hooks repo valid |
| 5A Env Var Completeness | ❌ **FAIL → FIXED** | `CLAUDE_CODE_FORWARD_SUBAGENT_TEXT` was missing |
| 5B Ownership Boundary | ✅ PASS | No cross-file duplication without cross-refs |
| 5C Env Var Descriptions | ✅ PASS | Descriptions accurate |
| 5D Inverse Env Var Check | ✅ PASS | All entries traceable |
| 6A Quick Reference Example | ✅ PASS | Valid — 24 JSON blocks parse cleanly |
| 6B Example URL Validation | ✅ PASS | `$schema` uses `json.schemastore.org` (correct) |
| 7A CLAUDE.md Sync | ✅ PASS | Hierarchy consistent |
| 8A Source Credibility Guard | ✅ PASS | Applied — rejected WebFetch small-model hallucinations for model aliases and sandbox keys |
| 9A Local File Links | ✅ PASS | All relative links resolve (`../.claude/settings.json`, `../!/claude-jumping.svg`, `./claude-cli-startup-flags.md`) |
| 9B External URL Links | ✅ PASS | All `code.claude.com` docs URLs resolve; changelog URL resolves |
| 9C Anchor Links | ✅ PASS | No heading renames detected |
| 10A Version Metadata | ❌ **FAIL → FIXED** | Badge was v2.1.210; bumped to v2.1.211 |
| 10B Suspect Key Escalation | ✅ PASS | `OTEL_LOG_TOOL_DETAILS` (57+ runs, annotated), `CLAUDE_CODE_RETRY_WATCHDOG` (12 runs, annotated) |
| 10C Bidirectional Completeness | ✅ PASS | All entries traceable |

---

## Action Items

| # | Priority | Type | Action | Marking |
|---|----------|------|--------|---------|
| 1 | MED | Missing Env Var | Add `CLAUDE_CODE_FORWARD_SUBAGENT_TEXT` — include subagent text/thinking in stream-json output; v2.1.211 changelog; not yet on official /en/env-vars page | ✅ COMPLETE |
| 2 | LOW | Version Bump | Bump badge v2.1.210 → v2.1.211, Last Updated Jul 15 → Jul 16 | ✅ COMPLETE |
| 3 | LOW | Behavior Note | Add callout: integer env vars accept scientific notation (`1e6`) and digit-separator spellings (`64_000`) as of v2.1.211 | ✅ COMPLETE |
| 4 | LOW | Unconfirmed Env Var | `CLAUDE_CODE_AWS_CHAIN_RESOLVE_TIMEOUT_MS` — surfaced by /en/env-vars page WebFetch but NOT confirmed by either research agent's sweep; per Rule 8A defer to next run | ✋ ON HOLD |
| 5 | LOW | Suspect Key | `CLAUDE_CODE_RETRY_WATCHDOG` — still NOT on official /en/env-vars page; 12 consecutive runs; annotated in report | ✋ ON HOLD |
| 6 | LOW | Suspect Key | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page; 57+ consecutive runs; annotated in report | ✋ ON HOLD |

---

## Files Changed

- **`best-practice/claude-settings.md`** — added `CLAUDE_CODE_FORWARD_SUBAGENT_TEXT` env var, scientific notation callout, bumped badge to v2.1.211
- **`changelog/best-practice/claude-settings/changelog.md`** — appended 2026-07-16 dated entry (Phase 2.5, mandatory)

---

## Rule 8A Note

The WebFetch small-model render of the official settings page returned outdated model aliases ("Claude 3 Opus", "Claude 3.5 Sonnet") and likely-hallucinated sandbox key names (`blockedDomains`, `filesystem.allowedPaths`). Per Rule 8A, these were **not** adopted — the local report's values (Opus 4.8, Sonnet 5, `deniedDomains`, `filesystem.allowWrite/denyWrite/denyRead`) are authoritative. The GitHub raw changelog was used as the primary authoritative source for v2.1.211 changes.

---

Generated with [Claude Code](https://claude.ai/code)
https://claude.ai/code/session_01A1fyFWGNR4q8gzoDz2JXhL

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1fyFWGNR4q8gzoDz2JXhL)_