### PR TITLE
Daily settings drift check — 2026-07-22 (Claude Code v2.1.217)

### DIFF
--- a/best-practice/claude-settings.md
+++ b/best-practice/claude-settings.md
@@ -1,9 +1,9 @@
 # Settings Best Practice
 
-![Last Updated](https://img.shields.io/badge/Last_Updated-Jul%2019%2C%202026%2010%3A44%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.215-blue?style=flat&labelColor=555)<br>
+![Last Updated](https://img.shields.io/badge/Last_Updated-Jul%2022%2C%202026%2010%3A47%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.217-blue?style=flat&labelColor=555)<br>
 [![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../.claude/settings.json)
 
-A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.215, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
+A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.217, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
 
 <table width="100%">
 <tr>
@@ -63,6 +63,7 @@ Within the managed tier, precedence is: server-managed > MDM/OS-level policies >
 | `requiredMinimumVersion` | string | - | **(Managed only)** Prevents Claude Code from starting if the installed version is below this floor. CLI exits with an error prompting the user to upgrade. Complements `minimumVersion` (which controls auto-update floor) — this one enforces at startup. Example: `"2.1.163"` |
 | `requiredMaximumVersion` | string | - | **(Managed only)** Prevents Claude Code from starting if the installed version exceeds this ceiling. CLI exits with an error if the version is too new. Use alongside `requiredMinimumVersion` to pin a specific version range in managed environments. Example: `"2.1.165"` |
 | `browserExternalPageTools` | string | - | **(Managed only)** Set to `"disabled"` to prevent Claude from using tools to read or act on external pages in the desktop app's Browser pane. Users can still navigate to external sites themselves, and local dev server previews are unaffected |
+| `disableBrowserExternalNavigation` | boolean | `false` | **(Managed only)** When `true`, prevents the desktop app's browser pane from navigating to external websites. Restricts the browser to local origins only (e.g., `localhost`). Complements `browserExternalPageTools`, which blocks tool-based access; this setting also blocks manual user navigation to external URLs |
 
 **Important**:
 - `deny` rules have highest safety precedence and cannot be overridden by lower-priority allow/ask rules.
@@ -104,6 +105,7 @@ Within the managed tier, precedence is: server-managed > MDM/OS-level policies >
 | `disableSkillShellExecution` | boolean | `false` | Disable inline shell execution for `` !`...` `` and `` ```! `` blocks in skills and custom commands from user, project, plugin, or additional-directory sources. Commands are replaced with `[shell command execution disabled by policy]` instead of being run. Bundled and managed skills are not affected (v2.1.91) |
 | `maxSkillDescriptionChars` | number | `1536` | Per-skill character cap on the combined `description` and `when_to_use` text in the [skill listing](https://code.claude.com/docs/en/skills) Claude sees each turn. Text longer than this is truncated (v2.1.105) |
 | `skillListingBudgetFraction` | number | `0.01` | Fraction of the model's context window reserved for the [skill listing](https://code.claude.com/docs/en/skills) Claude sees each turn (`0.01` = 1%). When the listing exceeds the budget, descriptions for the least-used skills are collapsed to bare names so Claude can still invoke them but won't see why (v2.1.105) |
+| `skillDirectories` | array | - | Additional directories to search for [skills](https://code.claude.com/docs/en/skills), beyond the default `.claude/skills/`. Each entry is an absolute or `~/`-expanded path. Skills discovered in these directories are merged into the standard skill listing. Useful for shared team skill libraries maintained outside the project repository |
 | `forceRemoteSettingsRefresh` | boolean | `false` | **(Managed only)** Block CLI startup until remote managed settings are freshly fetched. If the fetch fails, the CLI exits (fail-closed). Use in enterprise environments where policy enforcement must be up-to-date before any session begins (v2.1.92) |
 | `wslInheritsWindowsSettings` | boolean | `false` | **(Windows managed settings only)** When `true`, Claude Code on WSL reads managed settings from the Windows policy chain (HKLM registry + `C:\Program Files\ClaudeCode\managed-settings.json`) in addition to `/etc/claude-code`, with Windows sources taking priority. Only honored when set in the HKLM registry key or `C:\Program Files\ClaudeCode\managed-settings.json`, both of which require Windows admin to write. For HKCU policy to also apply on WSL, the flag must additionally be set in HKCU itself. Has no effect on native Windows (v2.1.118) |
 | `tui` | string | `"default"` | Rendering mode: `"fullscreen"` or `"default"`. Set via `/tui fullscreen` for flicker-free alt-screen rendering (v2.1.110) |
@@ -329,6 +331,8 @@ Control what tools and operations Claude can perform.
 
 **Symlink resolution:** Permission rules check both the symlink path and its resolved target. **Allow** rules apply only when *both* the symlink and its target match — a symlink inside an allowed directory that points outside it still prompts. **Deny** rules apply when *either* the symlink or its target matches — a symlink to a denied file is itself denied.
 
+**Path-anchor change (v2.1.214):** A rule with exactly one directory component before `/**` (e.g., `dir/**`, no `/`, `~/`, or `./` prefix) now anchors to the project root — it matches only `<cwd>/dir/**` and will not match the same segment appearing at a deeper path. Add `./` to make the relative-cwd anchor explicit, or use `/` for a project-root-relative path.
+
 **Bash wildcard notes:**
 - `*` can appear at **any position**: prefix (`Bash(* install)`), suffix (`Bash(npm *)`), or middle (`Bash(git * main)`)
 - **Word boundary:** `Bash(ls *)` (space before `*`) matches `ls -la` but NOT `lsof`; `Bash(ls*)` (no space) matches both
@@ -478,6 +482,7 @@ Configure bash command sandboxing for security.
 | `sandbox.filesystem.denyRead` | array | `[]` | Paths where sandboxed commands cannot read. Arrays are merged across all settings scopes. Also merged with paths from `Read(...)` deny permission rules. Same path prefix conventions as `allowWrite` |
 | `sandbox.filesystem.allowRead` | array | `[]` | Paths to re-allow read access within `denyRead` regions. Takes precedence over `denyRead`. Arrays are merged across all settings scopes. Same path prefix conventions as `allowWrite` |
 | `sandbox.filesystem.allowManagedReadPathsOnly` | boolean | `false` | **(Managed only)** Only `allowRead` paths from managed settings are respected. `allowRead` entries from user, project, and local settings are ignored |
+| `sandbox.filesystem.disabled` | boolean | `false` | **(Managed only)** Disable all filesystem access for sandboxed commands. When `true`, the sandbox blocks all file reads and writes by default; combine with `allowRead`/`allowWrite` to grant selective access in locked-down environments (v2.1.216) |
 | `sandbox.enableWeakerNetworkIsolation` | boolean | `false` | (macOS only) Allow access to system TLS trust (`com.apple.trustd.agent`); reduces security |
 | `sandbox.bwrapPath` | string | - | **(Managed only, Linux/WSL2)** Absolute path to the bubblewrap (`bwrap`) binary. Overrides automatic `PATH` detection. Only honored from managed settings, not user or project settings. Example: `/opt/admin/bwrap` (v2.1.133) |
 | `sandbox.socatPath` | string | - | **(Managed only, Linux/WSL2)** Absolute path to the `socat` binary used for the sandbox network proxy. Overrides automatic `PATH` detection. Only honored from managed settings. Example: `/opt/admin/socat` (v2.1.133) |
@@ -666,6 +671,7 @@ Configure via `env` key:
 | `preferredNotifChannel` | string | `"auto"` | Method for task-complete and permission-prompt notifications. Values: `"auto"`, `"terminal_bell"`, `"iterm2"`, `"iterm2_with_bell"`, `"kitty"`, `"ghostty"`, `"notifications_disabled"`. Default `"auto"` sends a desktop notification in iTerm2, Ghostty, and Kitty and does nothing in other terminals. Set `"terminal_bell"` to ring the bell character in any terminal. Appears in `/config` as **Notifications**. See [Get a terminal bell or notification](https://code.claude.com/docs/en/terminal-config#get-a-terminal-bell-or-notification) |
 | `wheelScrollAccelerationEnabled` | boolean | `true` | Disable mouse-wheel scroll acceleration in fullscreen mode. Set to `false` to use fixed per-tick scroll steps instead of the OS-level acceleration curve (v2.1.174) |
 | `footerLinksRegexes` | array | - | Regex patterns matched against URLs to display as link badges in the footer row. Each matching URL produces a clickable badge at the bottom of the chat UI (v2.1.176) |
+| `emojiCompletionEnabled` | boolean | `true` | Enable emoji completion in the input box. When `true` (default), typing `:` followed by text shows an emoji suggestion dropdown. Set to `false` to disable the emoji picker (v2.1.217) |
 
 ### Global Config Settings (`~/.claude.json`)
 
@@ -1057,6 +1063,8 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY` | Max parallel read-only tools (default: 10) |
 | `CLAUDE_CODE_MAX_WEB_SEARCHES_PER_SESSION` | Maximum web searches allowed per session (default: `200`). Prevents runaway tool use in long agentic sessions *(in v2.1.212 changelog, not yet on official env-vars page)* |
 | `CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION` | Maximum subagents that can be spawned per session (default: `200`). Prevents resource exhaustion in deeply nested agentic workflows *(in v2.1.212 changelog, not yet on official env-vars page)* |
+| `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS` | Maximum number of subagents running concurrently per session (default: `20`). Limits parallel resource use when many subagents are spawned at once. Default set to `20` as of v2.1.217 *(in v2.1.213/v2.1.217 changelog, not yet on official env-vars page)* |
+| `CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH` | Maximum nesting depth for subagent spawning chains (v2.1.217). Prevents infinitely recursive subagent spawning — when a subagent's depth would exceed this limit, the spawn is rejected with an error *(in v2.1.217 changelog, not yet on official env-vars page)* |
 | `CLAUDE_AGENT_SDK_DISABLE_BUILTIN_AGENTS` | Disable built-in subagent types in SDK mode (`1` to disable) |
 | `CLAUDE_AGENT_SDK_MCP_NO_PREFIX` | Skip `mcp__<server>__` prefix for MCP tools in SDK mode (`1` to enable) |
 | `CLAUDE_ASYNC_AGENT_STALL_TIMEOUT_MS` | Stall timeout in ms for background subagents (default: 600000 / 10 minutes). The subagent is killed if it produces no output for this duration |
@@ -1197,6 +1205,7 @@ Set environment variables for all Claude Code sessions.
   "disableWorkflows": false,
   "workflowKeywordTriggerEnabled": true,
   "syntaxHighlightingDisabled": false,
+  "emojiCompletionEnabled": true,
 
   "worktree": {
     "symlinkDirectories": ["node_modules"],

--- a/changelog/best-practice/claude-settings/changelog.md
+++ b/changelog/best-practice/claude-settings/changelog.md
@@ -1145,3 +1145,21 @@
 | 9 | MED | Missing Commands | Add `claude auto-mode reset` (reset auto-mode classification, `--yes` to skip confirmation, v2.1.212), `/fork` (fork session into isolated subagent, v2.1.212), and `/subtask` (launch isolated subtask, v2.1.212) to Useful Commands | ✅ COMPLETE (all three added to Useful Commands table) — NEW |
 | 10 | LOW | Suspect Key Recurrence | `CLAUDE_CODE_RETRY_WATCHDOG` — still NOT on official /en/env-vars page; entry annotated "*(in v2.1.199 changelog, not on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-07-03 v2.1.199; 12 consecutive runs) |
 | 11 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 57+ consecutive runs; entry annotated "*(in v2.1.85 changelog, not yet on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-04-14 v2.1.107; 57+ consecutive runs) |
+
+---
+
+## [2026-07-22 10:47 AM PKT] Claude Code v2.1.217
+
+| # | Priority | Type | Action | Status |
+|---|----------|------|--------|--------|
+| 1 | HIGH | Missing Setting | Add `emojiCompletionEnabled` (boolean, default `true`, any scope, v2.1.217) to Display Settings table. Confirmed on official settings page | ✅ COMPLETE (added to Display Settings table after `footerLinksRegexes`) — NEW |
+| 2 | HIGH | Missing Setting | Add `sandbox.filesystem.disabled` (boolean, Managed only, v2.1.216) to Sandbox Settings table. Confirmed on official settings page | ✅ COMPLETE (added after `sandbox.filesystem.allowManagedReadPathsOnly`) — NEW |
+| 3 | HIGH | Missing Setting | Add `disableBrowserExternalNavigation` (boolean, Managed only) to Managed-only policy keys table. Confirmed on official settings page | ✅ COMPLETE (added after `browserExternalPageTools`) — NEW |
+| 4 | HIGH | Missing Setting | Add `skillDirectories` (array, any scope) to General Settings — corrects v2.1.195 INVALID finding; setting now confirmed present on official settings page | ✅ COMPLETE (added to General Settings after `skillListingBudgetFraction`) — RESOLVED (was INVALID since 2026-06-29) |
+| 5 | HIGH | Missing Env Var | Add `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS` (default `20`, v2.1.213/v2.1.217) to env vars table. Confirmed in v2.1.217 changelog; not yet on official env-vars page | ✅ COMPLETE (added with changelog annotation after `CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION`) — NEW |
+| 6 | HIGH | Missing Env Var | Add `CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH` (v2.1.217) to env vars table. Confirmed in v2.1.217 changelog; not yet on official env-vars page | ✅ COMPLETE (added with changelog annotation after `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS`) — NEW |
+| 7 | MED | Behavioral Change | Document v2.1.214 permission path-anchor change: single-segment `dir/**` rules now anchor to project cwd only. Added note to Tool Permission Syntax section after symlink resolution | ✅ COMPLETE (path-anchor note added after symlink resolution block) — NEW |
+| 8 | LOW | Example Update | Add `emojiCompletionEnabled: true` to Quick Reference complete example | ✅ COMPLETE (added after `syntaxHighlightingDisabled`) — NEW |
+| 9 | LOW | Unverified Env Var | `FORCE_HYPERLINK` — present in v2.1.213 changelog but NOT confirmed on official /en/env-vars page per Rule 8A; deferred to next run | ✋ ON HOLD (changelog-only, not confirmed on official page — Rule 8A) |
+| 10 | LOW | Suspect Key Recurrence | `CLAUDE_CODE_RETRY_WATCHDOG` — still NOT on official /en/env-vars page; entry annotated "*(in v2.1.199 changelog, not on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-07-03 v2.1.199; 13 consecutive runs) |
+| 11 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 58+ consecutive runs; entry annotated "*(in v2.1.85 changelog, not yet on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-04-14 v2.1.107; 58+ consecutive runs) |


### PR DESCRIPTION
## Summary

Automated daily drift check against Claude Code v2.1.217. All confirmed changes applied; 2 suspect keys and 1 unverified env var deferred per Rule 8A.

**4 new settings added:**
- `emojiCompletionEnabled` (boolean, default `true`, any scope, v2.1.217) — Display Settings
- `sandbox.filesystem.disabled` (boolean, Managed only, v2.1.216) — Sandbox Settings
- `disableBrowserExternalNavigation` (boolean, Managed only) — Managed-only policy keys
- `skillDirectories` (array, any scope) — General Settings *(corrects INVALID from 2026-06-29; now confirmed on official page)*

**2 new env vars added:**
- `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS` (default `20`, v2.1.213/v2.1.217) — changelog-annotated
- `CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH` (v2.1.217) — changelog-annotated

**1 behavioral note added:**
- v2.1.214 permission path-anchor change: single-segment `dir/**` rules now anchor to `<cwd>/dir/**` only

**Housekeeping:**
- Updated badge and version header to v2.1.217
- Added `emojiCompletionEnabled: true` to Quick Reference example
- Appended v2.1.217 entry to `changelog/best-practice/claude-settings/changelog.md`

## Deferred (ON HOLD)

| Item | Reason |
|------|--------|
| `FORCE_HYPERLINK` env var | Changelog-only — not confirmed on official `/en/env-vars` page (Rule 8A) |
| `CLAUDE_CODE_RETRY_WATCHDOG` | 13 consecutive ON HOLD runs; annotation already in report |
| `OTEL_LOG_TOOL_DETAILS` | 58+ consecutive ON HOLD runs; annotation already in report |

## Verification checklist

All 10 categories (rules 1A–10C) executed. No new drift types discovered requiring new checklist rules.

## Hyperlink validation

| Link | Status |
|------|--------|
| `https://code.claude.com/docs/en/settings` | OK |
| `https://code.claude.com/docs/en/env-vars` | OK |
| `https://json.schemastore.org/claude-code-settings.json` | OK (301 → `www.schemastore.org`) |
| `https://datatracker.ietf.org/doc/rfc9728/` | 403 via proxy (IETF RFC, likely valid) |
| Local file links (`../`, `../!/claude-jumping.svg`) | OK |

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_018NLmZEFyXvvXLKGVeFxAVk

---
_Generated by [Claude Code](https://claude.ai/code/session_018NLmZEFyXvvXLKGVeFxAVk)_