### PR TITLE
Daily settings drift check — 2026-07-17 (Claude Code v2.1.212)

### DIFF
--- a/best-practice/claude-settings.md
+++ b/best-practice/claude-settings.md
@@ -1,9 +1,9 @@
 # Settings Best Practice
 
-![Last Updated](https://img.shields.io/badge/Last_Updated-Jul%2015%2C%202026%2010%3A45%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.210-blue?style=flat&labelColor=555)<br>
+![Last Updated](https://img.shields.io/badge/Last_Updated-Jul%2017%2C%202026%2010%3A46%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.212-blue?style=flat&labelColor=555)<br>
 [![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../.claude/settings.json)
 
-A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.210, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
+A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.212, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
 
 <table width="100%">
 <tr>
@@ -211,7 +211,7 @@ Scripts for dynamic authentication token generation.
 | Key | Type | Description |
 |-----|------|-------------|
 | `apiKeyHelper` | string | Shell script path that outputs auth token (sent as both `X-Api-Key` and `Authorization: Bearer` headers) |
-| `forceLoginMethod` | string | Restrict login to `"claudeai"`, `"console"`, or `"gateway"` accounts. Use `"gateway"` for organization-managed Claude gateway deployments. **(Managed only)** |
+| `forceLoginMethod` | string | Restrict login to `"claudeai"`, `"console"`, or `"gateway"` accounts. Use `"gateway"` for organization-managed Claude gateway deployments. As of v2.1.212, enforcement extends to VS Code, SDK, `setup-token`, and `install-github-app` login paths. **(Managed only)** |
 | `forceLoginOrgUUID` | string \| array | Require login to belong to a specific organization. Accepts a single UUID string (which also pre-selects that organization during login) or an array of UUIDs where any listed organization is accepted without pre-selection. When set in managed settings, login fails if the authenticated account does not belong to a listed organization; an empty array fails closed and blocks login with a misconfiguration message |
 | `forceLoginGatewayUrl` | string | **(Managed only)** Pre-fill the Claude gateway URL on the login screen when `forceLoginMethod` is `"gateway"`. Avoids requiring users to manually enter the gateway URL. Typically set alongside `forceLoginMethod: "gateway"` |
 | `gcpAuthRefresh` | string | Custom script that refreshes GCP Application Default Credentials when they expire or cannot be loaded. Run by Claude Code before retrying authentication. Useful when ADC are short-lived and require an org-specific helper to renew. Example: `"gcloud auth application-default login"` |
@@ -315,6 +315,8 @@ Control what tools and operations Claude can perform.
 > **v2.1.210:** `Write(path)`, `NotebookEdit(path)`, and `Glob(path)` permission rules generate a startup warning recommending the more targeted `Edit(path)` or `Read(path)` alternatives. Existing settings continue to work; the warning is a nudge to tighten permissions.
 
 **Evaluation order:** Rules are evaluated in order: deny rules first, then ask, then allow. The first matching rule wins.
+
+**"Always allow" persistence (v2.1.211):** When you respond "Yes, always allow" to a permission prompt, the rule is saved to `.claude/settings.json` at the repository root (not the directory where Claude Code was launched). This ensures interactively-granted allow rules are always persisted in the project's canonical settings file.
 
 **Deny rule glob patterns (v2.1.166):** In a `deny` rule, using `"*"` in the tool-name position matches ALL tools — equivalent to a global deny. For example, `"*"` in the deny array blocks every tool call. This makes it possible to lock down access completely and carve out specific allow/ask exceptions.
 
@@ -857,6 +859,8 @@ Set environment variables for all Claude Code sessions.
 
 ### Common Environment Variables
 
+> **v2.1.211:** Integer-typed environment variables now accept scientific notation (e.g., `1e6`) and digit separators (e.g., `64_000`) in addition to plain integers.
+
 | Variable | Description |
 |----------|-------------|
 | `ANTHROPIC_API_KEY` | API key for authentication |
@@ -918,6 +922,7 @@ Set environment variables for all Claude Code sessions.
 | `MCP_TIMEOUT` | MCP startup timeout in ms |
 | `CLAUDE_CODE_MCP_ALLOWLIST_ENV` | Spawn stdio MCP servers with a safe baseline environment only, stripping most inherited env vars to prevent credential leakage into untrusted server processes |
 | `MAX_MCP_OUTPUT_TOKENS` | Max MCP output tokens (default: 25000). Warning displayed when output exceeds 10,000 tokens |
+| `CLAUDE_CODE_MCP_AUTO_BACKGROUND_MS` | Threshold in milliseconds at which a long-running MCP tool call is automatically backgrounded so Claude Code can continue the session. Default: `120000` (2 minutes). Increase if your MCP tools legitimately take longer before producing output *(in v2.1.212 changelog, not yet on official env-vars page)* |
 | `API_TIMEOUT_MS` | Timeout in ms for API requests (default: 600000) |
 | `API_FORCE_IDLE_TIMEOUT` | Override the 5-minute idle timeout for streaming connections. Set to `0` to disable the idle timeout entirely, `1` to enforce it on all connections, or leave unset for the default (auto-enabled on slow or unreliable gateways that frequently stall). Useful for slow API gateways (v2.1.169) |
 | `CLAUDE_CODE_CONNECT_TIMEOUT_MS` | Timeout in milliseconds for the connect, TLS, and response-header phase of a streaming API request (default: `60000` / 60 seconds). If no response headers arrive within this window, the request is aborted and retried. Set to `0` to disable and rely on `API_TIMEOUT_MS` alone |
@@ -1008,6 +1013,8 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_SHELL_PREFIX` | Command prefix prepended to bash commands |
 | `BASH_DEFAULT_TIMEOUT_MS` | Default bash command timeout in ms |
 | `CLAUDE_CODE_SKIP_BEDROCK_AUTH` | Skip AWS auth for Bedrock (`1` to skip) |
+| `CLAUDE_CODE_AWS_CHAIN_RESOLVE_TIMEOUT_MS` | Time in milliseconds Claude Code waits for the AWS default credential provider chain to produce credentials before failing with `AWS default-chain credential resolve timed out` (default: `60000`). Raise it for slow auth flows such as browser-based SSO with MFA via `aws-vault`. Applies to Bedrock, Claude Platform on AWS, and the Mantle endpoint (v2.1.207) |
+| `CLAUDE_CODE_DISABLE_BEDROCK_CONTENT_TYPE_GUARD` | Set to `1` to skip the check that an Amazon Bedrock streaming response carries the `application/vnd.amazon.eventstream` content-type. Use only when a gateway rewrites the `Content-Type` header but passes the binary event-stream body through unmodified; if the body itself is transformed, requests fail with `Truncated event message received` instead (v2.1.208) |
 | `CLAUDE_CODE_SKIP_FOUNDRY_AUTH` | Skip Azure auth for Foundry (`1` to skip) |
 | `CLAUDE_CODE_SKIP_MANTLE_AUTH` | Skip AWS authentication for Bedrock Mantle (e.g., when using an LLM gateway) |
 | `CLAUDE_CODE_SKIP_VERTEX_AUTH` | Skip Google auth for Vertex (`1` to skip) |
@@ -1045,6 +1052,7 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_GIT_BASH_PATH` | Windows only: path to the Git Bash executable (`bash.exe`). Use when Git Bash is installed but not in your PATH |
 | `DISABLE_COST_WARNINGS` | Disable cost warning messages |
 | `CLAUDE_CODE_SUBAGENT_MODEL` | Override model for subagents (e.g., `haiku`, `sonnet`) |
+| `CLAUDE_CODE_FORWARD_SUBAGENT_TEXT` | Set to `1` to forward subagent text output to the parent session's output stream. Pairs with the `--forward-subagent-text` CLI flag. Useful in SDK or automated mode when you want text generated by background subagents captured in the parent output *(in v2.1.211 changelog, not yet on official env-vars page)* |
 | `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB` | Set to `1` to strip Anthropic and cloud provider credentials from subprocess environments (Bash tool, hooks, MCP stdio servers). Use for defense-in-depth when subprocesses should not inherit API keys (v2.1.83) |
 | `CLAUDE_CODE_SCRIPT_CAPS` | JSON object limiting how many times specific scripts may be invoked per session when `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB` is set. Keys are substrings matched against the command text; values are integer call limits. For example, `{"deploy.sh": 2}` allows `deploy.sh` to be called at most twice. Matching is substring-based; runtime fan-out via `xargs` or `find -exec` is not detected — this is a defense-in-depth control |
 | `CLAUDE_CODE_PERFORCE_MODE` | Set to `1` to enable Perforce-aware write protection. When set, Edit, Write, and NotebookEdit fail with a `p4 edit <file>` hint if the target file lacks the owner-write bit, which Perforce clears on synced files until `p4 edit` opens them. Prevents Claude Code from bypassing Perforce change tracking (v2.1.98) |
@@ -1052,6 +1060,8 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_MAX_RETRIES` | Override API request retry count (default: 10) |
 | `CLAUDE_CODE_RETRY_WATCHDOG` | Raise the retry count for non-capacity API errors to 300. The standard retry cap (`CLAUDE_CODE_MAX_RETRIES`, default: 10) still applies for capacity errors *(in v2.1.199 changelog, not on official env-vars page)* |
 | `CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY` | Max parallel read-only tools (default: 10) |
+| `CLAUDE_CODE_MAX_WEB_SEARCHES_PER_SESSION` | Cap on the number of WebSearch calls Claude Code can make in a single session (default: `200`). Prevents runaway search usage in long-running or agentic sessions *(in v2.1.212 changelog, not yet on official env-vars page)* |
+| `CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION` | Cap on the number of subagents that can be spawned in a single session (default: `200`). Applies to all agent-spawning paths (Agent tool, background tasks, workflow agents) *(in v2.1.212 changelog, not yet on official env-vars page)* |
 | `CLAUDE_AGENT_SDK_DISABLE_BUILTIN_AGENTS` | Disable built-in subagent types in SDK mode (`1` to disable) |
 | `CLAUDE_AGENT_SDK_MCP_NO_PREFIX` | Skip `mcp__<server>__` prefix for MCP tools in SDK mode (`1` to enable) |
 | `CLAUDE_ASYNC_AGENT_STALL_TIMEOUT_MS` | Stall timeout in ms for background subagents (default: 600000 / 10 minutes). The subagent is killed if it produces no output for this duration |

--- a/changelog/best-practice/claude-settings/changelog.md
+++ b/changelog/best-practice/claude-settings/changelog.md
@@ -1127,3 +1127,21 @@
 | 4 | MED | Behavioral Note | Add v2.1.210 startup warning note for `Write(path)`, `NotebookEdit(path)`, `Glob(path)` permission rules suggesting `Edit(path)`/`Read(path)` alternatives. Confirmed in v2.1.210 changelog | ✅ COMPLETE (added blockquote note after Tool Permission Syntax table) — NEW |
 | 5 | LOW | Suspect Key Recurrence | `CLAUDE_CODE_RETRY_WATCHDOG` — still NOT on official /en/env-vars page; entry annotated "*(in v2.1.199 changelog, not on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-07-03 v2.1.199; 11 consecutive runs) |
 | 6 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 56+ consecutive runs; entry annotated "*(in v2.1.85 changelog, not yet on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-04-14 v2.1.107; 56+ consecutive runs) |
+
+---
+
+## [2026-07-17 10:46 AM PKT] Claude Code v2.1.212
+
+| # | Priority | Type | Action | Status |
+|---|----------|------|--------|--------|
+| 1 | HIGH | Missing Env Var | Add `CLAUDE_CODE_AWS_CHAIN_RESOLVE_TIMEOUT_MS` (default `60000`ms) — AWS default credential chain timeout for Bedrock, Claude on AWS, and Mantle. Confirmed on official /en/env-vars page (v2.1.207) | ✅ COMPLETE (added to env vars table after CLAUDE_CODE_SKIP_BEDROCK_AUTH) — NEW |
+| 2 | HIGH | Missing Env Var | Add `CLAUDE_CODE_DISABLE_BEDROCK_CONTENT_TYPE_GUARD` — skip Bedrock streaming content-type check. Confirmed on official /en/env-vars page (v2.1.208) | ✅ COMPLETE (added to env vars table after CLAUDE_CODE_AWS_CHAIN_RESOLVE_TIMEOUT_MS) — NEW |
+| 3 | HIGH | Missing Env Var | Add `CLAUDE_CODE_FORWARD_SUBAGENT_TEXT` — forward subagent text output to parent stream; pairs with `--forward-subagent-text` flag. Confirmed in v2.1.211 changelog | ✅ COMPLETE (added with "not yet on official env-vars page" annotation) — NEW |
+| 4 | HIGH | Missing Env Var | Add `CLAUDE_CODE_MAX_WEB_SEARCHES_PER_SESSION` (default `200`) — session-wide WebSearch cap. Confirmed in v2.1.212 changelog | ✅ COMPLETE (added with "not yet on official env-vars page" annotation) — NEW |
+| 5 | HIGH | Missing Env Var | Add `CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION` (default `200`) — per-session subagent spawn cap. Confirmed in v2.1.212 changelog | ✅ COMPLETE (added with "not yet on official env-vars page" annotation) — NEW |
+| 6 | HIGH | Missing Env Var | Add `CLAUDE_CODE_MCP_AUTO_BACKGROUND_MS` (default `120000`ms) — threshold for auto-backgrounding long MCP calls. Confirmed in v2.1.212 changelog | ✅ COMPLETE (added after MAX_MCP_OUTPUT_TOKENS) — NEW |
+| 7 | MED | Changed Behavior | Note `forceLoginMethod` enforcement scope expanded to VS Code, SDK, `setup-token`, and `install-github-app` login paths in v2.1.212 | ✅ COMPLETE (added to forceLoginMethod description) — NEW |
+| 8 | MED | Changed Behavior | Note "always allow" permission rules now saved at repository root (`.claude/settings.json`) since v2.1.211 | ✅ COMPLETE (added note after Evaluation order paragraph in Permission Syntax section) — NEW |
+| 9 | LOW | Changed Behavior | Note integer env vars accept scientific notation (e.g., `1e6`) and digit separators (e.g., `64_000`) as of v2.1.211 | ✅ COMPLETE (added blockquote note before env vars table) — NEW |
+| 10 | LOW | Suspect Key Recurrence | `CLAUDE_CODE_RETRY_WATCHDOG` — NOT on official env-vars page; 12 consecutive ON HOLD runs | ❌ INVALID (entry already annotated in report as changelog-only; annotation IS the resolution per rule 10B; no further tracking needed) — RECURRING from 2026-07-03 |
+| 11 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — NOT on official env-vars page; 57+ consecutive ON HOLD runs | ❌ INVALID (entry already annotated in report as changelog-only; annotation IS the resolution per rule 10B; no further tracking needed) — RECURRING from 2026-04-14 |


### PR DESCRIPTION
## Summary

Automated daily drift check against Claude Code **v2.1.212** (2 versions ahead of the previous badge v2.1.210). All action items executed in-branch.

### Changes Applied

| # | Priority | Type | Action | Status |
|---|----------|------|--------|--------|
| 1 | HIGH | New Env Var | `CLAUDE_CODE_AWS_CHAIN_RESOLVE_TIMEOUT_MS` — AWS default credential chain timeout (v2.1.207, confirmed on official `/en/env-vars` page) | ✅ COMPLETE |
| 2 | HIGH | New Env Var | `CLAUDE_CODE_DISABLE_BEDROCK_CONTENT_TYPE_GUARD` — skip Bedrock streaming content-type check (v2.1.208, confirmed on official `/en/env-vars` page) | ✅ COMPLETE |
| 3 | HIGH | New Env Var | `CLAUDE_CODE_FORWARD_SUBAGENT_TEXT` — forward subagent text to parent stream; pairs with `--forward-subagent-text` flag (v2.1.211, changelog) | ✅ COMPLETE |
| 4 | HIGH | New Env Var | `CLAUDE_CODE_MAX_WEB_SEARCHES_PER_SESSION` — session-wide WebSearch cap, default 200 (v2.1.212, changelog) | ✅ COMPLETE |
| 5 | HIGH | New Env Var | `CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION` — per-session subagent spawn cap, default 200 (v2.1.212, changelog) | ✅ COMPLETE |
| 6 | HIGH | New Env Var | `CLAUDE_CODE_MCP_AUTO_BACKGROUND_MS` — auto-background threshold for long MCP calls, default 2 min (v2.1.212, changelog) | ✅ COMPLETE |
| 7 | MED | Changed Behavior | `forceLoginMethod` — enforcement now extends to VS Code, SDK, `setup-token`, and `install-github-app` login paths (v2.1.212) | ✅ COMPLETE |
| 8 | MED | Changed Behavior | "Always allow" permission rules now save at repository root (`.claude/settings.json`), not the cwd (v2.1.211) | ✅ COMPLETE |
| 9 | LOW | Changed Behavior | Integer env vars now accept scientific notation (`1e6`) and digit separators (`64_000`) (v2.1.211) | ✅ COMPLETE |
| 10 | LOW | Suspect Key | `CLAUDE_CODE_RETRY_WATCHDOG` (12 consecutive ON HOLD runs) | ❌ INVALID — already annotated in report as changelog-only; resolved per rule 10B |
| 11 | LOW | Suspect Key | `OTEL_LOG_TOOL_DETAILS` (57+ consecutive ON HOLD runs) | ❌ INVALID — already annotated in report as changelog-only; resolved per rule 10B |

### Verification Log (selected)

- **Rule 5A** (Env Var Completeness): FAIL → FIXED — 6 missing vars added
- **Rule 10A** (Version Metadata): FAIL → FIXED — badge updated v2.1.210 → v2.1.212
- **Rule 4A** (Hooks Redirect): PASS — redirect to `claude-code-hooks` repo intact
- **Rules 9A/9B/9C** (Hyperlinks): PASS — all external URLs valid; `json.schemastore.org` schema URL redirects 301 but resolves correctly
- **Rule 10B** (Suspect Key Escalation): RESOLVED — RETRY_WATCHDOG (12 runs) and OTEL_LOG_TOOL_DETAILS (57+ runs) both already annotated; annotation is the resolution
- All other rules (1A–1I, 2A–2D, 3A–3D, 5B–5D, 6A–6B, 7A, 8A, 10C): PASS

### Agents Used

- **workflow-claude-settings-agent** (Opus): read local file + fetched official docs, identified 4 new v2.1.211–212 env vars
- **claude-code-guide**: independent web research, additionally surfaced `CLAUDE_CODE_AWS_CHAIN_RESOLVE_TIMEOUT_MS` and `CLAUDE_CODE_DISABLE_BEDROCK_CONTENT_TYPE_GUARD` (v2.1.207–208, both confirmed against the official env-vars page)

### Files Changed

- `best-practice/claude-settings.md` — 6 new env vars, 3 behavior notes, badge bump
- `changelog/best-practice/claude-settings/changelog.md` — new run entry appended

---
_Generated by [Claude Code](https://claude.ai/code/session_019rdqWE86JNF3BWMQCJQhXC)_