### PR TITLE
Daily settings drift check — 2026-07-20 (Claude Code v2.1.215)

### DIFF
--- a/best-practice/claude-settings.md
+++ b/best-practice/claude-settings.md
@@ -1,6 +1,6 @@
 # Settings Best Practice
 
-![Last Updated](https://img.shields.io/badge/Last_Updated-Jul%2019%2C%202026%2010%3A44%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.215-blue?style=flat&labelColor=555)<br>
+![Last Updated](https://img.shields.io/badge/Last_Updated-Jul%2020%2C%202026%2010%3A46%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.215-blue?style=flat&labelColor=555)<br>
 [![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../.claude/settings.json)
 
 A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.215, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
@@ -63,6 +63,7 @@ Within the managed tier, precedence is: server-managed > MDM/OS-level policies >
 | `requiredMinimumVersion` | string | - | **(Managed only)** Prevents Claude Code from starting if the installed version is below this floor. CLI exits with an error prompting the user to upgrade. Complements `minimumVersion` (which controls auto-update floor) — this one enforces at startup. Example: `"2.1.163"` |
 | `requiredMaximumVersion` | string | - | **(Managed only)** Prevents Claude Code from starting if the installed version exceeds this ceiling. CLI exits with an error if the version is too new. Use alongside `requiredMinimumVersion` to pin a specific version range in managed environments. Example: `"2.1.165"` |
 | `browserExternalPageTools` | string | - | **(Managed only)** Set to `"disabled"` to prevent Claude from using tools to read or act on external pages in the desktop app's Browser pane. Users can still navigate to external sites themselves, and local dev server previews are unaffected |
+| `disableBrowserExternalNavigation` | boolean | - | **(Managed only)** Disable external browsing in the desktop app's Browser pane. When `true`, users cannot navigate to any external page in the Browser pane; local dev-server previews remain accessible |
 
 **Important**:
 - `deny` rules have highest safety precedence and cannot be overridden by lower-priority allow/ask rules.

--- a/changelog/best-practice/claude-settings/changelog.md
+++ b/changelog/best-practice/claude-settings/changelog.md
@@ -1145,3 +1145,14 @@
 | 9 | MED | Missing Commands | Add `claude auto-mode reset` (reset auto-mode classification, `--yes` to skip confirmation, v2.1.212), `/fork` (fork session into isolated subagent, v2.1.212), and `/subtask` (launch isolated subtask, v2.1.212) to Useful Commands | ✅ COMPLETE (all three added to Useful Commands table) — NEW |
 | 10 | LOW | Suspect Key Recurrence | `CLAUDE_CODE_RETRY_WATCHDOG` — still NOT on official /en/env-vars page; entry annotated "*(in v2.1.199 changelog, not on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-07-03 v2.1.199; 12 consecutive runs) |
 | 11 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 57+ consecutive runs; entry annotated "*(in v2.1.85 changelog, not yet on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-04-14 v2.1.107; 57+ consecutive runs) |
+
+---
+
+## [2026-07-20 10:46 AM PKT] Claude Code v2.1.215
+
+| # | Priority | Type | Action | Status |
+|---|----------|------|--------|--------|
+| 1 | HIGH | Missing Setting | Add `disableBrowserExternalNavigation` (boolean, Managed only) to managed-only policy keys table — confirmed on official settings page; separate from `browserExternalPageTools` (disables navigation entirely, not just tool usage) | ✅ COMPLETE (added after `browserExternalPageTools` in managed-only table) — NEW |
+| 2 | LOW | Version Attribution | `CLAUDE_CODE_OTEL_CONTENT_MAX_LENGTH` tagged as "v2.1.215 changelog" but research agent notes changelog attributes it to v2.1.214 (confidence 0.5) — not actioning per Rule 8A | ✋ ON HOLD (unresolved — source confidence too low) |
+| 3 | LOW | Suspect Key Recurrence | `CLAUDE_CODE_RETRY_WATCHDOG` — still NOT on official /en/env-vars page; annotated "*(in v2.1.199 changelog, not on official env-vars page)*" | ✋ ON HOLD (RECURRING; 13 consecutive runs) |
+| 4 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page; annotated "*(in v2.1.85 changelog, not yet on official env-vars page)*" | ✋ ON HOLD (RECURRING; 58+ consecutive runs) |


### PR DESCRIPTION
## Verification Log

All rules from `changelog/best-practice/claude-settings/verification-checklist.md` executed against official sources (settings page, env-vars page, permissions page, JSON schema).

| Rule | Category | Result |
|------|----------|--------|
| 1A | Key Completeness | ❌ DRIFT — `disableBrowserExternalNavigation` missing (see fix below) |
| 1B–1I | Types / Defaults / Descriptions / Scope / Inverse / Edge-case / File scope / Skills keys | ✅ PASS |
| 2A–2D | Settings Hierarchy | ✅ PASS |
| 3A–3D | Permissions | ✅ PASS — all 6 modes confirmed (`default`/`manual`, `acceptEdits`, `plan`, `auto`, `dontAsk`, `bypassPermissions`) |
| 4A | Hooks Redirect | ✅ PASS — redirect link present and correct |
| 5A–5D | Environment Variables | ✅ PASS — `NO_COLOR`/`FORCE_COLOR` NOT on official env-vars page (ruled out); ON HOLD items recurring as expected |
| 6A–6B | Examples / URL Validation | ✅ PASS — schema URL redirects (301) but resolves to valid JSON Schema |
| 7A | CLAUDE.md Sync | ✅ PASS |
| 8A | Source Credibility Guard | Applied — only actioning `disableBrowserExternalNavigation` which is confirmed on official settings page |
| 9A | Local File Links | ✅ PASS — `.claude/settings.json`, `!/claude-jumping.svg` both exist |
| 9B | External URLs | ✅ PASS — all 6 sources resolve (GitHub pages have JS rendering quirks but pages exist) |
| 9C | Anchor Links | ✅ PASS — all 12 ToC anchors correspond to H2 headings |
| 10A | Version Metadata | ✅ PASS — badge shows v2.1.215 |
| 10B | Suspect Key Lifecycle | ✋ ON HOLD — `CLAUDE_CODE_RETRY_WATCHDOG` (13 consecutive), `OTEL_LOG_TOOL_DETAILS` (58+ consecutive); both annotated with changelog source |
| 10C | Bidirectional Completeness | ✅ PASS |

---

## Action Items

| # | Priority | Type | Action | Status |
|---|----------|------|--------|--------|
| 1 | HIGH | Missing Setting | Add `disableBrowserExternalNavigation` (boolean, Managed only) — confirmed on official settings page | ✅ COMPLETE — NEW |
| 2 | LOW | Version Attribution | `CLAUDE_CODE_OTEL_CONTENT_MAX_LENGTH` tagged "v2.1.215 changelog" but changelog may attribute it to v2.1.214 (conf 0.5) — not actioning per Rule 8A | ✋ ON HOLD |
| 3 | LOW | Suspect Key | `CLAUDE_CODE_RETRY_WATCHDOG` — 13 consecutive ON HOLD runs | ✋ ON HOLD (RECURRING) |
| 4 | LOW | Suspect Key | `OTEL_LOG_TOOL_DETAILS` — 58+ consecutive ON HOLD runs | ✋ ON HOLD (RECURRING) |

---

## Changes

### `best-practice/claude-settings.md`
- Added `disableBrowserExternalNavigation` (boolean, Managed only) to the managed-only policy keys table after `browserExternalPageTools`. These are distinct keys: `browserExternalPageTools: "disabled"` prevents Claude from *using tools* on external pages while users can still navigate; `disableBrowserExternalNavigation: true` disables external navigation in the Browser pane entirely.
- Updated **Last Updated** badge to `Jul 20, 2026 10:46 AM PKT`

### `changelog/best-practice/claude-settings/changelog.md`
- Appended `[2026-07-20 10:46 AM PKT] Claude Code v2.1.215` entry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Etgp2PJZaYgcURK9kH4TCn)_