### PR TITLE
Daily settings drift check — 2026-07-26 (Claude Code v2.1.220)

### DIFF
--- a/best-practice/claude-settings.md
+++ b/best-practice/claude-settings.md
@@ -1,9 +1,9 @@
 # Settings Best Practice
 
-![Last Updated](https://img.shields.io/badge/Last_Updated-Jul%2019%2C%202026%2010%3A44%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.215-blue?style=flat&labelColor=555)<br>
+![Last Updated](https://img.shields.io/badge/Last_Updated-Jul%2026%2C%202026%2010%3A40%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.220-blue?style=flat&labelColor=555)<br>
 [![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../.claude/settings.json)
 
-A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.215, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
+A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.220, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
 
 <table width="100%">
 <tr>
@@ -63,6 +63,8 @@ Within the managed tier, precedence is: server-managed > MDM/OS-level policies >
 | `requiredMinimumVersion` | string | - | **(Managed only)** Prevents Claude Code from starting if the installed version is below this floor. CLI exits with an error prompting the user to upgrade. Complements `minimumVersion` (which controls auto-update floor) — this one enforces at startup. Example: `"2.1.163"` |
 | `requiredMaximumVersion` | string | - | **(Managed only)** Prevents Claude Code from starting if the installed version exceeds this ceiling. CLI exits with an error if the version is too new. Use alongside `requiredMinimumVersion` to pin a specific version range in managed environments. Example: `"2.1.165"` |
 | `browserExternalPageTools` | string | - | **(Managed only)** Set to `"disabled"` to prevent Claude from using tools to read or act on external pages in the desktop app's Browser pane. Users can still navigate to external sites themselves, and local dev server previews are unaffected |
+| `disableMobileSimulatorTools` | boolean | `false` | **(Managed only)** When `true`, disables the mobile simulator tools (iOS Simulator, Android Emulator) so Claude cannot interact with mobile device emulators. Useful in managed environments where simulator access should be restricted |
+| `disableBrowserExternalNavigation` | boolean | `false` | **(Managed only)** When `true`, prevents Claude from navigating the desktop app Browser pane to external URLs. Claude can still operate on already-open pages and local dev server previews |
 
 **Important**:
 - `deny` rules have highest safety precedence and cannot be overridden by lower-priority allow/ask rules.
@@ -102,7 +104,7 @@ Within the managed tier, precedence is: server-managed > MDM/OS-level policies >
 | `disableDeepLinkRegistration` | string | - | Set to `"disable"` to prevent Claude Code from registering the `claude-cli://` protocol handler with the operating system on startup. Deep links let external tools open a Claude Code session with a pre-filled prompt via `claude-cli://open?q=...`. The `q` parameter supports multi-line prompts using URL-encoded newlines (`%0A`). Useful in environments where protocol handler registration is restricted or managed separately |
 | `showThinkingSummaries` | boolean | `false` | Show extended thinking summaries in interactive sessions. When unset or `false` (default in interactive mode), thinking blocks are redacted by the API and shown as a collapsed stub. Redaction only changes what you see, not what the model generates — to reduce thinking spend, lower the budget or disable thinking instead. Non-interactive mode (`-p`) and SDK callers always receive summaries regardless of this setting |
 | `disableSkillShellExecution` | boolean | `false` | Disable inline shell execution for `` !`...` `` and `` ```! `` blocks in skills and custom commands from user, project, plugin, or additional-directory sources. Commands are replaced with `[shell command execution disabled by policy]` instead of being run. Bundled and managed skills are not affected (v2.1.91) |
-| `maxSkillDescriptionChars` | number | `1536` | Per-skill character cap on the combined `description` and `when_to_use` text in the [skill listing](https://code.claude.com/docs/en/skills) Claude sees each turn. Text longer than this is truncated (v2.1.105) |
+| `skillListingMaxDescChars` | number | `1536` | Per-skill character cap on the combined `description` and `when_to_use` text in the [skill listing](https://code.claude.com/docs/en/skills) Claude sees each turn. Text longer than this is truncated (v2.1.105; renamed from `maxSkillDescriptionChars` in v2.1.218) |
 | `skillListingBudgetFraction` | number | `0.01` | Fraction of the model's context window reserved for the [skill listing](https://code.claude.com/docs/en/skills) Claude sees each turn (`0.01` = 1%). When the listing exceeds the budget, descriptions for the least-used skills are collapsed to bare names so Claude can still invoke them but won't see why (v2.1.105) |
 | `forceRemoteSettingsRefresh` | boolean | `false` | **(Managed only)** Block CLI startup until remote managed settings are freshly fetched. If the fetch fails, the CLI exits (fail-closed). Use in enterprise environments where policy enforcement must be up-to-date before any session begins (v2.1.92) |
 | `wslInheritsWindowsSettings` | boolean | `false` | **(Windows managed settings only)** When `true`, Claude Code on WSL reads managed settings from the Windows policy chain (HKLM registry + `C:\Program Files\ClaudeCode\managed-settings.json`) in addition to `/etc/claude-code`, with Windows sources taking priority. Only honored when set in the HKLM registry key or `C:\Program Files\ClaudeCode\managed-settings.json`, both of which require Windows admin to write. For HKCU policy to also apply on WSL, the flag must additionally be set in HKCU itself. Has no effect on native Windows (v2.1.118) |
@@ -118,7 +120,7 @@ Within the managed tier, precedence is: server-managed > MDM/OS-level policies >
 | `disableWorkflows` | boolean | `false` | Set to `true` to disable [dynamic workflows](https://code.claude.com/docs/en/workflows) (`/workflows`) and the bundled workflow slash commands. Can be set at any scope. Equivalent to the `CLAUDE_CODE_DISABLE_WORKFLOWS` env var. Workflows were introduced in v2.1.154 |
 | `workflowKeywordTriggerEnabled` | boolean | `true` | Whether typing the word "ultracode" in a prompt triggers a [dynamic workflow](https://code.claude.com/docs/en/workflows). Set to `false` to require explicit `/workflows` invocation. Ultracode, `/workflows`, and saved workflow commands are unaffected by this setting. Appears in `/config` as **Workflow keyword trigger** (v2.1.157; trigger keyword renamed workflow→ultracode in v2.1.160) |
 | `ultracode` | boolean | - | **(Session-only — not persisted)** When `true`, the harness authors and runs a workflow for every substantive task by default, maximizing thoroughness regardless of token cost. Appears in the official "Available settings" list but is session-scoped: set via `/effort ultracode`, `--settings`, or the SDK rather than written to `settings.json` (v2.1.154) |
-| `dynamicWorkflowSize` | string | - | Advisory guideline for the number of agents spawned in a [dynamic workflow](https://code.claude.com/docs/en/workflows). Values: `"small"`, `"medium"`, `"large"`. When set, the workflow harness uses this as the default fleet size before scaling up or down based on the task. Set via `/config` as **Workflow size** (v2.1.202; values formalized in v2.1.205) |
+| `workflowSizeGuideline` | string | `"unrestricted"` | Advisory guideline for the number of agents spawned in a [dynamic workflow](https://code.claude.com/docs/en/workflows). Values: `"small"`, `"medium"`, `"large"`, `"unrestricted"`. When set, the workflow harness uses this as the default fleet size before scaling up or down based on the task. Set via `/config` as **Workflow size** (v2.1.202; values formalized in v2.1.205; renamed from `dynamicWorkflowSize` in v2.1.215) |
 | `disableBundledSkills` | boolean | `false` | Conceal Claude Code's built-in capabilities (bundled skills) from the model. When `true`, the model cannot invoke built-in skills. Paired with the `CLAUDE_CODE_DISABLE_BUNDLED_SKILLS` env var. Useful when strict plugin-only customization is required (v2.1.169) |
 | `disableArtifact` | boolean | `false` | Disable the Artifact web publishing tool. When `true`, Claude cannot create or publish web artifacts. Can be set at any scope |
 | `enableArtifact` | boolean | - | **(v2.1.196+)** User-level opt-in for the Artifact web publishing tool. When set to `true`, enables Artifact for the user even when no organization policy requires it. `disableArtifact: true` takes precedence and overrides this setting |
@@ -483,6 +485,8 @@ Configure bash command sandboxing for security.
 | `sandbox.socatPath` | string | - | **(Managed only, Linux/WSL2)** Absolute path to the `socat` binary used for the sandbox network proxy. Overrides automatic `PATH` detection. Only honored from managed settings. Example: `/opt/admin/socat` (v2.1.133) |
 | `sandbox.allowAppleEvents` | boolean | `false` | **(macOS only)** Opt-in for sandboxed commands to send Apple Events. Required for tools that use `open`, `osascript`, or browser authentication flows that depend on Apple Events IPC (v2.1.181) |
 | `sandbox.credentials` | object | — | Fine-grained control over which credential files and environment variables are blocked from sandboxed subprocess environments. Contains `files` (array of file paths to block from sandboxed reads) and `envVars` (array of env var names to strip from the subprocess environment). Supports two modes via a `mode` field: `"deny"` (default) blocks files and strips env vars entirely; `"mask"` with an `injectHosts` array selectively exposes credentials to specific trusted hosts. An individual invalid entry in `files` or `envVars` is stripped with a warning and the valid subset is enforced (v2.1.187; extended to object with sub-arrays in v2.1.191+; `mode` and `injectHosts` added v2.1.199) |
+| `sandbox.filesystem.disabled` | boolean | `false` | When `true`, disables all filesystem sandbox enforcement — the `allowWrite`, `denyWrite`, `denyRead`, and `allowRead` lists are ignored and all file paths are accessible to sandboxed commands. Intended for debugging sandbox rule conflicts; do not set in production (v2.1.216) |
+| `sandbox.network.strictAllowlist` | boolean | `false` | When `true`, only domains explicitly listed in `sandbox.network.allowedDomains` are permitted in the sandbox; all other outbound connections are blocked by default. Without this flag, the network sandbox allows outbound traffic unless a domain matches `deniedDomains`. Pair with `allowedDomains` to enforce a strict allowlist policy (v2.1.219) |
 
 **Example:**
 ```json
@@ -517,7 +521,7 @@ Configure Claude Code plugins and marketplaces.
 | `pluginSuggestionMarketplaces` | array | Managed only | Allowlist of marketplace names whose plugins may appear as contextual install suggestions during a session. Restricts which marketplaces can surface "you might want this plugin" prompts (v2.1.152) |
 | `skippedMarketplaces` | array | Any | Marketplaces user declined to install *(in JSON schema, not on official settings page)* |
 | `skippedPlugins` | array | Any | Plugins user declined to install *(in JSON schema, not on official settings page)* |
-| `pluginConfigs` | object | Any | Per-plugin MCP server configs (keyed by `plugin@marketplace`). As of v2.1.207, no longer read from project-level `.claude/settings.json` or `.claude/settings.local.json`; only user, `--settings`, and managed settings are honored *(in JSON schema, not on official settings page)* |
+| `pluginConfigs` | object | Any | Per-plugin MCP server configs (keyed by `plugin@marketplace`). As of v2.1.207, no longer read from project-level `.claude/settings.json` or `.claude/settings.local.json`; only user, `--settings`, and managed settings are honored |
 | `blockedMarketplaces` | array | Managed only | Block specific plugin marketplaces. Each entry can match by source string, `hostPattern`, or `pathPattern` — as of v2.1.119 the `hostPattern` and `pathPattern` matchers are correctly enforced before any download touches the filesystem, so blocked marketplaces never reach disk |
 | `pluginTrustMessage` | string | Managed only | Custom message displayed when prompting users to trust plugins |
 | `disableSideloadFlags` | boolean | Managed only | Reject the `--plugin-dir`, `--plugin-url`, `--agents`, and `--mcp-config` startup flags. When `true`, users cannot bypass `strictKnownMarketplaces` by passing sideload flags at launch. Use in managed environments to enforce marketplace-only plugin distribution (v2.1.193) |
@@ -565,7 +569,7 @@ Configure Claude Code plugins and marketplaces.
 |-------|-------------|
 | `"default"` | Recommended for your account type |
 | `"sonnet"` | Latest Sonnet model (Claude Sonnet 5 on the Anthropic API — native 1M-token context, introduced v2.1.197; Claude Sonnet 4.6 on Bedrock/Vertex/Foundry) |
-| `"opus"` | Latest Opus model (Claude Opus 4.8 on the Anthropic API as of v2.1.154; Opus 4.8 also now default on Bedrock, Vertex, and Claude Platform on AWS as of v2.1.207 — was 4.6 before). Also the fast-mode default since v2.1.142. Opus 4.8 defaults to `high` effort and supports `/effort xhigh` |
+| `"opus"` | Latest Opus model (Claude Opus 5 on the Anthropic API as of v2.1.219 — replaces Opus 4.8; Opus 4.8 also now default on Bedrock, Vertex, and Claude Platform on AWS as of v2.1.207 — was 4.6 before). Also the fast-mode default since v2.1.142. Opus 5 defaults to `high` effort and supports `/effort xhigh` |
 | `"haiku"` | Fast Haiku model |
 | `"sonnet[1m]"` | Sonnet with 1M token context |
 | `"opus[1m]"` | Opus with 1M token context (default on Max, Team, and Enterprise since v2.1.75) |
@@ -648,6 +652,7 @@ Configure via `env` key:
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `statusLine` | object | - | Custom status line configuration |
+| `theme` | string | `"default"` | Color theme for the Claude Code UI. Values: `"default"`, `"light"`, `"dark"`, `"dark-daltonized"`, `"light-daltonized"`. Appears in `/config` as **Theme**. Written automatically when you select a theme via `/config`. Recognized since v2.1.119 |
 | `outputStyle` | string | `"default"` | Output style (e.g., `"Explanatory"`) |
 | `spinnerTipsEnabled` | boolean | `true` | Show tips while waiting |
 | `spinnerVerbs` | object | - | Custom spinner verbs with `mode` ("append" or "replace") and `verbs` array |
@@ -655,6 +660,7 @@ Configure via `env` key:
 | `respectGitignore` | boolean | `true` | Respect .gitignore in file picker |
 | `prefersReducedMotion` | boolean | `false` | Reduce animations and motion effects in the UI |
 | `axScreenReader` | boolean | `false` | Enable screen-reader-friendly output mode. When `true`, Claude outputs flat text without decorative box-drawing characters, color, and other terminal UI elements. Appears in `/config` as **Screen reader mode**. Only applies at the User scope — does not read from project or managed settings. Also available via the `--ax-screen-reader` CLI flag (v2.1.181) |
+| `emojiCompletionEnabled` | boolean | `true` | Enable emoji tab-completion in the input box. When `true` (default), typing `:` followed by an emoji name and pressing Tab completes to the emoji character. Set to `false` to disable (v2.1.217) |
 | `syntaxHighlightingDisabled` | boolean | `false` | Disable syntax highlighting in diffs, code blocks, and file previews. Distinct from the `CLAUDE_CODE_SYNTAX_HIGHLIGHT` env var, which only governs diff output |
 | `fileSuggestion` | object | - | Custom file suggestion command (see File Suggestion Configuration below) |
 | `autoScrollEnabled` | boolean | `true` | Auto-scroll the conversation in fullscreen mode. Set to `false` to disable automatic scrolling (v2.1.110). Versions before v2.1.119 stored this in `~/.claude.json` |
@@ -1057,6 +1063,8 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY` | Max parallel read-only tools (default: 10) |
 | `CLAUDE_CODE_MAX_WEB_SEARCHES_PER_SESSION` | Maximum web searches allowed per session (default: `200`). Prevents runaway tool use in long agentic sessions *(in v2.1.212 changelog, not yet on official env-vars page)* |
 | `CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION` | Maximum subagents that can be spawned per session (default: `200`). Prevents resource exhaustion in deeply nested agentic workflows *(in v2.1.212 changelog, not yet on official env-vars page)* |
+| `CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH` | Maximum nesting depth for subagent spawning (default: `3`). Prevents runaway recursion where a subagent spawns another subagent that spawns further subagents. Depth is counted from the root session: a subagent spawned directly by the user session is depth 1, its child is depth 2, and so on. When the limit is reached, further Agent() calls are rejected (v2.1.219) |
+| `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS` | Maximum number of subagents that can run concurrently within a session (default: `20`). Caps the number of in-flight subagent workers at any one time, distinct from the per-session total cap (`CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION`). Useful for controlling API rate-limit pressure in high-parallelism workflows (v2.1.217) |
 | `CLAUDE_AGENT_SDK_DISABLE_BUILTIN_AGENTS` | Disable built-in subagent types in SDK mode (`1` to disable) |
 | `CLAUDE_AGENT_SDK_MCP_NO_PREFIX` | Skip `mcp__<server>__` prefix for MCP tools in SDK mode (`1` to enable) |
 | `CLAUDE_ASYNC_AGENT_STALL_TIMEOUT_MS` | Stall timeout in ms for background subagents (default: 600000 / 10 minutes). The subagent is killed if it produces no output for this duration |
@@ -1191,12 +1199,13 @@ Set environment variables for all Claude Code sessions.
   "plansDirectory": "./plans",
   "claudeMdExcludes": ["**/vendor/**/CLAUDE.md"],
   "effortLevel": "high",
-  "maxSkillDescriptionChars": 1536,
+  "skillListingMaxDescChars": 1536,
   "skillListingBudgetFraction": 0.01,
   "disableAgentView": false,
   "disableWorkflows": false,
   "workflowKeywordTriggerEnabled": true,
   "syntaxHighlightingDisabled": false,
+  "emojiCompletionEnabled": true,
 
   "worktree": {
     "symlinkDirectories": ["node_modules"],

--- a/changelog/best-practice/claude-settings/changelog.md
+++ b/changelog/best-practice/claude-settings/changelog.md
@@ -1145,3 +1145,26 @@
 | 9 | MED | Missing Commands | Add `claude auto-mode reset` (reset auto-mode classification, `--yes` to skip confirmation, v2.1.212), `/fork` (fork session into isolated subagent, v2.1.212), and `/subtask` (launch isolated subtask, v2.1.212) to Useful Commands | ✅ COMPLETE (all three added to Useful Commands table) — NEW |
 | 10 | LOW | Suspect Key Recurrence | `CLAUDE_CODE_RETRY_WATCHDOG` — still NOT on official /en/env-vars page; entry annotated "*(in v2.1.199 changelog, not on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-07-03 v2.1.199; 12 consecutive runs) |
 | 11 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 57+ consecutive runs; entry annotated "*(in v2.1.85 changelog, not yet on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-04-14 v2.1.107; 57+ consecutive runs) |
+
+---
+
+## [2026-07-26 10:40 AM PKT] Claude Code v2.1.220
+
+| # | Priority | Type | Action | Status |
+|---|----------|------|--------|--------|
+| 1 | HIGH | Version Bump | Update version badge from v2.1.215 → v2.1.220 and "Last Updated" date from Jul 19 → Jul 26, 2026; update body "As of v2.1.215" → "As of v2.1.220" | ✅ COMPLETE (badge and body text updated) — NEW |
+| 2 | HIGH | New Setting | Add `disableMobileSimulatorTools` (boolean, default `false`, managed-only) to Managed Policy Keys table after `browserExternalPageTools`. Confirmed in v2.1.218+ changelog | ✅ COMPLETE (added to Managed Policy Keys table) — NEW |
+| 3 | HIGH | New Setting | Add `disableBrowserExternalNavigation` (boolean, default `false`, managed-only) to Managed Policy Keys table. Confirmed in v2.1.218+ changelog | ✅ COMPLETE (added to Managed Policy Keys table) — NEW |
+| 4 | HIGH | Key Rename | Rename `maxSkillDescriptionChars` → `skillListingMaxDescChars` in General Settings table and Quick Reference example. Confirmed in v2.1.218 changelog | ✅ COMPLETE (table row and Quick Reference example both updated) — NEW |
+| 5 | HIGH | Key Rename | Rename `dynamicWorkflowSize` → `workflowSizeGuideline`; correct default from `-` → `"unrestricted"`; add `"unrestricted"` as valid value. Confirmed in v2.1.215 changelog | ✅ COMPLETE (table row updated with corrected name and default) — NEW |
+| 6 | HIGH | New Setting | Add `sandbox.filesystem.disabled` (boolean, default `false`, v2.1.216) to Sandbox Settings table after `sandbox.credentials`. Confirmed in v2.1.216 changelog | ✅ COMPLETE (added to Sandbox Settings table) — NEW |
+| 7 | HIGH | New Setting | Add `sandbox.network.strictAllowlist` (boolean, default `false`, v2.1.219) to Sandbox Settings table. Confirmed in v2.1.219 changelog | ✅ COMPLETE (added to Sandbox Settings table) — NEW |
+| 8 | HIGH | Model Alias Update | Update `"opus"` alias: Claude Opus 5 is now the default on Anthropic API as of v2.1.219 (replaces Opus 4.8). Confirmed in v2.1.219 changelog | ✅ COMPLETE (Model Aliases table row updated) — NEW |
+| 9 | HIGH | New Setting | Add `emojiCompletionEnabled` (boolean, default `true`, v2.1.217) to Display Settings table after `axScreenReader`. Confirmed in v2.1.217 changelog | ✅ COMPLETE (added to Display Settings table) — NEW |
+| 10 | HIGH | New Env Var | Add `CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH` (nested subagent depth limit, default `3`, v2.1.219) to env vars table after `CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION`. Confirmed in v2.1.219 changelog | ✅ COMPLETE (added with version annotation) — NEW |
+| 11 | MED | New Env Var | Add `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS` (max concurrent subagents, default `20`, v2.1.217) to env vars table after `CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH`. Confirmed in v2.1.217 changelog | ✅ COMPLETE (added with version annotation) — NEW |
+| 12 | MED | Stale Annotation | Remove "(in JSON schema, not on official settings page)" annotation from `pluginConfigs` row — key is now present on the official settings page | ✅ COMPLETE (annotation removed from Plugin Settings table) — NEW |
+| 13 | MED | New Setting | Add `theme` (string, default `"default"`, v2.1.119) to Display Settings table before `outputStyle`. Confirmed as long-standing key in official settings page | ✅ COMPLETE (added to Display Settings table) — NEW |
+| 14 | MED | Quick Reference | Add `emojiCompletionEnabled: true` to Quick Reference JSON example | ✅ COMPLETE (added to Quick Reference example) — NEW |
+| 15 | LOW | Suspect Key Recurrence | `CLAUDE_CODE_RETRY_WATCHDOG` — still NOT on official /en/env-vars page; entry annotated "*(in v2.1.199 changelog, not on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-07-03 v2.1.199; 13 consecutive runs) |
+| 16 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 58+ consecutive runs; entry annotated "*(in v2.1.85 changelog, not yet on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-04-14 v2.1.107; 58+ consecutive runs) |


### PR DESCRIPTION
## Drift Summary

**Audited version:** Claude Code v2.1.220 (report was at v2.1.215 — 5 releases stale)
**Run date:** 2026-07-26 10:40 AM PKT
**Sources:** Official settings docs, env-vars page, GitHub CHANGELOG
**Verification rules executed:** All checklist rules 1A–10C

---

## Changes Applied

### HIGH Priority (10 items)

| # | Type | Change |
|---|------|--------|
| 1 | Version Bump | Badge + body text: v2.1.215 → v2.1.220, date Jul 19 → Jul 26 |
| 2 | New Setting | `disableMobileSimulatorTools` (boolean, `false`, managed-only) added to Managed Policy Keys |
| 3 | New Setting | `disableBrowserExternalNavigation` (boolean, `false`, managed-only) added to Managed Policy Keys |
| 4 | Key Rename | `maxSkillDescriptionChars` → `skillListingMaxDescChars` (v2.1.218) — table row + Quick Reference example |
| 5 | Key Rename | `dynamicWorkflowSize` → `workflowSizeGuideline`; default corrected to `"unrestricted"`; added `"unrestricted"` value (v2.1.215) |
| 6 | New Setting | `sandbox.filesystem.disabled` (boolean, `false`, v2.1.216) added to Sandbox Settings |
| 7 | New Setting | `sandbox.network.strictAllowlist` (boolean, `false`, v2.1.219) added to Sandbox Settings |
| 8 | Model Alias | `"opus"` alias updated: Claude Opus 5 now default on Anthropic API (v2.1.219, replaces Opus 4.8) |
| 9 | New Setting | `emojiCompletionEnabled` (boolean, `true`, v2.1.217) added to Display Settings |
| 10 | New Env Var | `CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH` (default `3`, v2.1.219) added to env vars |

### MED Priority (4 items)

| # | Type | Change |
|---|------|--------|
| 11 | New Env Var | `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS` (default `20`, v2.1.217) added to env vars |
| 12 | Stale Annotation | Removed `(in JSON schema, not on official settings page)` from `pluginConfigs` — now on official page |
| 13 | New Setting | `theme` (string, `"default"`, v2.1.119) added to Display Settings |
| 14 | Quick Reference | `emojiCompletionEnabled: true` added to Quick Reference JSON example |

### LOW Priority (2 recurring ON HOLD items)

| # | Key | Status |
|---|-----|--------|
| 15 | `CLAUDE_CODE_RETRY_WATCHDOG` | ✋ ON HOLD — 13 consecutive runs, not on official env-vars page |
| 16 | `OTEL_LOG_TOOL_DETAILS` | ✋ ON HOLD — 58+ consecutive runs, not on official env-vars page |

---

## Verification Log

| Rule | Check | Result |
|------|-------|--------|
| 1A | Key completeness (docs → report) | ✅ All confirmed keys present after this run |
| 1B/1C/1D | Types, defaults, descriptions | ✅ No drift found |
| 1E | Scope column accuracy | ✅ Managed-only flags verified |
| 1F | Inverse completeness (report → docs) | ✅ `pluginConfigs` annotation fixed |
| 1I | Skills settings keys | ✅ `skillListingMaxDescChars` + `skillListingBudgetFraction` present |
| 2A–2D | Settings hierarchy | ✅ No drift |
| 3A–3D | Permissions | ✅ No drift |
| 4A | Hooks redirect | ✅ Link valid |
| 5A–5D | Env vars completeness + descriptions | ✅ 2 new vars added; no orphaned entries |
| 6A–6B | Examples | ✅ Key rename + new key applied to Quick Reference |
| 7A | CLAUDE.md sync | ✅ No drift |
| 9A–9C | Hyperlinks (local, external, anchors) | ✅ All links valid |
| 10A | Version metadata | ✅ Badge + body text updated |
| 10B | Suspect key escalation | ✋ RETRY_WATCHDOG (13 runs), OTEL_LOG_TOOL_DETAILS (58+ runs) |

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjURfnuNon99sULZtVGKyG)_