### PR TITLE
Daily settings drift check — 2026-07-19 (Claude Code v2.1.215)

### DIFF
--- a/best-practice/claude-settings.md
+++ b/best-practice/claude-settings.md
@@ -1,9 +1,9 @@
 # Settings Best Practice
 
-![Last Updated](https://img.shields.io/badge/Last_Updated-Jul%2015%2C%202026%2010%3A45%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.210-blue?style=flat&labelColor=555)<br>
+![Last Updated](https://img.shields.io/badge/Last_Updated-Jul%2019%2C%202026%2010%3A44%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.215-blue?style=flat&labelColor=555)<br>
 [![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../.claude/settings.json)
 
-A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.210, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
+A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.215, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
 
 <table width="100%">
 <tr>
@@ -482,7 +482,7 @@ Configure bash command sandboxing for security.
 | `sandbox.bwrapPath` | string | - | **(Managed only, Linux/WSL2)** Absolute path to the bubblewrap (`bwrap`) binary. Overrides automatic `PATH` detection. Only honored from managed settings, not user or project settings. Example: `/opt/admin/bwrap` (v2.1.133) |
 | `sandbox.socatPath` | string | - | **(Managed only, Linux/WSL2)** Absolute path to the `socat` binary used for the sandbox network proxy. Overrides automatic `PATH` detection. Only honored from managed settings. Example: `/opt/admin/socat` (v2.1.133) |
 | `sandbox.allowAppleEvents` | boolean | `false` | **(macOS only)** Opt-in for sandboxed commands to send Apple Events. Required for tools that use `open`, `osascript`, or browser authentication flows that depend on Apple Events IPC (v2.1.181) |
-| `sandbox.credentials` | object | — | Fine-grained control over which credential files and environment variables are blocked from sandboxed subprocess environments. Contains `files` (array of file paths to block from sandboxed reads) and `envVars` (array of env var names to strip from the subprocess environment). An individual invalid entry in `files` or `envVars` is stripped with a warning and the valid subset is enforced (v2.1.187; extended to object with sub-arrays in v2.1.191+) |
+| `sandbox.credentials` | object | — | Fine-grained control over which credential files and environment variables are blocked from sandboxed subprocess environments. Contains `files` (array of file paths to block from sandboxed reads) and `envVars` (array of env var names to strip from the subprocess environment). Supports two modes via a `mode` field: `"deny"` (default) blocks files and strips env vars entirely; `"mask"` with an `injectHosts` array selectively exposes credentials to specific trusted hosts. An individual invalid entry in `files` or `envVars` is stripped with a warning and the valid subset is enforced (v2.1.187; extended to object with sub-arrays in v2.1.191+; `mode` and `injectHosts` added v2.1.199) |
 
 **Example:**
 ```json
@@ -1008,6 +1008,8 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_SHELL_PREFIX` | Command prefix prepended to bash commands |
 | `BASH_DEFAULT_TIMEOUT_MS` | Default bash command timeout in ms |
 | `CLAUDE_CODE_SKIP_BEDROCK_AUTH` | Skip AWS auth for Bedrock (`1` to skip) |
+| `CLAUDE_CODE_AWS_CHAIN_RESOLVE_TIMEOUT_MS` | Timeout in milliseconds for AWS credential chain resolution on Bedrock. Set lower (e.g., `5000`) in environments where a credential source is absent so the chain fails fast. Default: `60000` (60 seconds) (v2.1.207) |
+| `CLAUDE_CODE_DISABLE_BEDROCK_CONTENT_TYPE_GUARD` | Set to `1` to disable the Bedrock content-type guard that rejects responses with unexpected MIME types. Use when a gateway returns non-standard content types but the response body is valid (v2.1.208) |
 | `CLAUDE_CODE_SKIP_FOUNDRY_AUTH` | Skip Azure auth for Foundry (`1` to skip) |
 | `CLAUDE_CODE_SKIP_MANTLE_AUTH` | Skip AWS authentication for Bedrock Mantle (e.g., when using an LLM gateway) |
 | `CLAUDE_CODE_SKIP_VERTEX_AUTH` | Skip Google auth for Vertex (`1` to skip) |
@@ -1045,6 +1047,7 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_GIT_BASH_PATH` | Windows only: path to the Git Bash executable (`bash.exe`). Use when Git Bash is installed but not in your PATH |
 | `DISABLE_COST_WARNINGS` | Disable cost warning messages |
 | `CLAUDE_CODE_SUBAGENT_MODEL` | Override model for subagents (e.g., `haiku`, `sonnet`) |
+| `CLAUDE_CODE_FORWARD_SUBAGENT_TEXT` | Set to `1` to forward subagent streaming text output to the parent session in real time. By default, subagent output is buffered until the subagent completes *(in v2.1.211 changelog, not yet on official env-vars page)* |
 | `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB` | Set to `1` to strip Anthropic and cloud provider credentials from subprocess environments (Bash tool, hooks, MCP stdio servers). Use for defense-in-depth when subprocesses should not inherit API keys (v2.1.83) |
 | `CLAUDE_CODE_SCRIPT_CAPS` | JSON object limiting how many times specific scripts may be invoked per session when `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB` is set. Keys are substrings matched against the command text; values are integer call limits. For example, `{"deploy.sh": 2}` allows `deploy.sh` to be called at most twice. Matching is substring-based; runtime fan-out via `xargs` or `find -exec` is not detected — this is a defense-in-depth control |
 | `CLAUDE_CODE_PERFORCE_MODE` | Set to `1` to enable Perforce-aware write protection. When set, Edit, Write, and NotebookEdit fail with a `p4 edit <file>` hint if the target file lacks the owner-write bit, which Perforce clears on synced files until `p4 edit` opens them. Prevents Claude Code from bypassing Perforce change tracking (v2.1.98) |
@@ -1052,10 +1055,13 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_MAX_RETRIES` | Override API request retry count (default: 10) |
 | `CLAUDE_CODE_RETRY_WATCHDOG` | Raise the retry count for non-capacity API errors to 300. The standard retry cap (`CLAUDE_CODE_MAX_RETRIES`, default: 10) still applies for capacity errors *(in v2.1.199 changelog, not on official env-vars page)* |
 | `CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY` | Max parallel read-only tools (default: 10) |
+| `CLAUDE_CODE_MAX_WEB_SEARCHES_PER_SESSION` | Maximum web searches allowed per session (default: `200`). Prevents runaway tool use in long agentic sessions *(in v2.1.212 changelog, not yet on official env-vars page)* |
+| `CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION` | Maximum subagents that can be spawned per session (default: `200`). Prevents resource exhaustion in deeply nested agentic workflows *(in v2.1.212 changelog, not yet on official env-vars page)* |
 | `CLAUDE_AGENT_SDK_DISABLE_BUILTIN_AGENTS` | Disable built-in subagent types in SDK mode (`1` to disable) |
 | `CLAUDE_AGENT_SDK_MCP_NO_PREFIX` | Skip `mcp__<server>__` prefix for MCP tools in SDK mode (`1` to enable) |
 | `CLAUDE_ASYNC_AGENT_STALL_TIMEOUT_MS` | Stall timeout in ms for background subagents (default: 600000 / 10 minutes). The subagent is killed if it produces no output for this duration |
 | `MCP_CONNECTION_NONBLOCKING` | Set to `true` in `-p` mode to skip the MCP connection wait entirely. Bounds `--mcp-config` server connections at 5s instead of blocking on the slowest server *(in v2.1.89 changelog, not yet on official env-vars page)* |
+| `CLAUDE_CODE_MCP_AUTO_BACKGROUND_MS` | Duration in milliseconds after which a slow MCP tool call is automatically backgrounded (default: `120000` / 2 minutes). MCP calls that exceed this threshold continue running in the background without blocking the agent turn *(in v2.1.212 changelog, not yet on official env-vars page)* |
 | `CLAUDE_CODE_SESSIONEND_HOOKS_TIMEOUT_MS` | SessionEnd hook timeout in ms (replaces hard 1.5s limit) |
 | `CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY` | Disable feedback survey prompts (`1` to disable) |
 | `CLAUDE_CODE_ENABLE_FEEDBACK_SURVEY_FOR_OTEL` | Set to `1` to route the session quality survey to your own OpenTelemetry collector when Anthropic-bound nonessential traffic is blocked. Survey ratings are emitted only as OTEL events to your configured collector — no survey data is sent to Anthropic. Applies when `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`, `DISABLE_TELEMETRY`, or `DO_NOT_TRACK` is set; has no effect otherwise. `CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY` and the organization product feedback policy take precedence (v2.1.136) |
@@ -1084,6 +1090,7 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_ENABLE_BYTE_WATCHDOG` | Set to `1` to force-enable the byte-level streaming idle watchdog, or `0` to force-disable it. When unset, the watchdog is enabled by default for Anthropic API connections. The byte watchdog aborts a connection when no bytes arrive on the wire for the duration set by `CLAUDE_STREAM_IDLE_TIMEOUT_MS` (minimum 5 minutes), independent of the event-level watchdog |
 | `CLAUDE_STREAM_IDLE_TIMEOUT_MS` | Timeout in ms for the streaming idle watchdog. Two watchdogs apply: **byte-level** (default and minimum `300000` / 5 minutes, aborts when no bytes arrive on the wire) and **event-level** (default `90000` / 90 seconds, no minimum, aborts when no SSE events arrive). The byte watchdog is enabled by default for Anthropic API connections; control it via `CLAUDE_ENABLE_BYTE_WATCHDOG`. Increase the event timeout if long-running tools or slow networks cause premature timeout errors |
 | `OTEL_LOG_TOOL_DETAILS` | Set to `1` to include `tool_parameters` in OpenTelemetry events. Omitted by default for privacy *(in v2.1.85 changelog, not yet on official env-vars page)* |
+| `CLAUDE_CODE_OTEL_CONTENT_MAX_LENGTH` | Maximum content length in bytes for OpenTelemetry event payloads (default: `61440` / 60 KB). Truncates large tool inputs, outputs, or message bodies before emitting them as OTel events to prevent oversized payloads *(in v2.1.215 changelog, not yet on official env-vars page)* |
 | `OTEL_LOG_RAW_API_BODIES` | Set to `1` to emit full API request and response bodies as OpenTelemetry log events. Omitted by default for privacy and payload size. Useful for debugging at a gateway or proxy *(in v2.1.111 changelog, not yet on official env-vars page)* |
 | `OTEL_RESOURCE_ATTRIBUTES` | Comma-separated `key=value` pairs added as resource attributes on all OpenTelemetry metric data points emitted by Claude Code. Use to attach environment or deployment labels (e.g., `environment=production,team=platform`) that appear on every metric for filtering in your collector (v2.1.162) |
 | `OTEL_LOG_USER_PROMPTS` | Set to `1` to include the `user_system_prompt` field in OpenTelemetry LLM request spans. Omitted by default for privacy — user prompts can contain sensitive data, so opt in only when you control the OTel collector and have policies in place *(in v2.1.121 changelog, not yet on official env-vars page)* |
@@ -1155,6 +1162,9 @@ Set environment variables for all Claude Code sessions.
 | `/permissions` | View and manage permission rules |
 | `/usage-credits` | View remaining usage credits and limits. Renamed from `/extra-usage` in v2.1.144 (the old name still works) |
 | `claude gateway` | Manage Claude Gateway connections for organization-managed deployments. Requires `forceLoginMethod: "gateway"` in managed settings (v2.1.195) |
+| `claude auto-mode reset` | Reset auto-mode classification for the current session. Prompts for confirmation; pass `--yes` to skip the prompt (v2.1.212) |
+| `/fork` | Fork the current session context into a new isolated subagent session (v2.1.212) |
+| `/subtask` | Launch an isolated subtask in a separate context. The subtask runs independently and results are returned when it completes (v2.1.212) |
 | `--doctor` | Diagnose configuration issues |
 | `--debug` | Debug mode with hook execution details |
 

--- a/changelog/best-practice/claude-settings/changelog.md
+++ b/changelog/best-practice/claude-settings/changelog.md
@@ -1127,3 +1127,21 @@
 | 4 | MED | Behavioral Note | Add v2.1.210 startup warning note for `Write(path)`, `NotebookEdit(path)`, `Glob(path)` permission rules suggesting `Edit(path)`/`Read(path)` alternatives. Confirmed in v2.1.210 changelog | ✅ COMPLETE (added blockquote note after Tool Permission Syntax table) — NEW |
 | 5 | LOW | Suspect Key Recurrence | `CLAUDE_CODE_RETRY_WATCHDOG` — still NOT on official /en/env-vars page; entry annotated "*(in v2.1.199 changelog, not on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-07-03 v2.1.199; 11 consecutive runs) |
 | 6 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 56+ consecutive runs; entry annotated "*(in v2.1.85 changelog, not yet on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-04-14 v2.1.107; 56+ consecutive runs) |
+
+---
+
+## [2026-07-19 10:44 AM PKT] Claude Code v2.1.215
+
+| # | Priority | Type | Action | Status |
+|---|----------|------|--------|--------|
+| 1 | HIGH | Missing Env Var | Add `CLAUDE_CODE_AWS_CHAIN_RESOLVE_TIMEOUT_MS` (Bedrock credential chain timeout, default 60000ms, v2.1.207). Confirmed on official env-vars page | ✅ COMPLETE (added to env vars table after `CLAUDE_CODE_SKIP_BEDROCK_AUTH`) — NEW |
+| 2 | HIGH | Missing Env Var | Add `CLAUDE_CODE_DISABLE_BEDROCK_CONTENT_TYPE_GUARD` (disable Bedrock content-type guard, v2.1.208). Confirmed on official env-vars page | ✅ COMPLETE (added to env vars table after `CLAUDE_CODE_AWS_CHAIN_RESOLVE_TIMEOUT_MS`) — NEW |
+| 3 | HIGH | Missing Env Var | Add `CLAUDE_CODE_MAX_WEB_SEARCHES_PER_SESSION` (per-session web search limit, default 200, v2.1.212). In v2.1.212 changelog, not yet on official env-vars page | ✅ COMPLETE (added with changelog annotation after `CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY`) — NEW |
+| 4 | HIGH | Missing Env Var | Add `CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION` (per-session subagent limit, default 200, v2.1.212). In v2.1.212 changelog, not yet on official env-vars page | ✅ COMPLETE (added with changelog annotation after `CLAUDE_CODE_MAX_WEB_SEARCHES_PER_SESSION`) — NEW |
+| 5 | HIGH | Missing Env Var | Add `CLAUDE_CODE_MCP_AUTO_BACKGROUND_MS` (auto-background slow MCP calls >2min, v2.1.212). In v2.1.212 changelog, not yet on official env-vars page | ✅ COMPLETE (added with changelog annotation after `MCP_CONNECTION_NONBLOCKING`) — NEW |
+| 6 | HIGH | Missing Env Var | Add `CLAUDE_CODE_FORWARD_SUBAGENT_TEXT` (forward subagent text to parent session, v2.1.211). In v2.1.211 changelog, not yet on official env-vars page | ✅ COMPLETE (added with changelog annotation after `CLAUDE_CODE_SUBAGENT_MODEL`) — NEW |
+| 7 | HIGH | Missing Env Var | Add `CLAUDE_CODE_OTEL_CONTENT_MAX_LENGTH` (OTel payload max size, default 60KB, v2.1.215). In v2.1.215 changelog, not yet on official env-vars page | ✅ COMPLETE (added with changelog annotation after `OTEL_LOG_TOOL_DETAILS`) — NEW |
+| 8 | MED | Changed Behavior | Update `sandbox.credentials` description to mention `mode` field: `"deny"` blocks entirely, `"mask"` with `injectHosts` selectively exposes credentials to trusted hosts (v2.1.199) | ✅ COMPLETE (description updated in Sandbox Settings table) — NEW |
+| 9 | MED | Missing Commands | Add `claude auto-mode reset` (reset auto-mode classification, `--yes` to skip confirmation, v2.1.212), `/fork` (fork session into isolated subagent, v2.1.212), and `/subtask` (launch isolated subtask, v2.1.212) to Useful Commands | ✅ COMPLETE (all three added to Useful Commands table) — NEW |
+| 10 | LOW | Suspect Key Recurrence | `CLAUDE_CODE_RETRY_WATCHDOG` — still NOT on official /en/env-vars page; entry annotated "*(in v2.1.199 changelog, not on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-07-03 v2.1.199; 12 consecutive runs) |
+| 11 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 57+ consecutive runs; entry annotated "*(in v2.1.85 changelog, not yet on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-04-14 v2.1.107; 57+ consecutive runs) |


### PR DESCRIPTION
## Summary

Automated daily drift check against official Claude Code docs. Report version advanced from **v2.1.210 → v2.1.215** (5 releases). All 9 action items applied and committed.

---

## Verification Log

| Rule | Category | Depth | Result | Notes |
|------|----------|-------|--------|-------|
| 1A | Key Completeness | field-level | FAIL→FIXED | 7 missing env vars added |
| 1B | Key Types | content-match | PASS | All types match |
| 1C | Key Defaults | content-match | PASS | All defaults match |
| 1D | Key Descriptions | content-match | FAIL→FIXED | `sandbox.credentials` description updated |
| 1E | Scope Column | content-match | PASS | |
| 1F | Inverse Completeness | field-level | PASS | All keys traceable or annotated |
| 1G | Edge-Case Semantics | content-match | PASS | |
| 1H | File Scope Check | content-match | PASS | |
| 1I | Skills Settings Keys | field-level | PASS | |
| 2A–2D | Settings Hierarchy | field-level/content-match | PASS | |
| 3A–3D | Permissions | field-level/content-match | PASS | |
| 4A | Hooks Redirect | exists | PASS | |
| 5A | Env Var Completeness | field-level | FAIL→FIXED | 7 vars added |
| 5B | Ownership Boundary | cross-file | PASS | No duplicates with CLI flags file |
| 5C | Env Var Descriptions | content-match | FAIL→FIXED | `sandbox.credentials` updated |
| 5D | Inverse Env Var Check | field-level | PASS | |
| 6A | Quick Reference Example | content-match | PASS | |
| 6B | Example URL Validation | exists | PASS | Schema URL valid |
| 7A | CLAUDE.md Sync | cross-file | PASS | |
| 8A | Source Credibility Guard | content-match | PASS | All flagged items confirmed in official docs or changelog |
| 9A–9C | Hyperlinks | exists | PASS | All 6 external source links valid |
| 10A | Version Metadata | content-match | FAIL→FIXED | Badge and header updated to v2.1.215 |
| 10B | Suspect Key Escalation | exists | PASS | `CLAUDE_CODE_RETRY_WATCHDOG` run 12, `OTEL_LOG_TOOL_DETAILS` run 57+ |
| 10C | Bidirectional Completeness | field-level | PASS | |

---

## Action Items Applied

| # | Priority | Type | Action | Status |
|---|----------|------|--------|--------|
| 1 | HIGH | Missing Env Var | Added `CLAUDE_CODE_AWS_CHAIN_RESOLVE_TIMEOUT_MS` — Bedrock credential chain timeout, default 60000ms (v2.1.207, confirmed on official env-vars page) | COMPLETE — NEW |
| 2 | HIGH | Missing Env Var | Added `CLAUDE_CODE_DISABLE_BEDROCK_CONTENT_TYPE_GUARD` — disable Bedrock content-type guard (v2.1.208, confirmed on official env-vars page) | COMPLETE — NEW |
| 3 | HIGH | Missing Env Var | Added `CLAUDE_CODE_FORWARD_SUBAGENT_TEXT` — forward subagent streaming text to parent session in real time (v2.1.211, changelog annotation) | COMPLETE — NEW |
| 4 | HIGH | Missing Env Var | Added `CLAUDE_CODE_MAX_WEB_SEARCHES_PER_SESSION` — per-session web search limit, default 200 (v2.1.212, changelog annotation) | COMPLETE — NEW |
| 5 | HIGH | Missing Env Var | Added `CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION` — per-session subagent spawn limit, default 200 (v2.1.212, changelog annotation) | COMPLETE — NEW |
| 6 | HIGH | Missing Env Var | Added `CLAUDE_CODE_MCP_AUTO_BACKGROUND_MS` — auto-background slow MCP calls exceeding threshold, default 120000ms/2min (v2.1.212, changelog annotation) | COMPLETE — NEW |
| 7 | HIGH | Missing Env Var | Added `CLAUDE_CODE_OTEL_CONTENT_MAX_LENGTH` — max OTel event payload size, default 61440 bytes/60KB (v2.1.215, changelog annotation) | COMPLETE — NEW |
| 8 | MED | Changed Behavior | Updated `sandbox.credentials` description: added `mode` field semantics — `"deny"` blocks entirely, `"mask"` with `injectHosts` selectively exposes to trusted hosts (v2.1.199) | COMPLETE — NEW |
| 9 | MED | Missing Commands | Added `claude auto-mode reset` (`--yes` to skip confirmation), `/fork` (fork session into isolated subagent), and `/subtask` (launch isolated subtask) to Useful Commands (v2.1.212) | COMPLETE — NEW |
| 10 | LOW | Suspect Key Recurrence | `CLAUDE_CODE_RETRY_WATCHDOG` — 12 consecutive ON HOLD runs, still not on official env-vars page | ON HOLD — RECURRING (first seen: 2026-07-03 v2.1.199) |
| 11 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — 57+ consecutive ON HOLD runs, still not on official env-vars page | ON HOLD — RECURRING (first seen: 2026-04-14 v2.1.107) |

---

## Resolved Since Last Run

No items from the v2.1.210 run required follow-up; all prior COMPLETE items remain resolved.

---

## Not Applied (Rule 8A — Official Source Not Confirmed)

The following were considered but excluded per Rule 8A (Source Credibility Guard — only flag items confirmed by official docs/changelog):

- `sandbox.network.tlsTerminate` — found in agent inference only, not on official settings page or changelog
- `DISABLE_PROMPT_CACHING_FABLE` — inferred from `DISABLE_PROMPT_CACHING_OPUS` pattern, not in official docs

---

*Do not merge — leave for human review.*

---
_Generated by [Claude Code](https://claude.ai/code/session_017cUfhBzEX7FAEMkFU3k1z1)_