### PR TITLE
Daily settings drift check — 2026-07-21 (Claude Code v2.1.216)

### DIFF
--- a/best-practice/claude-settings.md
+++ b/best-practice/claude-settings.md
@@ -1,9 +1,9 @@
 # Settings Best Practice
 
-![Last Updated](https://img.shields.io/badge/Last_Updated-Jul%2019%2C%202026%2010%3A44%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.215-blue?style=flat&labelColor=555)<br>
+![Last Updated](https://img.shields.io/badge/Last_Updated-Jul%2021%2C%202026%2010%3A45%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.216-blue?style=flat&labelColor=555)<br>
 [![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../.claude/settings.json)
 
-A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.215, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
+A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.216, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
 
 <table width="100%">
 <tr>
@@ -329,6 +329,8 @@ Control what tools and operations Claude can perform.
 
 **Symlink resolution:** Permission rules check both the symlink path and its resolved target. **Allow** rules apply only when *both* the symlink and its target match — a symlink inside an allowed directory that points outside it still prompts. **Deny** rules apply when *either* the symlink or its target matches — a symlink to a denied file is itself denied.
 
+**Single-segment path patterns (v2.1.214):** `Edit(src/**)` matches only paths directly under `<cwd>/src` (the `src` component must be at the project root level). To approve edits to a `src/` directory at *any* depth in the tree, use `Edit(**/src/**)`. This tightens previous behavior where bare single-segment patterns could inadvertently match the same directory name at any depth.
+
 **Bash wildcard notes:**
 - `*` can appear at **any position**: prefix (`Bash(* install)`), suffix (`Bash(npm *)`), or middle (`Bash(git * main)`)
 - **Word boundary:** `Bash(ls *)` (space before `*`) matches `ls -la` but NOT `lsof`; `Bash(ls*)` (no space) matches both
@@ -337,6 +339,8 @@ Control what tools and operations Claude can perform.
 - The legacy `:*` suffix syntax (e.g., `Bash(npm:*)`) is equivalent to ` *` but is deprecated
 - **Compound commands:** shell operators (`&&`, `||`, `;`, `|`, `|&`, `&`, and newlines) split a command and each subcommand must match independently — `Bash(safe-cmd *)` does **not** authorize `safe-cmd && other-cmd`
 - **Process wrappers:** `timeout`, `time`, `nice`, `nohup`, and `stdbuf` are stripped before matching (so `Bash(npm test *)` also matches `timeout 30 npm test`); bare `xargs` (no flags) is stripped too. Exec wrappers `watch`, `setsid`, `ionice`, `flock`, and `find` with `-exec`/`-delete` always prompt and cannot be approved by a prefix rule
+
+**Docker daemon-redirect prompting (v2.1.214):** Docker commands that redirect to a different daemon — via `--url`, `--connection`, or `--identity` flags, or Podman in remote mode — always trigger an explicit permission prompt regardless of any allow rules. This prevents existing `Bash(docker *)` rules from being silently escalated by daemon-redirect flags.
 
 **Example:**
 ```json
@@ -473,6 +477,7 @@ Configure bash command sandboxing for security.
 | `sandbox.network.socksProxyPort` | number | - | SOCKS5 proxy port 1-65535 (custom proxy) |
 | `sandbox.network.allowManagedDomainsOnly` | boolean | `false` | Only allow domains in managed allowlist (managed settings) |
 | `sandbox.network.allowMachLookup` | array | `[]` | (macOS only) Additional XPC/Mach service names the sandbox may look up. Supports a single trailing `*` for prefix matching. Needed for tools that communicate via XPC such as the iOS Simulator or Playwright. Example: `["com.apple.coresimulator.*"]` |
+| `sandbox.filesystem.disabled` | boolean | `false` | Disable filesystem isolation while keeping network controls active. When `true`, sandboxed commands can read and write anywhere — `allowWrite`, `denyWrite`, `denyRead`, and `allowRead` path lists are ignored. Useful when you want network egress control without filesystem restrictions (v2.1.216) |
 | `sandbox.filesystem.allowWrite` | array | `[]` | Additional paths where sandboxed commands can write. Arrays are merged across all settings scopes. Also merged with paths from `Edit(...)` allow permission rules. Prefix: `/` (absolute), `~/` (home), `./` or none (project-relative in project settings, `~/.claude`-relative in user settings). The older `//` prefix for absolute paths still works. **Note:** This differs from [Read/Edit permission rules](#tool-permission-syntax), which use `//` for absolute and `/` for project-relative |
 | `sandbox.filesystem.denyWrite` | array | `[]` | Paths where sandboxed commands cannot write. Arrays are merged across all settings scopes. Also merged with paths from `Edit(...)` deny permission rules. Same path prefix conventions as `allowWrite` |
 | `sandbox.filesystem.denyRead` | array | `[]` | Paths where sandboxed commands cannot read. Arrays are merged across all settings scopes. Also merged with paths from `Read(...)` deny permission rules. Same path prefix conventions as `allowWrite` |
@@ -773,6 +778,7 @@ The status line command receives a JSON object on stdin. For the full JSON schem
 | `worktree.original_cwd` | Directory before entering the worktree |
 | `worktree.original_branch` | Git branch checked out before entering the worktree. Absent for hook-based worktrees |
 | `github` | GitHub repository and pull-request information for the current branch when detected — repo identity and the associated PR (v2.1.145) |
+| `subagentStatusLine` | Present in background-subagent status updates. Contains `name`, `status`, `icon`, and `effort` fields — `effort` carries the reasoning-effort string for the custom agent row and was added in v2.1.216. Only delivered when the status update originates from a background subagent, not the main session (v2.1.216) |
 
 ### File Suggestion Configuration
 
@@ -1090,7 +1096,7 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_ENABLE_BYTE_WATCHDOG` | Set to `1` to force-enable the byte-level streaming idle watchdog, or `0` to force-disable it. When unset, the watchdog is enabled by default for Anthropic API connections. The byte watchdog aborts a connection when no bytes arrive on the wire for the duration set by `CLAUDE_STREAM_IDLE_TIMEOUT_MS` (minimum 5 minutes), independent of the event-level watchdog |
 | `CLAUDE_STREAM_IDLE_TIMEOUT_MS` | Timeout in ms for the streaming idle watchdog. Two watchdogs apply: **byte-level** (default and minimum `300000` / 5 minutes, aborts when no bytes arrive on the wire) and **event-level** (default `90000` / 90 seconds, no minimum, aborts when no SSE events arrive). The byte watchdog is enabled by default for Anthropic API connections; control it via `CLAUDE_ENABLE_BYTE_WATCHDOG`. Increase the event timeout if long-running tools or slow networks cause premature timeout errors |
 | `OTEL_LOG_TOOL_DETAILS` | Set to `1` to include `tool_parameters` in OpenTelemetry events. Omitted by default for privacy *(in v2.1.85 changelog, not yet on official env-vars page)* |
-| `CLAUDE_CODE_OTEL_CONTENT_MAX_LENGTH` | Maximum content length in bytes for OpenTelemetry event payloads (default: `61440` / 60 KB). Truncates large tool inputs, outputs, or message bodies before emitting them as OTel events to prevent oversized payloads *(in v2.1.215 changelog, not yet on official env-vars page)* |
+| `CLAUDE_CODE_OTEL_CONTENT_MAX_LENGTH` | Maximum content length in bytes for OpenTelemetry event payloads (default: `61440` / 60 KB). Truncates large tool inputs, outputs, or message bodies before emitting them as OTel events to prevent oversized payloads *(in v2.1.214 changelog, not yet on official env-vars page)* |
 | `OTEL_LOG_RAW_API_BODIES` | Set to `1` to emit full API request and response bodies as OpenTelemetry log events. Omitted by default for privacy and payload size. Useful for debugging at a gateway or proxy *(in v2.1.111 changelog, not yet on official env-vars page)* |
 | `OTEL_RESOURCE_ATTRIBUTES` | Comma-separated `key=value` pairs added as resource attributes on all OpenTelemetry metric data points emitted by Claude Code. Use to attach environment or deployment labels (e.g., `environment=production,team=platform`) that appear on every metric for filtering in your collector (v2.1.162) |
 | `OTEL_LOG_USER_PROMPTS` | Set to `1` to include the `user_system_prompt` field in OpenTelemetry LLM request spans. Omitted by default for privacy — user prompts can contain sensitive data, so opt in only when you control the OTel collector and have policies in place *(in v2.1.121 changelog, not yet on official env-vars page)* |
@@ -1167,6 +1173,7 @@ Set environment variables for all Claude Code sessions.
 | `/subtask` | Launch an isolated subtask in a separate context. The subtask runs independently and results are returned when it completes (v2.1.212) |
 | `--doctor` | Diagnose configuration issues |
 | `--debug` | Debug mode with hook execution details |
+| `EndConversation` | Built-in tool Claude can invoke to terminate a session when a user engages in severe ToU violations. Not user-invocable — Claude calls it autonomously; users receive a message explaining the termination (v2.1.214) |
 
 ---
 

--- a/changelog/best-practice/claude-settings/changelog.md
+++ b/changelog/best-practice/claude-settings/changelog.md
@@ -1145,3 +1145,20 @@
 | 9 | MED | Missing Commands | Add `claude auto-mode reset` (reset auto-mode classification, `--yes` to skip confirmation, v2.1.212), `/fork` (fork session into isolated subagent, v2.1.212), and `/subtask` (launch isolated subtask, v2.1.212) to Useful Commands | ✅ COMPLETE (all three added to Useful Commands table) — NEW |
 | 10 | LOW | Suspect Key Recurrence | `CLAUDE_CODE_RETRY_WATCHDOG` — still NOT on official /en/env-vars page; entry annotated "*(in v2.1.199 changelog, not on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-07-03 v2.1.199; 12 consecutive runs) |
 | 11 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 57+ consecutive runs; entry annotated "*(in v2.1.85 changelog, not yet on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-04-14 v2.1.107; 57+ consecutive runs) |
+
+---
+
+## [2026-07-21 10:45 AM PKT] Claude Code v2.1.216
+
+| # | Priority | Type | Action | Status |
+|---|----------|------|--------|--------|
+| 1 | HIGH | Version Bump | Update report version badge from v2.1.215 → v2.1.216 and header "As of v2.1.215" → "As of v2.1.216" | ✅ COMPLETE (badge + header updated as mandatory maintenance) — NEW |
+| 2 | HIGH | Missing Setting | Add `sandbox.filesystem.disabled` (boolean, default `false`, v2.1.216) to Sandbox Settings table — skips filesystem isolation while maintaining network egress control. Confirmed in v2.1.216 changelog | ✅ COMPLETE (added to Sandbox Settings table) — NEW |
+| 3 | HIGH | Permission Syntax | Document single-segment `dir/**` allow rule restriction (v2.1.214/v2.1.216): `Edit(src/**)` auto-approves only paths starting at `<cwd>/src`; use `Edit(**/src/**)` for any-depth matching. Confirmed in v2.1.214/v2.1.216 changelog | ✅ COMPLETE (added behavioral note after Tool Permission Syntax table) — NEW |
+| 4 | MED | Permission Syntax | Document docker daemon-redirect prompting: docker commands with `--url`, `--connection`, `--identity`, or Podman remote mode now trigger explicit permission prompts (v2.1.214). Confirmed in v2.1.214 changelog | ✅ COMPLETE (added note to Permissions section) — NEW |
+| 5 | MED | New Tool Note | Add `EndConversation` tool note (v2.1.214) — Claude can terminate sessions with highly abusive users. Confirmed in v2.1.214 changelog | ✅ COMPLETE (added to Useful Commands / built-in notes) — NEW |
+| 6 | MED | Version Attribution | Fix `CLAUDE_CODE_OTEL_CONTENT_MAX_LENGTH` annotation: report says "v2.1.215 changelog" but official changelog shows v2.1.214. Confirmed in raw changelog | ✅ COMPLETE (annotation updated to v2.1.214 changelog) — NEW |
+| 7 | MED | Missing Setting | Add `disableBrowserExternalNavigation` (boolean, Managed only) to managed-only settings. Listed on official settings page but low confidence due to partial page garbling — kept as ON HOLD pending cleaner fetch | ✋ ON HOLD (official settings page listed it but fetch was partially garbled — verify on next run) — NEW |
+| 8 | LOW | Status Line | Add `subagentStatusLine` payload note to Status Line section (v2.1.216) — custom agent rows now include reasoning effort field. Confirmed in v2.1.216 changelog | ✅ COMPLETE (added note to Status Line / Display & UX section) — NEW |
+| 9 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 58+ consecutive runs; entry annotated "*(in v2.1.85 changelog, not yet on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-04-14 v2.1.107; 58+ consecutive runs) |
+| 10 | LOW | Suspect Key Recurrence | `CLAUDE_CODE_RETRY_WATCHDOG` — still NOT on official /en/env-vars page; entry annotated "*(in v2.1.199 changelog, not on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-07-03 v2.1.199; 13 consecutive runs) |


### PR DESCRIPTION
## Summary

Automated daily drift check against Claude Code v2.1.216. Two parallel research agents (workflow-claude-settings-agent + claude-code-guide) identified 8 actionable items; all HIGH/MED/LOW items applied in this PR. Badge, header, and changelog updated as mandatory housekeeping.

## Changes Applied

### `best-practice/claude-settings.md`

| # | Priority | Change |
|---|----------|--------|
| 1 | HIGH | Version badge + header bumped: v2.1.215 → v2.1.216 |
| 2 | HIGH | Added `sandbox.filesystem.disabled` (boolean, default `false`, v2.1.216) to Sandbox Settings table — disables filesystem isolation while network controls remain active |
| 3 | HIGH | Added **Single-segment path pattern** note (v2.1.214): `Edit(src/**)` only matches directly under `<cwd>/src`; use `Edit(**/src/**)` for any-depth matching |
| 4 | MED | Added **Docker daemon-redirect prompting** note (v2.1.214): `--url`/`--connection`/`--identity` flags and Podman remote mode always trigger permission prompts regardless of allow rules |
| 5 | MED | Added `EndConversation` built-in tool entry to Useful Commands (v2.1.214) — Claude can terminate sessions on severe ToU violations |
| 6 | MED | Fixed `CLAUDE_CODE_OTEL_CONTENT_MAX_LENGTH` version annotation: "v2.1.215 changelog" → "v2.1.214 changelog" |
| 7 | LOW | Added `subagentStatusLine.effort` field note to Status Line input fields table (v2.1.216) |

### `changelog/best-practice/claude-settings/changelog.md`

Appended new entry `[2026-07-21 10:45 AM PKT] Claude Code v2.1.216` with 10 items (7 COMPLETE, 1 ON HOLD pending cleaner fetch, 2 recurring ON HOLD suspect keys).

## Items Deferred (ON HOLD)

- **`disableBrowserExternalNavigation`** (MED) — listed on official settings page as a managed boolean, but the settings page fetch had partial garbling this run. Will resolve on next run with a cleaner fetch.
- **`OTEL_LOG_TOOL_DETAILS`** (LOW) — 58+ consecutive runs; still not on the official env-vars page. Kept with existing annotation.
- **`CLAUDE_CODE_RETRY_WATCHDOG`** (LOW) — 13 consecutive runs; still not on the official env-vars page. Kept with existing annotation.

## Hyperlink Validation

All links OK. One note: `json.schemastore.org` now issues a 301 redirect to `www.schemastore.org` — destination is valid; LOW priority for a future pass.

## Verification Checklist Results

All 25 rules executed. Failures this run (all fixed in this PR):
- **1A**: `sandbox.filesystem.disabled` missing → added
- **3B**: single-segment path restriction not documented → added
- **3D**: docker daemon-redirect not documented → added
- **10A**: badge/header at v2.1.215 → bumped to v2.1.216

---
*Do not merge — leave open for human review.*

---
_Generated by [Claude Code](https://claude.ai/code/session_01MYBMNTshAUzrGs8FaWBZ35)_