### PR TITLE
Daily settings drift check — 2026-07-29 (Claude Code v2.1.220)

### DIFF
--- a/best-practice/claude-settings.md
+++ b/best-practice/claude-settings.md
@@ -1,9 +1,9 @@
 # Settings Best Practice
 
-![Last Updated](https://img.shields.io/badge/Last_Updated-Jul%2027%2C%202026%2010%3A47%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.220-blue?style=flat&labelColor=555)<br>
+![Last Updated](https://img.shields.io/badge/Last_Updated-Jul%2029%2C%202026%2011%3A03%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.220-blue?style=flat&labelColor=555)<br>
 [![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../.claude/settings.json)
 
-A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.220, Claude Code exposes **80+ settings** and **200+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
+A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.220, Claude Code exposes **80+ settings** and **300+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
 
 <table width="100%">
 <tr>
@@ -100,11 +100,12 @@ Within the managed tier, precedence is: server-managed > MDM/OS-level policies >
 | `voice` | object | - | Voice dictation configuration. Object with three fields: `enabled` (boolean — push-to-talk on/off), `mode` (string — `"hold"` for hold-to-talk or `"tap"` for tap-to-toggle), and `autoSubmit` (boolean — submit transcript immediately when dictation ends). Written automatically when you run `/voice`. Requires a Claude.ai account (v2.1.118 expanded structure) |
 | `voiceEnabled` | boolean | - | **DEPRECATED** — legacy alias for `voice.enabled`. Use the `voice` object instead to get `mode` and `autoSubmit` controls |
 | `showClearContextOnPlanAccept` | boolean | `false` | Show the "clear context" option on the plan accept screen. Set to `true` to restore the option (hidden by default since v2.1.81) |
-| `viewMode` | string | - | Default transcript view mode on startup: `"default"`, `"verbose"`, or `"focus"`. Overrides the sticky Ctrl+O selection when set |
+| `verbose` | boolean | `false` | Show full tool output instead of truncated summaries in the transcript. Equivalent to running with `--verbose`. The `--verbose` flag overrides for one session. Appears in `/config` as **Verbose output** |
+| `viewMode` | string | - | Default transcript view mode on startup: `"default"`, `"verbose"`, or `"focus"`. Overrides the sticky `/focus` selection when set |
 | `disableDeepLinkRegistration` | string | - | Set to `"disable"` to prevent Claude Code from registering the `claude-cli://` protocol handler with the operating system on startup. Deep links let external tools open a Claude Code session with a pre-filled prompt via `claude-cli://open?q=...`. The `q` parameter supports multi-line prompts using URL-encoded newlines (`%0A`). Useful in environments where protocol handler registration is restricted or managed separately |
-| `showThinkingSummaries` | boolean | `false` | Show extended thinking summaries in interactive sessions. When unset or `false` (default in interactive mode), thinking blocks are redacted by the API and shown as a collapsed stub. Redaction only changes what you see, not what the model generates — to reduce thinking spend, lower the budget or disable thinking instead. Non-interactive mode (`-p`) and SDK callers always receive summaries regardless of this setting |
+| `showThinkingSummaries` | boolean | `false` | Show extended thinking summaries in interactive sessions. When unset or `false` (default in interactive mode), thinking blocks are redacted by the API and shown as a collapsed stub. Redaction only changes what you see, not what the model generates — to reduce thinking spend, lower the budget or disable thinking instead. **This setting has no effect** in non-interactive mode (`-p`), the Agent SDK, or IDE extensions such as VS Code — summaries are never shown in those contexts |
 | `disableSkillShellExecution` | boolean | `false` | Disable inline shell execution for `` !`...` `` and `` ```! `` blocks in skills and custom commands from user, project, plugin, or additional-directory sources. Commands are replaced with `[shell command execution disabled by policy]` instead of being run. Bundled and managed skills are not affected (v2.1.91) |
-| `maxSkillDescriptionChars` | number | `1536` | Per-skill character cap on the combined `description` and `when_to_use` text in the [skill listing](https://code.claude.com/docs/en/skills) Claude sees each turn. Text longer than this is truncated (v2.1.105) |
+| `skillListingMaxDescChars` | number | `1536` | Per-skill character cap on the combined `description` and `when_to_use` text in the [skill listing](https://code.claude.com/docs/en/skills) Claude sees each turn. Text longer than this is truncated (v2.1.105) |
 | `skillListingBudgetFraction` | number | `0.01` | Fraction of the model's context window reserved for the [skill listing](https://code.claude.com/docs/en/skills) Claude sees each turn (`0.01` = 1%). When the listing exceeds the budget, descriptions for the least-used skills are collapsed to bare names so Claude can still invoke them but won't see why (v2.1.105) |
 | `forceRemoteSettingsRefresh` | boolean | `false` | **(Managed only)** Block CLI startup until remote managed settings are freshly fetched. If the fetch fails, the CLI exits (fail-closed). Use in enterprise environments where policy enforcement must be up-to-date before any session begins (v2.1.92) |
 | `wslInheritsWindowsSettings` | boolean | `false` | **(Windows managed settings only)** When `true`, Claude Code on WSL reads managed settings from the Windows policy chain (HKLM registry + `C:\Program Files\ClaudeCode\managed-settings.json`) in addition to `/etc/claude-code`, with Windows sources taking priority. Only honored when set in the HKLM registry key or `C:\Program Files\ClaudeCode\managed-settings.json`, both of which require Windows admin to write. For HKCU policy to also apply on WSL, the flag must additionally be set in HKCU itself. Has no effect on native Windows (v2.1.118) |
@@ -121,7 +122,9 @@ Within the managed tier, precedence is: server-managed > MDM/OS-level policies >
 | `workflowKeywordTriggerEnabled` | boolean | `true` | Whether typing the word "ultracode" in a prompt triggers a [dynamic workflow](https://code.claude.com/docs/en/workflows). Set to `false` to require explicit `/workflows` invocation. Ultracode, `/workflows`, and saved workflow commands are unaffected by this setting. Appears in `/config` as **Workflow keyword trigger** (v2.1.157; trigger keyword renamed workflow→ultracode in v2.1.160) |
 | `ultracode` | boolean | - | **(Session-only — not persisted)** When `true`, the harness authors and runs a workflow for every substantive task by default, maximizing thoroughness regardless of token cost. Appears in the official "Available settings" list but is session-scoped: set via `/effort ultracode`, `--settings`, or the SDK rather than written to `settings.json` (v2.1.154) |
 | `dynamicWorkflowSize` | string | - | Advisory guideline for the number of agents spawned in a [dynamic workflow](https://code.claude.com/docs/en/workflows). Values: `"small"`, `"medium"`, `"large"`. When set, the workflow harness uses this as the default fleet size before scaling up or down based on the task. Set via `/config` as **Workflow size** (v2.1.202; values formalized in v2.1.205) |
-| `workflowSizeGuideline` | string | `"medium"` | Advisory guideline for the dynamic workflow fleet size, settable from any settings file. Values: `"small"`, `"medium"` (default as of v2.1.219), `"large"`. The default fleet size now renders in the running-workflow status line. Complements `dynamicWorkflowSize` — use this key when the guideline needs to propagate from managed or user settings (v2.1.219) |
+| `workflowSizeGuideline` | string | `"medium"` | Advisory guideline for the dynamic workflow fleet size, settable from any settings file. Values: `"unrestricted"` (no cap), `"small"`, `"medium"` (default as of v2.1.219), `"large"`. The default fleet size now renders in the running-workflow status line. Complements `dynamicWorkflowSize` — use this key when the guideline needs to propagate from managed or user settings. Takes precedence over the `/config` **Dynamic workflow size** row and hides that row while set (v2.1.219) |
+| `processWrapper` | string | - | Corporate launcher command placed in front of Claude Code background processes (e.g., `"sudo -u agent /usr/local/bin/wrapper"`). Claude Code is appended as the final argument. Only honored from managed settings, user settings (`~/.claude/settings.json`), or `--settings`; ignored in project and local settings. The `CLAUDE_CODE_PROCESS_WRAPPER` env var takes precedence (v2.1.210) |
+| `remote.defaultEnvironmentId` | string | - | Default cloud environment ID for `claude --remote`. Written automatically when you select an environment in `/remote-env`. Standard precedence applies |
 | `disableBundledSkills` | boolean | `false` | Conceal Claude Code's built-in capabilities (bundled skills) from the model. When `true`, the model cannot invoke built-in skills. Paired with the `CLAUDE_CODE_DISABLE_BUNDLED_SKILLS` env var. Useful when strict plugin-only customization is required (v2.1.169) |
 | `disableArtifact` | boolean | `false` | Disable the Artifact web publishing tool. When `true`, Claude cannot create or publish web artifacts. Can be set at any scope |
 | `enableArtifact` | boolean | - | **(v2.1.196+)** User-level opt-in for the Artifact web publishing tool. When set to `true`, enables Artifact for the user even when no organization policy requires it. `disableArtifact: true` takes precedence and overrides this setting |
@@ -276,7 +279,7 @@ Control what tools and operations Claude can perform.
 | `permissions.ask` | array | Rules requiring user confirmation |
 | `permissions.deny` | array | Rules blocking tool use (highest precedence) |
 | `permissions.additionalDirectories` | array | Extra directories Claude can access |
-| `permissions.defaultMode` | string | Default permission mode. Valid values: `"default"`, `"manual"` (alias for `"default"`, v2.1.200), `"acceptEdits"`, `"dontAsk"`, `"bypassPermissions"`, `"auto"`, `"plan"`. In Remote environments, only `acceptEdits` and `plan` are honored (v2.1.70+) |
+| `permissions.defaultMode` | string | Default permission mode. Valid values: `"default"`, `"manual"` (alias for `"default"`, v2.1.200), `"acceptEdits"`, `"dontAsk"`, `"bypassPermissions"`, `"auto"`, `"plan"`. In Remote environments, only `acceptEdits` and `plan` are honored (v2.1.70+). **`"auto"` is ignored in project settings** (`.claude/settings.json`) to prevent a repo from granting itself auto mode — set it in `~/.claude/settings.json` instead |
 | `permissions.disableBypassPermissionsMode` | string | Prevent bypass mode activation |
 | `permissions.skipDangerousModePermissionPrompt` | boolean | Skip the confirmation prompt shown before entering bypass permissions mode via `--dangerously-skip-permissions` or `defaultMode: "bypassPermissions"`. Ignored when set in project settings (`.claude/settings.json`) to prevent untrusted repositories from auto-bypassing the prompt |
 | `allowManagedPermissionRulesOnly` | boolean | **(Managed only)** Only managed permission rules apply; user/project `allow`, `ask`, `deny` rules are ignored |
@@ -291,8 +294,8 @@ Control what tools and operations Claude can perform.
 | `"default"` | Standard permission checking with prompts |
 | `"manual"` | Alias for `"default"` introduced in v2.1.200 — same standard permission checking with prompts. The rename improves clarity across the CLI, VS Code, and JetBrains UIs. Accepted wherever `"default"` is accepted |
 | `"acceptEdits"` | Automatically accepts file edits **and common filesystem commands** (`mkdir`, `touch`, `mv`, `cp`, etc.) for paths in the working directory or `additionalDirectories`. **v2.1.160:** Always prompts before writing build-tool config files that grant code execution (`.npmrc`, `.yarnrc*`, `bunfig.toml`, `.bazelrc`, `.pre-commit-config.yaml`, `.devcontainer/`, etc.) and before writing to shell startup files (`.zshenv`, `.zlogin`, `.bash_login`) and `~/.config/git/` |
-| `"dontAsk"` | Auto-denies tools unless pre-approved via `/permissions` or `permissions.allow` rules |
-| `"bypassPermissions"` | Skip all permission checks (dangerous). All path-based prompts are skipped — writes to `.git`, `.config/git`, `.claude`, `.vscode`, `.idea`, `.husky`, `.cargo`, `.devcontainer`, `.yarn`, and `.mvn` no longer prompt (**v2.1.121** exempted `.claude/commands/`, `.claude/agents/`, `.claude/skills/`, and `.claude/worktrees/`; **v2.1.126** removed all remaining path-based prompts). Only removals targeting the filesystem root or home directory (`rm -rf /`, `rm -rf ~`) still prompt as a circuit breaker against model error |
+| `"dontAsk"` | Auto-denies tools unless pre-approved via `/permissions` or `permissions.allow` rules. **Even pre-approved tools are denied** if they are: `AskUserQuestion`, org-`ask` connector tools, or MCP tools marked `requiresUserInteraction` |
+| `"bypassPermissions"` | Skip all permission checks (dangerous). All path-based prompts are skipped — writes to `.git`, `.config/git`, `.claude`, `.vscode`, `.idea`, `.husky`, `.cargo`, `.devcontainer`, `.yarn`, and `.mvn` no longer prompt (**v2.1.121** exempted `.claude/commands/`, `.claude/agents/`, `.claude/skills/`, and `.claude/worktrees/`; **v2.1.126** removed all remaining path-based prompts). Only these still prompt: (1) removals targeting the filesystem root or home directory (`rm -rf /`, `rm -rf ~`, including `$(...)`, backticks, and `<(...)` substitution forms, v2.1.208); (2) explicit `ask` rules; (3) connector tools your org set to `ask`; (4) MCP tools marked `requiresUserInteraction` |
 | `"auto"` | Auto-approves tool calls with background safety checks that verify actions align with your request. Research preview. Classifier auto-approves read-only and file edits; sends everything else through a safety check. Falls back to prompting after 3 consecutive or 20 total blocks. In the default `Shift+Tab` permission-mode cycle since v2.1.111 (the `--enable-auto-mode` flag was removed in v2.1.111 — start in this mode with `--permission-mode auto`). Configure with the `autoMode` setting |
 | `"plan"` | Read-only exploration mode. As of v2.1.136, file writes are blocked even when a matching `Edit(...)` allow rule exists — plan mode now overrides explicit allow rules to maintain its read-only guarantee |
 
@@ -312,14 +315,14 @@ Control what tools and operations Claude can perform.
 | `Agent` | `Agent(name)` | `Agent(researcher)`, `Agent(*)` — permission scoped to subagent spawning |
 | `Skill` | `Skill(skill-name)` or `Skill(prefix *)` | `Skill(weather-fetcher)`, `Skill(weather *)` matches `weather-fetcher`/`weather-svg-creator` (v2.1.139) |
 | `MCP` | `mcp__server__tool` or `MCP(server:tool)` | `mcp__memory__*`, `MCP(github:*)` |
-| `Tool` | `Tool(param:value)` | `Agent(model:opus)`, `Bash(cmd:npm run *)` — match permission rules against a tool's input parameters; supports `*` wildcards in the value position (v2.1.178) |
+| `Tool` | `Tool(param:value)` | `Agent(model:opus)` — match **deny or ask** rules against a tool's input parameters; supports `*` wildcards in the value position. Only applies to deny and ask rules — allow rules use each tool's own specifier. Non-matchable fields (logged with a startup warning): `command` (Bash/PowerShell), `file_path` (Read/Edit/Write), `path` (Grep/Glob), `notebook_path` (NotebookEdit), `url` (WebFetch) (v2.1.178) |
 | `Cd` | `Cd(path pattern)` | `Cd(/home/*)`, `Cd(~/projects/*)` — controls which directories the `/cd` command may navigate to |
 
 > **v2.1.210:** `Write(path)`, `NotebookEdit(path)`, and `Glob(path)` permission rules generate a startup warning recommending the more targeted `Edit(path)` or `Read(path)` alternatives. Existing settings continue to work; the warning is a nudge to tighten permissions.
 
 **Evaluation order:** Rules are evaluated in order: deny rules first, then ask, then allow. The first matching rule wins.
 
-**Deny rule glob patterns (v2.1.166):** In a `deny` rule, using `"*"` in the tool-name position matches ALL tools — equivalent to a global deny. For example, `"*"` in the deny array blocks every tool call. This makes it possible to lock down access completely and carve out specific allow/ask exceptions.
+**Deny and ask rule glob patterns (v2.1.166):** In a `deny` or `ask` rule, using `"*"` in the tool-name position matches ALL tools — equivalent to a global deny/ask. For example, `"*"` in the deny array blocks every tool call. This makes it possible to lock down access completely and carve out specific allow exceptions. **Note:** `EndConversation` (v2.1.214) cannot be removed by a glob deny while any other tool remains available. Unanchored allow globs (`"*"`, `"B*"`, `"mcp__*"`) are **silently skipped** — allow rules require a specific tool prefix.
 
 **Read/Edit path patterns:** Permission rules for `Read`, `Edit`, and `Write` support gitignore-style patterns with four prefix types:
 
@@ -327,19 +330,23 @@ Control what tools and operations Claude can perform.
 |--------|---------|---------|
 | `//` | Absolute path from filesystem root | `Read(//Users/alice/file)` |
 | `~/` | Relative to home directory | `Read(~/.zshrc)` |
-| `/` | Relative to project root | `Edit(/src/**)` |
+| `/` | Relative to the **settings source file** — resolves differently per file: `~/.claude/` for user settings, the project root for `.claude/settings.json` | `Edit(/src/**)` |
 | `./` or none | Relative path (current directory) | `Read(.env)`, `Read(*.ts)` |
 
 **Symlink resolution:** Permission rules check both the symlink path and its resolved target. **Allow** rules apply only when *both* the symlink and its target match — a symlink inside an allowed directory that points outside it still prompts. **Deny** rules apply when *either* the symlink or its target matches — a symlink to a denied file is itself denied.
+
+**`Read` deny blocks `Edit` (v2.1.208):** A `Read` deny rule on a path also blocks the Edit tool on the same path, including file creation. `Write` and `NotebookEdit` are not affected — deny them explicitly if needed.
+
+**`dir/**` scoping fix (v2.1.214):** Single-segment allow rules like `Edit(src/**)` now match only `<cwd>/src`, not `src` at any depth. Deny and ask rules retain any-depth matching. Example: `Edit(/src/**)` in `.claude/settings.json` allows edits only under the project's `src/` directory.
 
 **Bash wildcard notes:**
 - `*` can appear at **any position**: prefix (`Bash(* install)`), suffix (`Bash(npm *)`), or middle (`Bash(git * main)`)
 - **Word boundary:** `Bash(ls *)` (space before `*`) matches `ls -la` but NOT `lsof`; `Bash(ls*)` (no space) matches both
 - `Bash(*)` is treated as equivalent to `Bash` (matches all bash commands)
 - Permission rules support output redirections: `Bash(python:*)` matches `python script.py > output.txt`
-- The legacy `:*` suffix syntax (e.g., `Bash(npm:*)`) is equivalent to ` *` but is deprecated
+- The legacy `:*` suffix syntax (e.g., `Bash(npm:*)`) is equivalent to ` *` (both are recognized; `:*` is recognized **only at the end** of a pattern — in `Bash(git:* push)` the colon is treated as a literal character)
 - **Compound commands:** shell operators (`&&`, `||`, `;`, `|`, `|&`, `&`, and newlines) split a command and each subcommand must match independently — `Bash(safe-cmd *)` does **not** authorize `safe-cmd && other-cmd`
-- **Process wrappers:** `timeout`, `time`, `nice`, `nohup`, and `stdbuf` are stripped before matching (so `Bash(npm test *)` also matches `timeout 30 npm test`); bare `xargs` (no flags) is stripped too. Exec wrappers `watch`, `setsid`, `ionice`, `flock`, and `find` with `-exec`/`-delete` always prompt and cannot be approved by a prefix rule
+- **Process wrappers:** `timeout`, `time`, `nice`, `nohup`, `stdbuf`, and shell builtins `command` and `builtin` are stripped before matching (so `Bash(npm test *)` also matches `timeout 30 npm test`); bare `xargs` (no flags) is stripped too. Zsh's `noglob` is also stripped. Exec wrappers `watch`, `setsid`, `ionice`, `flock`, and `find` with `-exec`/`-delete` always prompt and cannot be approved by a prefix rule. **Note:** env runners like `devbox run`, `mise exec`, `npx`, and `docker exec` are NOT stripped — `Bash(devbox run *)` authorizes arbitrary inner commands
 
 **Example:**
 ```json
@@ -351,7 +358,7 @@ Control what tools and operations Claude can perform.
       "Bash(npm run *)",
       "Bash(git *)",
       "WebFetch(domain:*)",
-      "mcp__*"
+      "mcp__github__*"
     ],
     "ask": [
       "Bash(rm *)",
@@ -373,7 +380,7 @@ Control what tools and operations Claude can perform.
 
 Hook configuration (events, properties, matchers, exit codes, environment variables, and HTTP hooks) is maintained in a dedicated repository:
 
-> **[claude-code-hooks](https://github.com/shanraisshan/claude-code-hooks)** — Complete hook reference with sound notification system, all 26 hook events, HTTP hooks, matcher patterns, exit codes, and environment variables.
+> **[claude-code-hooks](https://github.com/shanraisshan/claude-code-hooks)** — Complete hook reference with sound notification system, all 30 hook events, HTTP hooks, matcher patterns, exit codes, and environment variables.
 
 Hook-related settings keys (`hooks`, `disableAllHooks` (also disables any custom status line), `allowManagedHooksOnly`, `allowedHttpHookUrls`, `httpHookAllowedEnvVars`) are documented there.
 
@@ -467,14 +474,14 @@ Configure bash command sandboxing for security.
 | `sandbox.autoAllowBashIfSandboxed` | boolean | `true` | Auto-approve bash when sandboxed. As of v2.1.139, shell-expansion forms (`$VAR`, `$(cmd)`) are correctly recognized so commands containing variable substitution no longer fall back to a prompt when sandbox auto-approval is enabled |
 | `sandbox.excludedCommands` | array | `[]` | Commands to run outside sandbox |
 | `sandbox.allowUnsandboxedCommands` | boolean | `true` | Allow `dangerouslyDisableSandbox`. When set to `false`, the escape hatch is completely disabled and all commands must run sandboxed (or be in `excludedCommands`). Useful for enterprise policies that require strict sandboxing |
-| `sandbox.filesystem.disabled` | boolean | `false` | Skip filesystem isolation while keeping network egress control active. When `true`, the sandbox does not restrict file access but still applies `sandbox.network.*` rules. Useful when filesystem restrictions are not needed but network egress control is (v2.1.216) |
+| `sandbox.filesystem.disabled` | boolean | `false` | Skip filesystem isolation while keeping network egress control active. When `true`, the sandbox does not restrict file access but still applies `sandbox.network.*` rules. Only honored from user settings, managed settings, or `--settings` (not `.claude/settings.json` or local settings). Useful when filesystem restrictions are not needed but network egress control is (v2.1.216) |
 | `sandbox.ignoreViolations` | object | `{}` | Map of command patterns to path arrays — suppress violation warnings *(in JSON schema, not on official settings page)* |
 | `sandbox.enableWeakerNestedSandbox` | boolean | `false` | **(Linux and WSL2 only)** Enable weaker sandbox for unprivileged Docker environments (reduces security) |
 | `sandbox.network.allowUnixSockets` | array | `[]` | **(macOS only)** Specific Unix socket paths accessible in sandbox. Ignored on Linux and WSL2, where the seccomp filter cannot inspect socket paths; use `allowAllUnixSockets` instead |
 | `sandbox.network.allowAllUnixSockets` | boolean | `false` | Allow all Unix sockets (overrides `allowUnixSockets`). On Linux and WSL2 this is the only way to permit Unix sockets, since it skips the seccomp filter that otherwise blocks `socket(AF_UNIX, ...)` calls |
 | `sandbox.network.allowLocalBinding` | boolean | `false` | Allow binding to localhost ports (macOS) |
 | `sandbox.network.allowedDomains` | array | `[]` | Network domain allowlist for sandbox |
-| `sandbox.network.strictAllowlist` | boolean | `false` | When `true`, deny all network access to hosts **not** in `allowedDomains` without prompting the user. By default, unlisted hosts prompt for permission; this setting makes the allowlist a hard block (v2.1.219) |
+| `sandbox.network.strictAllowlist` | boolean | `false` | When `true`, deny all network access to hosts **not** in `allowedDomains` (plus domains from `WebFetch(domain:...)` allow rules) without prompting the user. Only enforced for shell-based network calls — in-process `WebFetch` is not sandboxed. Only honored from user settings, managed settings, or `--settings` (not `.claude/settings.json` or local settings). By default, unlisted hosts prompt for permission; this setting makes the allowlist a hard block (v2.1.219) |
 | `sandbox.network.deniedDomains` | array | `[]` | Network domain denylist for bash sandbox. Takes precedence over wildcards in `allowedDomains`. Supports glob patterns (e.g., `"*.example.com"`) (v2.1.113) |
 | `sandbox.network.httpProxyPort` | number | - | HTTP proxy port 1-65535 (custom proxy) |
 | `sandbox.network.socksProxyPort` | number | - | SOCKS5 proxy port 1-65535 (custom proxy) |
@@ -489,7 +496,9 @@ Configure bash command sandboxing for security.
 | `sandbox.bwrapPath` | string | - | **(Managed only, Linux/WSL2)** Absolute path to the bubblewrap (`bwrap`) binary. Overrides automatic `PATH` detection. Only honored from managed settings, not user or project settings. Example: `/opt/admin/bwrap` (v2.1.133) |
 | `sandbox.socatPath` | string | - | **(Managed only, Linux/WSL2)** Absolute path to the `socat` binary used for the sandbox network proxy. Overrides automatic `PATH` detection. Only honored from managed settings. Example: `/opt/admin/socat` (v2.1.133) |
 | `sandbox.allowAppleEvents` | boolean | `false` | **(macOS only)** Opt-in for sandboxed commands to send Apple Events. Required for tools that use `open`, `osascript`, or browser authentication flows that depend on Apple Events IPC (v2.1.181) |
-| `sandbox.credentials` | object | — | Fine-grained control over which credential files and environment variables are blocked from sandboxed subprocess environments. Contains `files` (array of file paths to block from sandboxed reads) and `envVars` (array of env var names to strip from the subprocess environment). Supports two modes via a `mode` field: `"deny"` (default) blocks files and strips env vars entirely; `"mask"` with an `injectHosts` array selectively exposes credentials to specific trusted hosts. An individual invalid entry in `files` or `envVars` is stripped with a warning and the valid subset is enforced (v2.1.187; extended to object with sub-arrays in v2.1.191+; `mode` and `injectHosts` added v2.1.199) |
+| `sandbox.credentials` | object | — | Fine-grained control over which credential files and environment variables are blocked from sandboxed subprocess environments. Contains `files` (array of file paths to block from sandboxed reads) and `envVars` (array of env var names to strip from the subprocess environment). Supports two modes via a `mode` field: `"deny"` (default) blocks files and strips env vars entirely; `"mask"` with an `injectHosts` array selectively exposes credentials to specific trusted hosts — **`mask` mode requires `sandbox.network.tlsTerminate` to be configured** (without TLS termination, substitution cannot occur on HTTPS). An individual invalid entry in `files` or `envVars` is stripped with a warning and the valid subset is enforced (v2.1.187; extended to object with sub-arrays in v2.1.191+; `mode` and `injectHosts` added v2.1.199) |
+| `sandbox.network.tlsTerminate` | object | — | **(Experimental)** Terminate TLS inside the sandbox proxy so it can read HTTPS request contents. Required for `sandbox.credentials` `mask` mode to perform credential substitution on HTTPS traffic. Set to `{}` for an ephemeral CA (generated at sandbox start), or set `caCertPath`/`caKeyPath` to provide a persistent CA. Only honored from user settings, managed settings, or `--settings` (v2.1.199) |
+| `sandbox.credentials.allowPlaintextInject` | boolean | `false` | Allow `sandbox.credentials` `mask` mode to perform credential substitution on plain HTTP (in addition to TLS-terminated HTTPS). Only honored from user settings, managed settings, or `--settings` (v2.1.199) |
 
 **Example:**
 ```json
@@ -519,12 +528,12 @@ Configure Claude Code plugins and marketplaces.
 |-----|------|-------|-------------|
 | `enabledPlugins` | object | Any | Enable/disable specific plugins |
 | `extraKnownMarketplaces` | object | Project | Add custom plugin marketplaces (team sharing via `.claude/settings.json`) |
-| `strictKnownMarketplaces` | boolean | Managed only | When `true`, only the official Anthropic marketplace is permitted; no additional or custom marketplaces may be installed |
+| `strictKnownMarketplaces` | array | Managed only | Allowlist of permitted plugin marketplace sources. `undefined` (unset) = no restrictions; `[]` (empty array) = complete lockdown including the official Anthropic marketplace. Each entry is a source specifier (e.g., `{ "source": "github", "repo": "acme/plugins" }`). **Do NOT use `true`** — the type is array, not boolean |
 | `strictPluginOnlyCustomization` | boolean \| array | Managed only | Block skills, agents, hooks, and MCP servers from user and project sources, so they can only come from plugins or managed settings. `true` locks all four surfaces; an array such as `["skills", "hooks"]` locks only the named ones |
 | `pluginSuggestionMarketplaces` | array | Managed only | Allowlist of marketplace names whose plugins may appear as contextual install suggestions during a session. Restricts which marketplaces can surface "you might want this plugin" prompts (v2.1.152) |
 | `skippedMarketplaces` | array | Any | Marketplaces user declined to install *(in JSON schema, not on official settings page)* |
 | `skippedPlugins` | array | Any | Plugins user declined to install *(in JSON schema, not on official settings page)* |
-| `pluginConfigs` | object | Any | Per-plugin MCP server configs (keyed by `plugin@marketplace`). As of v2.1.207, no longer read from project-level `.claude/settings.json` or `.claude/settings.local.json`; only user, `--settings`, and managed settings are honored *(in JSON schema, not on official settings page)* |
+| `pluginConfigs` | object | Any (user/managed/`--settings` only since v2.1.207) | Per-plugin non-sensitive `userConfig` option values collected by the plugin's configuration dialog (keyed by `plugin@marketplace`). Sensitive options go to the OS keychain / `~/.claude/.credentials.json`. No longer read from `.claude/settings.json` or `.claude/settings.local.json` since v2.1.207 |
 | `blockedMarketplaces` | array | Managed only | Block specific plugin marketplaces. Each entry can match by source string, `hostPattern`, or `pathPattern` — as of v2.1.119 the `hostPattern` and `pathPattern` matchers are correctly enforced before any download touches the filesystem, so blocked marketplaces never reach disk |
 | `pluginTrustMessage` | string | Managed only | Custom message displayed when prompting users to trust plugins |
 | `disableSideloadFlags` | boolean | Managed only | Reject the `--plugin-dir`, `--plugin-url`, `--agents`, and `--mcp-config` startup flags. When `true`, users cannot bypass `strictKnownMarketplaces` by passing sideload flags at launch. Use in managed environments to enforce marketplace-only plugin distribution (v2.1.193) |
@@ -594,7 +603,7 @@ Map Anthropic model IDs to provider-specific model IDs for Bedrock, Vertex, or F
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `effortLevel` | string | - | Persist the effort level across sessions. Accepts `"low"`, `"medium"`, `"high"`, `"xhigh"` (Opus 4.7, 4.8, and Opus 5, v2.1.111), `"max"` (Opus 4.6 only), or `"ultracode"` (Opus 4.8 and Opus 5; starts at `xhigh` with ultracode workflow enabled, v2.1.203+). Written automatically when you run `/effort <level>`. Supported on Opus 4.6, Sonnet 4.6, Opus 4.7, Opus 4.8, and Opus 5 (Opus 4.8 and Opus 5 default to `high`). Unsupported levels fall back to the highest supported level on the active model |
+| `effortLevel` | string | - | Persist the effort level across sessions. Valid `settings.json` values: `"low"`, `"medium"`, `"high"`, `"xhigh"` (Opus 4.7, 4.8, and Opus 5, v2.1.111). **Note:** `"max"` (Opus 4.6 only) and `"ultracode"` (Opus 4.8 and Opus 5, v2.1.203+) are only available via `/effort` and `--effort` — they are **not** valid values for this settings key. Written automatically when you run `/effort <level>`. Supported on Opus 4.6, Sonnet 4.6, Opus 4.7, Opus 4.8, and Opus 5 (Opus 4.8 and Opus 5 default to `high`). Unsupported levels fall back to the highest supported level on the active model |
 | `fallbackModel` | array | - | Up to 3 fallback model IDs tried sequentially when the primary model is unavailable (e.g., rate-limited or capacity issue). Each entry is a model ID or alias. Claude Code attempts the primary model first; if it fails, each fallback is tried in order. Stops at the first successful response (v2.1.166) |
 | `modelOverrides` | object | - | Map model picker entries to provider-specific IDs (e.g., Bedrock inference profile ARNs). Each key is a model picker entry name, each value is the provider model ID |
 
@@ -602,8 +611,8 @@ Map Anthropic model IDs to provider-specific model IDs for Bedrock, Vertex, or F
 ```json
 {
   "modelOverrides": {
-    "claude-opus-4-6": "arn:aws:bedrock:us-east-1:123456789:inference-profile/anthropic.claude-opus-4-6-v1:0",
-    "claude-sonnet-4-6": "arn:aws:bedrock:us-east-1:123456789:inference-profile/anthropic.claude-sonnet-4-6-v1:0"
+    "claude-opus-5": "arn:aws:bedrock:us-east-1:123456789:inference-profile/anthropic.claude-opus-5-v1:0",
+    "claude-sonnet-5": "arn:aws:bedrock:us-east-1:123456789:inference-profile/anthropic.claude-sonnet-5-v1:0"
   }
 }
 ```
@@ -614,12 +623,12 @@ The `/model` command exposes an **effort level** control that adjusts how much r
 
 | Effort Level | Description |
 |-------------|-------------|
-| Ultracode | Triggers the ultracode workflow in addition to xhigh reasoning depth. Applies to Opus 4.8 and Opus 5 (v2.1.203+). Activated via `/effort ultracode` or `effortLevel: "ultracode"` |
-| Max | Maximum reasoning depth, Opus 4.6 only |
-| XHigh | Extended high reasoning depth, Opus 4.7, 4.8, and Opus 5 (default on Opus 4.7 across all plans, v2.1.111; on Opus 4.8 and Opus 5 it is available but the default is `high`, v2.1.154) |
-| High (default on Opus 4.6/Sonnet 4.6/Opus 4.8/Opus 5) | Full reasoning depth, best for complex tasks |
-| Medium | Balanced reasoning, good for everyday tasks |
-| Low | Minimal reasoning, fastest responses |
+| Ultracode | Triggers the ultracode workflow in addition to xhigh reasoning depth. Applies to Opus 4.8 and Opus 5 (v2.1.203+). Activated via `/effort ultracode` or `--effort ultracode` — **not a valid `settings.json` value** |
+| Max | Maximum reasoning depth, Opus 4.6 only. Activated via `/effort max` — **not a valid `settings.json` value** |
+| XHigh | Extended high reasoning depth (`"xhigh"`), Opus 4.7, 4.8, and Opus 5 (default on Opus 4.7 across all plans, v2.1.111; on Opus 4.8 and Opus 5 it is available but the default is `high`, v2.1.154). Valid as `effortLevel: "xhigh"` |
+| High (default on Opus 4.6/Sonnet 4.6/Opus 4.8/Opus 5) | Full reasoning depth, best for complex tasks. Valid as `effortLevel: "high"` |
+| Medium | Balanced reasoning, good for everyday tasks. Valid as `effortLevel: "medium"` |
+| Low | Minimal reasoning, fastest responses. Valid as `effortLevel: "low"` |
 
 **How to use:**
 1. Run `/effort low`, `/effort medium`, or `/effort high` to set directly (v2.1.76+)
@@ -655,6 +664,7 @@ Configure via `env` key:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| `theme` | string | `"dark"` | UI color theme. Values: `"auto"` (follow OS light/dark preference), `"dark"`, `"light"`, `"dark-daltonized"`, `"light-daltonized"`, `"dark-ansi"`, `"light-ansi"`, or `"custom:<slug>"` / `"custom:<plugin-name>:<slug>"` for plugin-provided themes. Appears in `/config` as **Theme** (v2.1.119) |
 | `statusLine` | object | - | Custom status line configuration |
 | `outputStyle` | string | `"default"` | Output style (e.g., `"Explanatory"`) |
 | `spinnerTipsEnabled` | boolean | `true` | Show tips while waiting |
@@ -673,20 +683,22 @@ Configure via `env` key:
 | `terminalProgressBarEnabled` | boolean | `true` | Show the terminal progress bar in supported terminals (ConEmu, Ghostty 1.2.0+, and iTerm2 3.6.6+). Appears in `/config` as **Terminal progress bar**. Versions before v2.1.119 stored this in `~/.claude.json` |
 | `preferredNotifChannel` | string | `"auto"` | Method for task-complete and permission-prompt notifications. Values: `"auto"`, `"terminal_bell"`, `"iterm2"`, `"iterm2_with_bell"`, `"kitty"`, `"ghostty"`, `"notifications_disabled"`. Default `"auto"` sends a desktop notification in iTerm2, Ghostty, and Kitty and does nothing in other terminals. Set `"terminal_bell"` to ring the bell character in any terminal. Appears in `/config` as **Notifications**. See [Get a terminal bell or notification](https://code.claude.com/docs/en/terminal-config#get-a-terminal-bell-or-notification) |
 | `wheelScrollAccelerationEnabled` | boolean | `true` | Disable mouse-wheel scroll acceleration in fullscreen mode. Set to `false` to use fixed per-tick scroll steps instead of the OS-level acceleration curve (v2.1.174) |
-| `footerLinksRegexes` | array | - | Regex patterns matched against URLs to display as link badges in the footer row. Each matching URL produces a clickable badge at the bottom of the chat UI (v2.1.176) |
+| `footerLinksRegexes` | array | - | Regex patterns matched against **turn output** (tool results, file contents, fetched pages, Claude's replies) to surface clickable link badges in the footer row. Each entry is an object with `pattern` (regex string with named capture groups), `url` (URL template using `{name}` placeholders from capture groups), and optional `label`. Max 5 badges. Only honored from user, `--settings`, and managed settings — ignored in project and local settings (v2.1.176) |
 | `emojiCompletionEnabled` | boolean | `true` | Enable emoji shortcode autocomplete in the prompt input (e.g., `:tada:` → 🎉). Set to `false` to disable. Requires v2.1.217+ |
 
 ### Global Config Settings (`~/.claude.json`)
 
 These IDE-related preferences are stored in `~/.claude.json`, **not** `settings.json`.
 
-> **v2.1.119 migration note:** As of v2.1.119, `autoScrollEnabled`, `editorMode`, `showTurnDuration`, `teammateMode`, and `terminalProgressBarEnabled` moved into `settings.json` and are documented in the Display Settings table above. Earlier versions stored them here.
+> **v2.1.119 migration note:** As of v2.1.119, `autoScrollEnabled`, `editorMode`, `showTurnDuration`, `teammateMode`, `terminalProgressBarEnabled`, `theme`, and `verbose` moved into `settings.json` and are documented in the Display Settings table above. Earlier versions stored them here.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `autoConnectIde` | boolean | `false` | Automatically connect to a running IDE when Claude Code starts from an external terminal. Appears in `/config` as **Auto-connect to IDE (external terminal)** when running outside a VS Code or JetBrains terminal |
 | `autoInstallIdeExtension` | boolean | `true` | Automatically install the Claude Code IDE extension when running from a VS Code terminal. Appears in `/config` as **Auto-install IDE extension**. Can also be disabled via `CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL` env var |
+| `diffTool` | string | `"auto"` | Where to show diffs when an IDE is connected: `"auto"` (use IDE diff viewer when available) or `"terminal"`. Appears in `/config` as **Diff tool** |
 | `externalEditorContext` | boolean | `false` | Prepend Claude's previous response as `#`-commented context when you open the external editor with `Ctrl+G`. Set to `true` to enable |
+| `permissionExplainerEnabled` | boolean | `true` | Show a model-generated command explanation on `Ctrl+E` at a Bash or PowerShell permission prompt. Set to `false` to disable |
 | `teammateDefaultModel` | string | `null` | Default model for [agent-team](https://code.claude.com/docs/en/agent-teams) teammates when the lead dispatches them. `null` inherits the lead's model. Listed under "Global config settings" on the official settings page |
 
 ### Workspace & Teams
@@ -741,6 +753,7 @@ These IDE-related preferences are stored in `~/.claude.json`, **not** `settings.
 | `command` | Shell command or script path that generates the status line output |
 | `padding` | Extra horizontal spacing (in characters) added to status line content. Defaults to `0`. Controls relative indentation beyond the interface's built-in spacing |
 | `refreshInterval` | Re-run the command every N seconds in addition to event-driven updates. Minimum is `1`. Useful when the status line shows time-based data (e.g., a clock) or when background subagents change git state while the main session is idle. Leave unset to run only on events (v2.1.97) |
+| `hideVimModeIndicator` | Set to `true` to hide the vim mode indicator (NORMAL/INSERT) from the status line even when vim mode is active |
 
 **Status Line Input Fields:**
 
@@ -901,8 +914,8 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDECODE` | Set to `1` in shell environments Claude Code spawns (Bash tool, tmux sessions). Not set in hooks or status line commands. Use to detect when a script is running inside a Claude Code shell |
 | `CLAUDE_CODE_CHILD_SESSION` | Set to `1` in subprocesses Claude Code spawns via the Bash, PowerShell, and Monitor tools, hook commands, and status line commands. Not set for stdio MCP server subprocesses. Unlike `CLAUDECODE`, this is only set by Claude Code's own spawn path (not IDE extensions), so it reliably distinguishes a nested `claude` session from a top-level `claude` launched in an IDE-integrated terminal. Nested interactive TUI sessions are automatically excluded from `--resume`, `--continue`, up-arrow history, and `claude agents`. Non-interactive `claude -p` sessions still persist. Set `CLAUDE_CODE_FORCE_SESSION_PERSISTENCE=1` to override this exclusion (v2.1.172) |
 | `CLAUDE_CODE_FORCE_SESSION_PERSISTENCE` | Set to `1` to override the automatic exclusion of nested interactive TUI sessions from `--resume`, `--continue`, up-arrow history, and `claude agents`. By default, nested sessions (where `CLAUDE_CODE_CHILD_SESSION=1`) are excluded to prevent them from polluting history. Set this to force persistence when you want nested sessions tracked |
-| `CLAUDE_CODE_SESSION_ID` | Read-only. Set automatically in Bash and PowerShell tool subprocesses to the current session ID. Matches the `session_id` field passed to hooks. Updated on `/clear`. Use to correlate scripts and external tools with the Claude Code session that launched them (v2.1.132). Also injected into stdio MCP server environments on `--resume` (v2.1.163 changelog) *(in v2.1.163 changelog; not yet on official env-vars page — read-only)* |
-| `AI_AGENT` | Set automatically by Claude Code in subprocess environments (Bash tool, hooks, MCP stdio servers). Generic flag identifying the parent process as an AI agent — useful for tools that adapt behavior when invoked from any AI agent rather than checking each agent-specific variable like `CLAUDECODE` *(in v2.1.120 changelog, not yet on official env-vars page)* |
+| `CLAUDE_CODE_SESSION_ID` | Read-only. Set automatically in Bash and PowerShell tool subprocesses to the current session ID. Matches the `session_id` field passed to hooks. Updated on `/clear`. Use to correlate scripts and external tools with the Claude Code session that launched them (v2.1.132). Also injected into stdio MCP server environments on `--resume` (v2.1.163) |
+| `AI_AGENT` | Set automatically by Claude Code in subprocess environments (Bash tool, hooks, MCP stdio servers). Generic flag identifying the parent process as an AI agent — useful for tools that adapt behavior when invoked from any AI agent rather than checking each agent-specific variable like `CLAUDECODE` |
 | `CLAUDE_CODE_SKIP_FAST_MODE_NETWORK_ERRORS` | Set to `1` to allow fast mode when the organization status check fails due to a network error. Useful when a corporate proxy blocks the status endpoint |
 | `CLAUDE_CODE_USE_BEDROCK` | Use AWS Bedrock (`1` to enable) |
 | `CLAUDE_CODE_USE_VERTEX` | Use Google Vertex AI (`1` to enable) |
@@ -919,7 +932,7 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_ENABLE_TELEMETRY` | Enable/disable telemetry (`0` or `1`) |
 | `DISABLE_ERROR_REPORTING` | Disable error reporting (`1` to disable) |
 | `DISABLE_AUTOUPDATER` | Set to `1` to disable automatic update checks against the npm registry. Also configurable as a startup-only var — see [CLI Startup Flags](./claude-cli-startup-flags.md#environment-variables) |
-| `DISABLE_UPDATES` | Set to `1` to completely block all update paths — automatic checks, notifications, and manual `claude update`. Stricter than `DISABLE_AUTOUPDATER`, which only disables the background check. Use in environments where all updates must be blocked until explicitly re-enabled *(in v2.1.118 changelog, not yet on official env-vars page)* |
+| `DISABLE_UPDATES` | Set to `1` to completely block all update paths — automatic checks, notifications, and manual `claude update`. Stricter than `DISABLE_AUTOUPDATER`, which only disables the background check. Use in environments where all updates must be blocked until explicitly re-enabled |
 | `CLAUDE_CODE_PACKAGE_MANAGER_AUTO_UPDATE` | Set to `1` to let Claude Code run your package manager's upgrade command in the background when a new version is available. Applies to Homebrew and WinGet installations. Other package managers continue to show the upgrade command without running it. See [Auto updates](https://code.claude.com/docs/en/setup#auto-updates) (v2.1.129) |
 | `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY` | Set to `1` to populate the `/model` picker from your gateway's `/v1/models` endpoint when `ANTHROPIC_BASE_URL` points at an Anthropic-compatible gateway such as LiteLLM, Kong, or an internal proxy. Off by default because gateways backed by a shared API key would otherwise expose every model the key can access. Discovered models are still filtered by the `availableModels` allowlist (v2.1.129, opt-in change from prior auto-discovery) |
 | `DISABLE_TELEMETRY` | Disable telemetry (`1` to disable) |
@@ -938,7 +951,7 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_MAX_CONTEXT_TOKENS` | Override the context window size Claude Code assumes for the active model. Only takes effect when `DISABLE_COMPACT` is also set. Use when routing to a model through `ANTHROPIC_BASE_URL` whose context window does not match the built-in size for its name |
 | `CLAUDE_CODE_BASH_MAINTAIN_PROJECT_WORKING_DIR` | Keep cwd between bash calls (`1` to enable) |
 | `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS` | Disable background tasks (`1` to disable) |
-| `CLAUDE_CODE_DISABLE_BG_SHELL_PRESSURE_REAP` | Set to `1` to disable automatic memory-pressure reaping of idle background shell commands. When unset, Claude Code automatically reaps idle background shells under memory pressure to free resources (v2.1.193 changelog, not yet on official env-vars page) |
+| `CLAUDE_CODE_DISABLE_BG_SHELL_PRESSURE_REAP` | Set to `1` to disable automatic memory-pressure reaping of idle background shell commands. When unset, Claude Code automatically reaps idle background shells under memory pressure to free resources (v2.1.193) |
 | `CLAUDE_CODE_DISABLE_BG_EXIT_HANDOFF` | Set to `1` to stop a background session's running background shell commands, dynamic workflows, and background subagents when the supervisor stops, restarts, or updates that session's process. By default they are handed off to the session's next process (v2.1.198) |
 | `CLAUDE_CODE_DISABLE_ADVISOR_TOOL` | Set to `1` to disable the advisor tool and the `/advisor` command. Env-var equivalent of omitting advisor usage. Pair with `advisorModel` for advisor configuration (min v2.1.98) |
 | `CLAUDE_CODE_DISABLE_AGENT_VIEW` | Set to `1` to turn off background agents and agent view (`claude agents`, `--bg`, `/background`, on-demand supervisor). Env-var equivalent of the `disableAgentView` setting *(referenced on official settings page; not listed on the env-vars page)* |
@@ -950,8 +963,8 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_DISABLE_ARTIFACT` | Set to `1` to disable the [Artifact](https://code.claude.com/docs/en/artifacts) tool, which publishes session output as a private web page on claude.ai. Equivalent to the `disableArtifact` setting |
 | `CLAUDE_CODE_ARTIFACT_AUTO_OPEN` | Set to `0` to stop Claude Code from opening the browser automatically when a new artifact is published. Republishing an existing artifact does not open the browser regardless of this setting |
 | `ENABLE_TOOL_SEARCH` | MCP tool search threshold (e.g., `auto:5`) |
-| `ENABLE_PROMPT_CACHING_1H` | Opt into 1-hour prompt cache TTL. Replaces the deprecated `ENABLE_PROMPT_CACHING_1H_BEDROCK` *(in v2.1.108 changelog, not yet on official env-vars page)* |
-| `FORCE_PROMPT_CACHING_5M` | Force 5-minute prompt cache TTL *(in v2.1.108 changelog, not yet on official env-vars page)* |
+| `ENABLE_PROMPT_CACHING_1H` | Opt into 1-hour prompt cache TTL. Replaces the deprecated `ENABLE_PROMPT_CACHING_1H_BEDROCK` |
+| `FORCE_PROMPT_CACHING_5M` | Force 5-minute prompt cache TTL |
 | `CLAUDE_CODE_ENABLE_AWAY_SUMMARY` | Opt out of away summary / idle-session recap. Set to `0` to disable. Pairs with the `awaySummaryEnabled` setting (v2.1.110) |
 | `DISABLE_PROMPT_CACHING` | Disable all prompt caching (`1` to disable) |
 | `DISABLE_PROMPT_CACHING_HAIKU` | Disable Haiku prompt caching |
@@ -978,9 +991,9 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_PLUGIN_SEED_DIR` | Path to one or more read-only plugin seed directories, separated by `:` on Unix or `;` on Windows. Bundle pre-populated plugins into a container image. Claude Code registers marketplaces from these directories at startup and uses pre-cached plugins without re-cloning |
 | `ENABLE_CLAUDEAI_MCP_SERVERS` | Enable Claude.ai MCP servers |
 | `CLAUDE_CODE_EFFORT_LEVEL` | Set effort level: `low`, `medium`, `high`, `xhigh` (Opus 4.7 and 4.8, v2.1.111), `max` (Opus 4.6 only), or `auto` (use model default). Takes precedence over `/effort` and the `effortLevel` setting. Also configurable as a startup-only var — see [CLI Startup Flags](./claude-cli-startup-flags.md#environment-variables) |
-| `CLAUDE_EFFORT` | Read-only. Injected into Bash tool subprocesses and hook handlers with the active effort level so shell scripts and hooks can adapt to the current tier (companion to `CLAUDE_CODE_EFFORT_LEVEL`; v2.1.133). Inside skill files use `${CLAUDE_EFFORT}` *(in changelog, not on official env-vars page — read-only, not user-configurable)* |
+| `CLAUDE_EFFORT` | Read-only. Injected into Bash tool subprocesses and hook handlers with the active effort level so shell scripts and hooks can adapt to the current tier (companion to `CLAUDE_CODE_EFFORT_LEVEL`; v2.1.133). Inside skill files use `${CLAUDE_EFFORT}` |
 | `CLAUDE_CODE_ALWAYS_ENABLE_EFFORT` | Set to `1` to force-enable the effort parameter on all models, even those that do not normally support effort-level selection. Allows `/effort` and the `effortLevel` setting to take effect on models outside the standard effort-capable set (v2.1.154) |
-| `CLAUDE_CODE_MAX_TURNS` | Maximum agentic turns before stopping *(not in official docs — unverified)* |
+| `CLAUDE_CODE_MAX_TURNS` | Maximum agentic turns before stopping |
 | `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` | Equivalent of setting `DISABLE_AUTOUPDATER`, `DISABLE_FEEDBACK_COMMAND`, `DISABLE_ERROR_REPORTING`, and `DISABLE_TELEMETRY` |
 | `CLAUDE_CODE_SKIP_SETTINGS_SETUP` | Skip first-run settings setup flow *(not in official docs — unverified)* |
 | `CLAUDE_CODE_PROMPT_CACHING_ENABLED` | Override prompt caching behavior *(not in official docs — unverified)* |
@@ -1056,21 +1069,23 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_GIT_BASH_PATH` | Windows only: path to the Git Bash executable (`bash.exe`). Use when Git Bash is installed but not in your PATH |
 | `DISABLE_COST_WARNINGS` | Disable cost warning messages |
 | `CLAUDE_CODE_SUBAGENT_MODEL` | Override model for subagents (e.g., `haiku`, `sonnet`) |
-| `CLAUDE_CODE_FORWARD_SUBAGENT_TEXT` | Set to `1` to forward subagent streaming text output to the parent session in real time. By default, subagent output is buffered until the subagent completes. As of v2.1.219, forwarding also works for nested subagents at depth 2+ *(in v2.1.211 changelog, not yet on official env-vars page)* |
+| `CLAUDE_CODE_FORWARD_SUBAGENT_TEXT` | Set to `1` to forward subagent streaming text output to the parent session in real time. By default, subagent output is buffered until the subagent completes. As of v2.1.219, forwarding also works for nested subagents at depth 2+ |
 | `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB` | Set to `1` to strip Anthropic and cloud provider credentials from subprocess environments (Bash tool, hooks, MCP stdio servers). Use for defense-in-depth when subprocesses should not inherit API keys (v2.1.83) |
 | `CLAUDE_CODE_SCRIPT_CAPS` | JSON object limiting how many times specific scripts may be invoked per session when `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB` is set. Keys are substrings matched against the command text; values are integer call limits. For example, `{"deploy.sh": 2}` allows `deploy.sh` to be called at most twice. Matching is substring-based; runtime fan-out via `xargs` or `find -exec` is not detected — this is a defense-in-depth control |
 | `CLAUDE_CODE_PERFORCE_MODE` | Set to `1` to enable Perforce-aware write protection. When set, Edit, Write, and NotebookEdit fail with a `p4 edit <file>` hint if the target file lacks the owner-write bit, which Perforce clears on synced files until `p4 edit` opens them. Prevents Claude Code from bypassing Perforce change tracking (v2.1.98) |
-| `CLAUDE_CODE_PROCESS_WRAPPER` | Wrap the Claude Code process at startup. Specify the wrapper executable and arguments; Claude Code is appended as the final argument. Useful for profiling tools, sandboxes, or tracing (e.g., `CLAUDE_CODE_PROCESS_WRAPPER="strace -e trace=file"`). *(in v2.1.208 changelog, not yet on official env-vars page)* |
+| `CLAUDE_CODE_PROCESS_WRAPPER` | Wrap the Claude Code process at startup. Specify the wrapper executable and arguments; Claude Code is appended as the final argument. Useful for profiling tools, sandboxes, or tracing (e.g., `CLAUDE_CODE_PROCESS_WRAPPER="strace -e trace=file"`). Takes precedence over the `processWrapper` settings key (v2.1.208) |
 | `CLAUDE_CODE_MAX_RETRIES` | Override API request retry count (default: 10) |
-| `CLAUDE_CODE_RETRY_WATCHDOG` | Raise the retry count for non-capacity API errors to 300. The standard retry cap (`CLAUDE_CODE_MAX_RETRIES`, default: 10) still applies for capacity errors *(in v2.1.199 changelog, not on official env-vars page)* |
+| `CLAUDE_CODE_RETRY_WATCHDOG` | Raise the retry count for non-capacity API errors to 300. The standard retry cap (`CLAUDE_CODE_MAX_RETRIES`, default: 10) still applies for capacity errors |
 | `CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY` | Max parallel read-only tools (default: 10) |
-| `CLAUDE_CODE_MAX_WEB_SEARCHES_PER_SESSION` | Maximum web searches allowed per session (default: `200`). Prevents runaway tool use in long agentic sessions *(in v2.1.212 changelog, not yet on official env-vars page)* |
-| `CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION` | Maximum subagents that can be spawned per session (default: `200`). Prevents resource exhaustion in deeply nested agentic workflows *(in v2.1.212 changelog, not yet on official env-vars page)* |
+| `CLAUDE_CODE_MAX_WEB_SEARCHES_PER_SESSION` | Maximum web searches allowed per session (default: `200`). Prevents runaway tool use in long agentic sessions |
+| `CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION` | Maximum subagents that can be spawned per session (default: `200`). Prevents resource exhaustion in deeply nested agentic workflows |
+| `CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH` | Maximum nesting depth for subagent spawning. Default raised from 1 to `3` in v2.1.219. Prevents infinite subagent recursion (v2.1.217) |
+| `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS` | Maximum subagents running concurrently within a session (default: `20`). Limits parallel spawning to prevent resource exhaustion (v2.1.217) |
 | `CLAUDE_AGENT_SDK_DISABLE_BUILTIN_AGENTS` | Disable built-in subagent types in SDK mode (`1` to disable) |
 | `CLAUDE_AGENT_SDK_MCP_NO_PREFIX` | Skip `mcp__<server>__` prefix for MCP tools in SDK mode (`1` to enable) |
 | `CLAUDE_ASYNC_AGENT_STALL_TIMEOUT_MS` | Stall timeout in ms for background subagents (default: 600000 / 10 minutes). The subagent is killed if it produces no output for this duration |
-| `MCP_CONNECTION_NONBLOCKING` | Set to `true` in `-p` mode to skip the MCP connection wait entirely. Bounds `--mcp-config` server connections at 5s instead of blocking on the slowest server *(in v2.1.89 changelog, not yet on official env-vars page)* |
-| `CLAUDE_CODE_MCP_AUTO_BACKGROUND_MS` | Duration in milliseconds after which a slow MCP tool call is automatically backgrounded (default: `120000` / 2 minutes). MCP calls that exceed this threshold continue running in the background without blocking the agent turn *(in v2.1.212 changelog, not yet on official env-vars page)* |
+| `MCP_CONNECTION_NONBLOCKING` | As of v2.1.142, non-blocking MCP startup is the **default**. Set to `0` to restore the blocking 5-second wait. `alwaysLoad: true` MCP servers always block regardless. |
+| `CLAUDE_CODE_MCP_AUTO_BACKGROUND_MS` | Duration in milliseconds after which a slow MCP tool call is automatically backgrounded (default: `120000` / 2 minutes). MCP calls that exceed this threshold continue running in the background without blocking the agent turn |
 | `CLAUDE_CODE_SESSIONEND_HOOKS_TIMEOUT_MS` | SessionEnd hook timeout in ms (replaces hard 1.5s limit) |
 | `CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY` | Disable feedback survey prompts (`1` to disable) |
 | `CLAUDE_CODE_ENABLE_FEEDBACK_SURVEY_FOR_OTEL` | Set to `1` to route the session quality survey to your own OpenTelemetry collector when Anthropic-bound nonessential traffic is blocked. Survey ratings are emitted only as OTEL events to your configured collector — no survey data is sent to Anthropic. Applies when `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`, `DISABLE_TELEMETRY`, or `DO_NOT_TRACK` is set; has no effect otherwise. `CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY` and the organization product feedback policy take precedence (v2.1.136) |
@@ -1083,7 +1098,7 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_SCROLL_SPEED` | Mouse wheel scroll multiplier for fullscreen rendering. Increase for faster scrolling, decrease for finer control |
 | `CLAUDE_CODE_DISABLE_VIRTUAL_SCROLL` | Set to `1` to disable virtual scrolling in fullscreen rendering and render every message in the transcript. Use if scrolling in fullscreen mode shows blank regions where messages should appear |
 | `CLAUDE_CODE_DISABLE_MOUSE` | Set to `1` to disable mouse tracking in fullscreen rendering. Useful when mouse events interfere with terminal multiplexers or accessibility tools |
-| `CLAUDE_CODE_DISABLE_MOUSE_CLICKS` | Set to `1` to disable mouse click interactions in fullscreen rendering while preserving wheel scroll. Distinguishes click-event suppression from full mouse tracking disable (`CLAUDE_CODE_DISABLE_MOUSE`). Useful when terminal selection or external accessibility tools conflict with in-app mouse clicks *(in v2.1.195 changelog, not yet on official env-vars page)* |
+| `CLAUDE_CODE_DISABLE_MOUSE_CLICKS` | Set to `1` to disable mouse click interactions in fullscreen rendering while preserving wheel scroll. Distinguishes click-event suppression from full mouse tracking disable (`CLAUDE_CODE_DISABLE_MOUSE`). Useful when terminal selection or external accessibility tools conflict with in-app mouse clicks |
 | `CLAUDE_CODE_HIDE_CWD` | Set to `1` to hide the current working directory in the Claude Code startup logo banner. Useful in screen recordings, demos, or shared sessions where the CWD path leaks information about the host or project layout (v2.1.119) |
 | `CLAUDE_CODE_ACCESSIBILITY` | Set to `1` to keep native terminal cursor visible for screen readers and accessibility tools |
 | `CLAUDE_AX_SCREEN_READER` | Set to `1` to render screen-reader friendly output: flat text without decorative borders or animations. Set to `0` to force screen-reader mode off even when the `axScreenReader` setting is `true`. The `--ax-screen-reader` CLI flag takes precedence (v2.1.181+) |
@@ -1098,19 +1113,19 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_OTEL_SHUTDOWN_TIMEOUT_MS` | Timeout in ms for OpenTelemetry shutdown |
 | `CLAUDE_ENABLE_BYTE_WATCHDOG` | Set to `1` to force-enable the byte-level streaming idle watchdog, or `0` to force-disable it. When unset, the watchdog is enabled by default for Anthropic API connections. The byte watchdog aborts a connection when no bytes arrive on the wire for the duration set by `CLAUDE_STREAM_IDLE_TIMEOUT_MS` (minimum 5 minutes), independent of the event-level watchdog |
 | `CLAUDE_STREAM_IDLE_TIMEOUT_MS` | Timeout in ms for the streaming idle watchdog. Two watchdogs apply: **byte-level** (default and minimum `300000` / 5 minutes, aborts when no bytes arrive on the wire) and **event-level** (default `90000` / 90 seconds, no minimum, aborts when no SSE events arrive). The byte watchdog is enabled by default for Anthropic API connections; control it via `CLAUDE_ENABLE_BYTE_WATCHDOG`. Increase the event timeout if long-running tools or slow networks cause premature timeout errors |
-| `OTEL_LOG_TOOL_DETAILS` | Set to `1` to include `tool_parameters` in OpenTelemetry events. Omitted by default for privacy *(in v2.1.85 changelog, not yet on official env-vars page)* |
-| `CLAUDE_CODE_OTEL_CONTENT_MAX_LENGTH` | Maximum content length in bytes for OpenTelemetry event payloads (default: `61440` / 60 KB). Truncates large tool inputs, outputs, or message bodies before emitting them as OTel events to prevent oversized payloads *(in v2.1.214 changelog, not yet on official env-vars page)* |
-| `OTEL_LOG_RAW_API_BODIES` | Set to `1` to emit full API request and response bodies as OpenTelemetry log events. Omitted by default for privacy and payload size. Useful for debugging at a gateway or proxy *(in v2.1.111 changelog, not yet on official env-vars page)* |
+| `OTEL_LOG_TOOL_DETAILS` | Set to `1` to include `tool_parameters` in OpenTelemetry events. Omitted by default for privacy |
+| `CLAUDE_CODE_OTEL_CONTENT_MAX_LENGTH` | Maximum content length in bytes for OpenTelemetry event payloads (default: `61440` / 60 KB). Truncates large tool inputs, outputs, or message bodies before emitting them as OTel events to prevent oversized payloads |
+| `OTEL_LOG_RAW_API_BODIES` | Set to `1` to emit full API request and response bodies as OpenTelemetry log events. Omitted by default for privacy and payload size. Useful for debugging at a gateway or proxy |
 | `OTEL_RESOURCE_ATTRIBUTES` | Comma-separated `key=value` pairs added as resource attributes on all OpenTelemetry metric data points emitted by Claude Code. Use to attach environment or deployment labels (e.g., `environment=production,team=platform`) that appear on every metric for filtering in your collector (v2.1.162) |
-| `OTEL_LOG_USER_PROMPTS` | Set to `1` to include the `user_system_prompt` field in OpenTelemetry LLM request spans. Omitted by default for privacy — user prompts can contain sensitive data, so opt in only when you control the OTel collector and have policies in place *(in v2.1.121 changelog, not yet on official env-vars page)* |
-| `OTEL_LOG_ASSISTANT_RESPONSES` | Set to `1` to include model response text in OpenTelemetry log events. Omitted by default for privacy and payload size. Use only when you control the OTel collector and have policies for handling model output *(in v2.1.193 changelog, not yet on official env-vars page)* |
+| `OTEL_LOG_USER_PROMPTS` | Set to `1` to include the `user_system_prompt` field in OpenTelemetry LLM request spans. Omitted by default for privacy — user prompts can contain sensitive data, so opt in only when you control the OTel collector and have policies in place |
+| `OTEL_LOG_ASSISTANT_RESPONSES` | Set to `1` to include model response text in OpenTelemetry log events. Omitted by default for privacy and payload size. Use only when you control the OTel collector and have policies for handling model output |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | OpenTelemetry collector endpoint URL for metrics and logs. See [Monitoring](https://code.claude.com/docs/en/monitoring-usage) |
 | `OTEL_EXPORTER_OTLP_HEADERS` | OpenTelemetry exporter headers (`Name=Value` format, comma-separated) for authenticating with your collector |
 | `OTEL_LOG_TOOL_CONTENT` | Set to `1` to emit full tool inputs and outputs as OpenTelemetry log events. Omitted by default for privacy |
 | `OTEL_METRICS_EXPORTER` | OpenTelemetry metrics exporter type (e.g., `otlp`). See [Monitoring](https://code.claude.com/docs/en/monitoring-usage) |
 | `OTEL_TRACES_EXPORTER` | OpenTelemetry traces exporter type (e.g., `otlp`). See [Monitoring](https://code.claude.com/docs/en/monitoring-usage) |
-| `OTEL_METRICS_INCLUDE_ENTRYPOINT` | Set to `1` to include the session entry-point (e.g., interactive vs `-p` vs SDK) as a label on all OpenTelemetry metric data points. Useful for breaking down metrics by how Claude Code was invoked (v2.1.161 changelog) *(in v2.1.161 changelog, not yet on official env-vars page)* |
-| `CLAUDE_CODE_FORK_SUBAGENT` | Set to `1` to enable forked subagents on external builds (non-Anthropic-signed distributions). Forked subagents run in an isolated child process instead of sharing the main agent's context *(in v2.1.117 changelog, not yet on official env-vars page)* |
+| `OTEL_METRICS_INCLUDE_ENTRYPOINT` | Set to `1` to include the session entry-point (e.g., interactive vs `-p` vs SDK) as a label on all OpenTelemetry metric data points. Useful for breaking down metrics by how Claude Code was invoked (v2.1.161) |
+| `CLAUDE_CODE_FORK_SUBAGENT` | Set to `1` to enable forked subagents on external builds (non-Anthropic-signed distributions). Forked subagents run in an isolated child process instead of sharing the main agent's context |
 | `CLAUDE_CODE_MCP_SERVER_NAME` | Name of the MCP server, passed as an environment variable to `headersHelper` scripts so they can generate server-specific authentication headers *(in v2.1.85 changelog, not yet on official env-vars page)* |
 | `CLAUDE_CODE_MCP_SERVER_URL` | URL of the MCP server, passed as an environment variable to `headersHelper` scripts alongside `CLAUDE_CODE_MCP_SERVER_NAME` *(in v2.1.85 changelog, not yet on official env-vars page)* |
 | `ANTHROPIC_DEFAULT_OPUS_MODEL` | Override Opus model alias (e.g., `claude-opus-4-6[1m]`) |
@@ -1127,7 +1142,7 @@ Set environment variables for all Claude Code sessions.
 | `ANTHROPIC_DEFAULT_FABLE_MODEL_SUPPORTED_CAPABILITIES` | Override capability detection for a pinned Fable model. Comma-separated values (e.g., `effort,thinking`). Required when the pinned model supports features the auto-detection cannot confirm |
 | `MAX_THINKING_TOKENS` | Maximum extended thinking tokens per response. Set to `0` to disable extended thinking entirely on the Anthropic API (equivalent to `--thinking disabled`). Applies only when using a fixed thinking budget — on adaptive thinking models (Opus 4.7+), the effort level controls thinking depth instead |
 | `CLAUDE_CODE_AUTO_COMPACT_WINDOW` | Set the context capacity in tokens used for auto-compaction calculations. Defaults to the model's context window (200K standard, 1M for extended context models). Use a lower value (e.g., `500000`) on a 1M model to treat it as 500K for compaction. Capped at actual context window. `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` is applied as a percentage of this value. Setting this decouples the compaction threshold from the status line's `used_percentage` |
-| `DISABLE_AUTO_COMPACT` | Disable automatic context compaction (`1` to disable). Manual `/compact` still works *(not in official docs — unverified)* |
+| `DISABLE_AUTO_COMPACT` | Disable automatic context compaction (`1` to disable). Manual `/compact` still works |
 | `DISABLE_COMPACT` | Disable all compaction — both automatic and manual (`1` to disable) |
 | `CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION` | Enable prompt suggestions |
 | `CLAUDE_CODE_PLAN_MODE_REQUIRED` | Require plan mode for sessions |
@@ -1148,6 +1163,16 @@ Set environment variables for all Claude Code sessions.
 | `VERTEX_REGION_CLAUDE_4_0_OPUS` | Vertex AI region override for Claude 4.0 Opus |
 | `VERTEX_REGION_CLAUDE_4_0_SONNET` | Vertex AI region override for Claude 4.0 Sonnet |
 | `VERTEX_REGION_CLAUDE_4_1_OPUS` | Vertex AI region override for Claude 4.1 Opus |
+| `VERTEX_REGION_CLAUDE_4_5_OPUS` | Vertex AI region override for Claude 4.5 Opus |
+| `VERTEX_REGION_CLAUDE_4_5_SONNET` | Vertex AI region override for Claude 4.5 Sonnet |
+| `VERTEX_REGION_CLAUDE_4_6_OPUS` | Vertex AI region override for Claude Opus 4.6 |
+| `VERTEX_REGION_CLAUDE_4_6_SONNET` | Vertex AI region override for Claude Sonnet 4.6 |
+| `VERTEX_REGION_CLAUDE_4_7_OPUS` | Vertex AI region override for Claude Opus 4.7 |
+| `VERTEX_REGION_CLAUDE_4_8_OPUS` | Vertex AI region override for Claude Opus 4.8 |
+| `VERTEX_REGION_CLAUDE_5_OPUS` | Vertex AI region override for Claude Opus 5 (v2.1.219) |
+| `VERTEX_REGION_CLAUDE_5_SONNET` | Vertex AI region override for Claude Sonnet 5 |
+| `VERTEX_REGION_CLAUDE_FABLE_5` | Vertex AI region override for Claude Fable 5 |
+| `VERTEX_REGION_CLAUDE_HAIKU_4_5` | Vertex AI region override for Claude Haiku 4.5 |
 
 ---
 
@@ -1200,7 +1225,7 @@ Set environment variables for all Claude Code sessions.
   "plansDirectory": "./plans",
   "claudeMdExcludes": ["**/vendor/**/CLAUDE.md"],
   "effortLevel": "high",
-  "maxSkillDescriptionChars": 1536,
+  "skillListingMaxDescChars": 1536,
   "skillListingBudgetFraction": 0.01,
   "disableAgentView": false,
   "disableWorkflows": false,
@@ -1222,7 +1247,7 @@ Set environment variables for all Claude Code sessions.
   },
 
   "modelOverrides": {
-    "claude-opus-4-6": "arn:aws:bedrock:us-east-1:123456789:inference-profile/anthropic.claude-opus-4-6-v1:0"
+    "claude-opus-5": "arn:aws:bedrock:us-east-1:123456789:inference-profile/anthropic.claude-opus-5-v1:0"
   },
 
   "autoMode": {
@@ -1242,7 +1267,7 @@ Set environment variables for all Claude Code sessions.
       "Bash(npm run *)",
       "Bash(git *)",
       "WebFetch(domain:*)",
-      "mcp__*",
+      "mcp__github__*",
       "Agent(*)"
     ],
     "deny": [

--- a/changelog/best-practice/claude-settings/changelog.md
+++ b/changelog/best-practice/claude-settings/changelog.md
@@ -1171,3 +1171,49 @@
 | 17 | LOW | Missing Source | Add CLI Reference to Sources section — authoritative for `--permission-mode`, `--effort`, and `--advisor` values | ✅ COMPLETE (CLI reference added to Sources) — NEW |
 | 18 | LOW | Suspect Key Recurrence | `CLAUDE_CODE_RETRY_WATCHDOG` — still NOT on official /en/env-vars page; entry annotated "*(in v2.1.199 changelog, not on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-07-03 v2.1.199; 13 consecutive runs) |
 | 19 | LOW | Suspect Key Recurrence | `OTEL_LOG_TOOL_DETAILS` — still NOT on official /en/env-vars page after 58+ consecutive runs; entry annotated "*(in v2.1.85 changelog, not yet on official env-vars page)*" | ✋ ON HOLD (RECURRING from 2026-04-14 v2.1.107; 58+ consecutive runs) |
+
+---
+
+## [2026-07-29 11:03 AM PKT] Claude Code v2.1.220
+
+| # | Priority | Type | Action | Status |
+|---|----------|------|--------|--------|
+| 1 | HIGH | P0-Fix | Fixed `showThinkingSummaries` description: was "SDK callers always receive summaries regardless of this setting" — corrected to "This setting has no effect in non-interactive mode (`-p`), Agent SDK, or IDE extensions such as VS Code" | COMPLETE (description corrected to match official docs) |
+| 2 | HIGH | P0-Fix | Renamed `maxSkillDescriptionChars` → `skillListingMaxDescChars` throughout (General Settings table, Quick Reference example) — key was renamed in official docs | COMPLETE (renamed in table + QR example) |
+| 3 | HIGH | P0-Fix | Fixed `viewMode` description: changed "Ctrl+O selection" → "`/focus` selection" — `/focus` is the correct slash command per official docs | COMPLETE (description corrected) |
+| 4 | HIGH | P0-Fix | Fixed `Tool(param:value)` permission row: removed invalid `Bash(cmd:npm run *)` example; clarified pattern only applies to deny/ask rules; listed non-matchable fields | COMPLETE (example corrected, scope clarified) |
+| 5 | HIGH | P0-Fix | Fixed deny rule glob note: added `EndConversation` carve-out; added warning that unanchored allow globs are silently skipped (not errors) | COMPLETE (note updated with official behavior) |
+| 6 | HIGH | P0-Fix | Fixed `strictKnownMarketplaces`: type changed from `boolean` to array allowlist description per official docs | COMPLETE (type/description corrected) |
+| 7 | HIGH | P0-Fix | Fixed `effortLevel`: removed `"max"` and `"ultracode"` from valid settings.json values; added "not a valid `settings.json` value" notes to Ultracode/Max rows in Effort Level table — they are CLI/session-only | COMPLETE (clarified CLI-only scope for max/ultracode) |
+| 8 | HIGH | P0-Fix | Fixed permission example: `"mcp__*"` → `"mcp__github__*"` in both allow array and Quick Reference example — `mcp__*` by itself does not match tool names | COMPLETE (fixed in Permission Syntax section and QR example) |
+| 9 | HIGH | P0-Fix | Fixed `MCP_CONNECTION_NONBLOCKING` inverted semantics: as of v2.1.142 non-blocking is DEFAULT; set to `0` to restore blocking behavior | COMPLETE (semantics corrected) |
+| 10 | HIGH | Missing Setting | Added `verbose` (boolean, default false) to General Settings | COMPLETE (added to General Settings table) |
+| 11 | HIGH | Missing Setting | Added `processWrapper` (string/null) and `remote.defaultEnvironmentId` (string) to General Settings | COMPLETE (added to General Settings table) |
+| 12 | HIGH | Missing Setting | Added `theme` (string, default "dark") to Display Settings table | COMPLETE (added to Display Settings table) |
+| 13 | HIGH | Missing Setting | Added `diffTool` (string, default "auto") to Global Config (`~/.claude.json`) section | COMPLETE (added to Global Config section) |
+| 14 | HIGH | Missing Setting | Added `permissionExplainerEnabled` (boolean, default true) to Global Config section | COMPLETE (added to Global Config section) |
+| 15 | HIGH | Missing Setting | Added `statusLine.hideVimModeIndicator` field to Status Line Configuration table | COMPLETE (added to Status Line table) |
+| 16 | HIGH | Missing Setting | Added `sandbox.network.tlsTerminate` and `sandbox.credentials.allowPlaintextInject` to Sandbox Settings | COMPLETE (both added to Sandbox Settings table) |
+| 17 | HIGH | Missing Env Var | Added `CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH` (v2.1.217, default 3 as of v2.1.219) to env vars | COMPLETE (added to Environment Variables table) |
+| 18 | HIGH | Missing Env Var | Added `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS` (v2.1.217, default 20) to env vars | COMPLETE (added to Environment Variables table) |
+| 19 | HIGH | Missing Env Var | Added 10 new `VERTEX_REGION_*` entries for current model family (Claude 4.5–5, Fable 5, Haiku 4.5) | COMPLETE (all 10 added to VERTEX_REGION table) |
+| 20 | HIGH | Hooks Count | Updated hooks section from "26 hook events" to "30 hook events" — confirmed 30 events on official hooks page | COMPLETE (count updated in hooks redirect section) |
+| 21 | MED | Accuracy Fix | `workflowSizeGuideline`: added `"unrestricted"` to valid values; added note about hiding the /config row | COMPLETE (description updated) |
+| 22 | MED | Accuracy Fix | Fixed `/` prefix path resolution description: changed to "relative to the **settings source file**" per official docs | COMPLETE (path resolution corrected) |
+| 23 | MED | Accuracy Fix | Removed "deprecated" claim from `:*` suffix note; explained it's only recognized at end of tool name | COMPLETE (description corrected) |
+| 24 | MED | Accuracy Fix | Process wrapper strip list: added `command`, `builtin` (shell builtins), zsh's `noglob`; added warning about env runners (devbox/mise/npx/docker) | COMPLETE (strip list and warnings updated) |
+| 25 | MED | Accuracy Fix | `bypassPermissions`: expanded exceptions to include `ask` rules, connector tools, and `requiresUserInteraction` MCP tools; added v2.1.208 substitution forms note | COMPLETE (exceptions list updated) |
+| 26 | MED | Accuracy Fix | `dontAsk`: added exceptions note (mirrors bypassPermissions exceptions) | COMPLETE (exceptions note added) |
+| 27 | MED | Accuracy Fix | `permissions.defaultMode`: added "`auto` is ignored in project settings" restriction per official docs | COMPLETE (restriction note added) |
+| 28 | MED | Accuracy Fix | Added `Read` deny blocks `Edit` note (v2.1.208 behavior) | COMPLETE (note added) |
+| 29 | MED | Accuracy Fix | Added `dir/**` scoping fix note (v2.1.214) to path resolution section | COMPLETE (note added) |
+| 30 | MED | Accuracy Fix | `sandbox.filesystem.disabled`: added scope restriction note per official docs | COMPLETE (restriction noted) |
+| 31 | MED | Accuracy Fix | `sandbox.network.strictAllowlist`: added scope restriction, `WebFetch(domain:...)` allowlist inclusion, and in-process WebFetch caveat | COMPLETE (all three notes added) |
+| 32 | MED | Accuracy Fix | `sandbox.credentials`: added prerequisite note that `mask` mode requires `sandbox.network.tlsTerminate` | COMPLETE (prerequisite noted) |
+| 33 | MED | Accuracy Fix | `pluginConfigs`: fixed description from "MCP server configs" to "non-sensitive userConfig option values"; removed stale "not on official settings page" tag | COMPLETE (description and tag corrected) |
+| 34 | MED | Accuracy Fix | `footerLinksRegexes`: rewrote description (prior description was wrong about matching URLs) | COMPLETE (description rewritten) |
+| 35 | MED | Accuracy Fix | v2.1.119 migration note: added `theme` and `verbose` to list of migrated keys | COMPLETE (migration note updated) |
+| 36 | MED | Quick Reference | Updated `modelOverrides` in QR and Model Configuration examples from `claude-opus-4-6` → `claude-opus-5` | COMPLETE (examples updated to current model) |
+| 37 | LOW | Stale Annotation | Stripped "not in official docs" stale tags from 21 env vars that are now confirmed on official /en/env-vars page | COMPLETE (tags removed from: CLAUDE_CODE_SESSION_ID, AI_AGENT, DISABLE_UPDATES, CLAUDE_CODE_DISABLE_BG_SHELL_PRESSURE_REAP, ENABLE_PROMPT_CACHING_1H, FORCE_PROMPT_CACHING_5M, CLAUDE_EFFORT, CLAUDE_CODE_FORWARD_SUBAGENT_TEXT, CLAUDE_CODE_PROCESS_WRAPPER, CLAUDE_CODE_RETRY_WATCHDOG, CLAUDE_CODE_MCP_AUTO_BACKGROUND_MS, CLAUDE_CODE_DISABLE_MOUSE_CLICKS, OTEL_LOG_TOOL_DETAILS, CLAUDE_CODE_OTEL_CONTENT_MAX_LENGTH, OTEL_LOG_RAW_API_BODIES, OTEL_LOG_USER_PROMPTS, OTEL_LOG_ASSISTANT_RESPONSES, OTEL_METRICS_INCLUDE_ENTRYPOINT, CLAUDE_CODE_FORK_SUBAGENT, DISABLE_AUTO_COMPACT, CLAUDE_CODE_MAX_TURNS, CLAUDE_CODE_MAX_WEB_SEARCHES_PER_SESSION, CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION) |
+| 38 | LOW | Resolved ON HOLD | `CLAUDE_CODE_RETRY_WATCHDOG` (14 consecutive runs ON HOLD): stale "not on official env-vars page" tag removed — now confirmed on official page | COMPLETE (tag removed; ON HOLD resolved after 14 runs) |
+| 39 | LOW | Resolved ON HOLD | `OTEL_LOG_TOOL_DETAILS` (59+ consecutive runs ON HOLD): stale "not yet on official env-vars page" tag removed — now confirmed on official page | COMPLETE (tag removed; ON HOLD resolved after 59+ runs) |


### PR DESCRIPTION
## Summary

Automated daily drift check for `best-practice/claude-settings.md` against official Claude Code v2.1.220 documentation. Applied **39 action items** across 3 priority tiers.

---

## P0 — Factually Wrong (9 fixes)

| # | Setting/Key | Fix |
|---|-------------|-----|
| 1 | `showThinkingSummaries` | Corrected SDK/non-interactive behavior — was documented backwards; setting has **no effect** in `-p` mode, Agent SDK, or IDE extensions |
| 2 | `skillListingMaxDescChars` | Renamed from `maxSkillDescriptionChars` — key was renamed in official docs |
| 3 | `viewMode` | Changed "Ctrl+O selection" → "`/focus` selection" |
| 4 | `Tool(param:value)` permission | Removed invalid `Bash(cmd:npm run *)` example; clarified deny/ask-only scope; listed non-matchable fields |
| 5 | Deny-rule glob note | Added `EndConversation` carve-out; added warning that unanchored allow globs are silently skipped |
| 6 | `strictKnownMarketplaces` | Type changed from `boolean` to array allowlist description |
| 7 | `effortLevel` | Removed `"max"` and `"ultracode"` from valid `settings.json` values — they are CLI/session-only |
| 8 | Permission example | `"mcp__*"` → `"mcp__github__*"` in both allow array and Quick Reference |
| 9 | `MCP_CONNECTION_NONBLOCKING` | Fixed inverted semantics — non-blocking is the DEFAULT as of v2.1.142; set to `0` to restore blocking |

## P1 — Missing Keys / Counts (11 fixes)

| # | Key / Item | Fix |
|---|-----------|-----|
| 10 | `verbose` | Added to General Settings (boolean, default false) |
| 11 | `processWrapper`, `remote.defaultEnvironmentId` | Added to General Settings |
| 12 | `theme` | Added to Display Settings (string, default "dark") |
| 13 | `diffTool` | Added to Global Config `~/.claude.json` section |
| 14 | `permissionExplainerEnabled` | Added to Global Config section |
| 15 | `statusLine.hideVimModeIndicator` | Added to Status Line Configuration table |
| 16 | `sandbox.network.tlsTerminate`, `sandbox.credentials.allowPlaintextInject` | Added to Sandbox Settings |
| 17 | `CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH` | Added to env vars (v2.1.217, default 3 as of v2.1.219) |
| 18 | `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS` | Added to env vars (v2.1.217, default 20) |
| 19 | 10× `VERTEX_REGION_*` entries | Added for Claude 4.5–5 / Fable 5 / Haiku 4.5 model family |
| 20 | Hooks redirect count | Updated from "26" → "30" hook events |

## P2 — Accuracy & Stale Annotations (18 fixes)

- `workflowSizeGuideline`: added `"unrestricted"` value; added `/config` row note
- `/` prefix path resolution: corrected to "relative to the **settings source file**"
- `:*` suffix note: removed incorrect "deprecated" claim
- Process wrapper strip list: added `command`, `builtin`, `noglob`; added env-runner warning (devbox/mise/npx/docker)
- `bypassPermissions`: expanded exceptions to include `ask` rules, connector tools, `requiresUserInteraction` MCP tools, v2.1.208 substitution forms
- `dontAsk`: added exceptions note
- `permissions.defaultMode`: added "`auto` is ignored in project settings" restriction
- Added `Read` deny blocks `Edit` note (v2.1.208)
- Added `dir/**` scoping fix note (v2.1.214)
- `sandbox.filesystem.disabled` / `sandbox.network.strictAllowlist` / `sandbox.credentials`: added scope restrictions and prerequisite notes
- `pluginConfigs`: fixed description (was "MCP server configs" → "non-sensitive userConfig option values")
- `footerLinksRegexes`: rewrote description (prior description was wrong)
- v2.1.119 migration note: added `theme` and `verbose`
- `modelOverrides` examples: updated to `claude-opus-5`
- Effort Level table: added "not a valid `settings.json` value" notes to Ultracode/Max rows
- Stripped 21 stale "not in official docs" annotations from env vars now confirmed on official page
- Resolved `CLAUDE_CODE_RETRY_WATCHDOG` ON HOLD (14 runs) and `OTEL_LOG_TOOL_DETAILS` ON HOLD (59+ runs)

---

## Verification Log Summary

All 25 checklist rules executed (1A–1I, 2A–2D, 3A–3D, 4A, 5A–5D, 6A–6B, 7A, 8A, 9A–9C, 10A–10C).

## Hyperlink Validation

- 21 `code.claude.com` URLs: ✅ all 200 OK
- 2 local file links (`settings.json`, `claude-cli-startup-flags.md`): ✅ both exist
- 13 anchor links: ✅ all headings verified
- `json.schemastore.org` schema URL: ✅ 301→200 (valid redirect)
- GitHub/IETF: 403 from sandbox proxy — not broken links

---
_Generated by [Claude Code](https://claude.ai/code/session_01QuTykYe3YzHfM474HWe7CV)_