### PR TITLE
Daily settings drift check — 2026-08-15 (Claude Code v2.1.233)

### DIFF
--- a/best-practice/claude-settings.md
+++ b/best-practice/claude-settings.md
@@ -1,9 +1,9 @@
 # Settings Best Practice
 
-![Last Updated](https://img.shields.io/badge/Last_Updated-Aug%2007%2C%202026%2010%3A48%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.224-blue?style=flat&labelColor=555)<br>
+![Last Updated](https://img.shields.io/badge/Last_Updated-Aug%2015%2C%202026%2010%3A44%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.233-blue?style=flat&labelColor=555)<br>
 [![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../.claude/settings.json)
 
-A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.224, Claude Code exposes **127+ settings** and **311 environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
+A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.233, Claude Code exposes **133+ settings** and **338+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
 
 <table width="100%">
 <tr>
@@ -82,7 +82,7 @@ Within the managed tier, precedence is: server-managed > MDM/OS-level policies >
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `$schema` | string | - | JSON Schema URL for IDE validation and autocompletion (e.g., `"https://json.schemastore.org/claude-code-settings.json"`) |
-| `model` | string | `"default"` | Override default model. Accepts aliases (`sonnet`, `opus`, `haiku`) or full model IDs |
+| `model` | string | `"default"` | Override default model. Accepts aliases (`sonnet`, `opus`, `haiku`) or full model IDs. Read once at startup; use `/model` to change the active model mid-session |
 | `agent` | string | - | Set the default agent for the main conversation. Value is the agent name from `.claude/agents/`. Also available via `--agent` CLI flag |
 | `language` | string | `"english"` | Claude's preferred response language. Also sets the voice dictation language and **auto-generated session titles** (v2.1.121; since v2.1.176, an unset language causes titles to match the conversation language) |
 | `claudeMdExcludes` | array | - | Glob patterns or absolute paths of `CLAUDE.md` files to skip when loading [memory](https://code.claude.com/docs/en/memory). Patterns match against absolute file paths. Only applies to user, project, and local memory; managed policy files cannot be excluded. Example: `["**/vendor/**/CLAUDE.md"]` |
@@ -137,6 +137,8 @@ Within the managed tier, precedence is: server-managed > MDM/OS-level policies >
 | `switchModelsOnFlag` | boolean | `true` | Automatically switch to the fallback model when a safety classifier flags a request. When `false`, flagged requests are blocked rather than rerouted (v2.1.170) |
 | `processWrapper` | string | - | Corporate launcher command used for background processes (e.g., a credential-injecting wrapper). Only honored from managed settings, user settings (`~/.claude/settings.json`), or `--settings`; ignored from project and local settings to prevent untrusted repos from hijacking background process launches (v2.1.210) |
 | `remote.defaultEnvironmentId` | string | - | Default environment ID to use when launching remote sessions or background agents via `--remote` without an explicit environment ID. When set, Claude Code selects this environment automatically rather than prompting. Only honored from user and managed settings (v2.1.200+) |
+| `dialogExpiry` | string | `"5m"` | Deadline for dialogs forwarded to remote clients ([Remote Control](https://code.claude.com/docs/en/remote-control), SDK host) and held cross-session messages before they are discarded. Values: `"60s"`, `"5m"`, `"10m"`, `"never"`. Set via `/config` as **Dialog expiry**. **Only honored from user settings, managed settings, or `--settings`** — project/local values are ignored (v2.1.224) |
+| `crossSessionInbound` | string | - | How the session treats inbound cross-session messages: `"accept"` (process immediately), `"hold"` (queue until resumed), or `"refuse"` (reject without queuing). Resolution order: managed > `--settings` > user; project/local settings apply **only if stricter** than the effective value from higher scopes. Set via `/config` as **Messages from your other sessions** (v2.1.224) |
 
 **Example:**
 ```json
@@ -382,7 +384,7 @@ Control what tools and operations Claude can perform.
 
 Hook configuration (events, properties, matchers, exit codes, environment variables, and HTTP hooks) is maintained in a dedicated repository:
 
-> **[claude-code-hooks](https://github.com/shanraisshan/claude-code-hooks)** — Complete hook reference with sound notification system, all 26 hook events, HTTP hooks, matcher patterns, exit codes, and environment variables.
+> **[claude-code-hooks](https://github.com/shanraisshan/claude-code-hooks)** — Complete hook reference with sound notification system, all 30 hook events, HTTP hooks, matcher patterns, exit codes, and environment variables.
 
 Hook-related settings keys (`hooks`, `disableAllHooks` (also disables any custom status line), `allowManagedHooksOnly`, `allowedHttpHookUrls`, `httpHookAllowedEnvVars`) are documented there.
 
@@ -497,6 +499,7 @@ Configure bash command sandboxing for security.
 | `sandbox.enableWeakerNetworkIsolation` | boolean | `false` | (macOS only) Allow access to system TLS trust (`com.apple.trustd.agent`); reduces security |
 | `sandbox.bwrapPath` | string | - | **(Managed only, Linux/WSL2)** Absolute path to the bubblewrap (`bwrap`) binary. Overrides automatic `PATH` detection. Only honored from managed settings, not user or project settings. Example: `/opt/admin/bwrap` (v2.1.133) |
 | `sandbox.socatPath` | string | - | **(Managed only, Linux/WSL2)** Absolute path to the `socat` binary used for the sandbox network proxy. Overrides automatic `PATH` detection. Only honored from managed settings. Example: `/opt/admin/socat` (v2.1.133) |
+| `sandbox.ripgrep` | object | - | Ripgrep configuration for the sandbox environment. **Only honored from user settings, managed settings, or `--settings`** as of v2.1.232 — project/local settings values are ignored (v2.1.232) |
 | `sandbox.allowAppleEvents` | boolean | `false` | **(macOS only)** Opt-in for sandboxed commands to send Apple Events. Required for tools that use `open`, `osascript`, or browser authentication flows that depend on Apple Events IPC. **Warning:** Enabling this removes code-execution isolation — Apple Events can be used to execute code in other applications (v2.1.181) |
 | `sandbox.credentials` | object | — | Fine-grained control over which credential files and environment variables are blocked from sandboxed subprocess environments. Object with two arrays: `files` (array of credential file entries — see sub-keys below) and `envVars` (array of `{name: string, mode: string, injectHosts?: string[]}` entries — `mode` is `"deny"` (default, strips the var) or `"mask"` (substitutes a placeholder, only honored from user settings/managed/`--settings`; `deny` takes precedence when same var appears with both modes) with `injectHosts` selectively exposing the value to listed hosts only). An individual invalid entry is stripped with a warning; the valid subset is enforced. (v2.1.187; per-entry object shape since v2.1.191; per-entry `mode` and `injectHosts` since v2.1.199) |
 | `sandbox.credentials.files[].path` | string | — | Absolute or `~/`-prefixed path to the credential file to protect |
@@ -542,11 +545,14 @@ Configure Claude Code plugins and marketplaces.
 | `skippedMarketplaces` | array | Any | Marketplaces user declined to install *(in JSON schema, not on official settings page)* |
 | `skippedPlugins` | array | Any | Plugins user declined to install *(in JSON schema, not on official settings page)* |
 | `pluginConfigs` | object | Managed / User / --settings | Per-plugin MCP server configs (keyed by `plugin@marketplace`). As of v2.1.207, no longer read from project-level `.claude/settings.json` or `.claude/settings.local.json`; only user, `--settings`, and managed settings are honored |
-| `blockedMarketplaces` | array | Managed only | Block specific plugin marketplaces. Each entry can match by source string, `hostPattern`, or `pathPattern` — as of v2.1.119 the `hostPattern` and `pathPattern` matchers are correctly enforced before any download touches the filesystem, so blocked marketplaces never reach disk |
+| `blockedMarketplaces` | array | Managed only | Block specific plugin marketplaces. Each entry can match by source string, `hostPattern`, `pathPattern`, or bare repo URL (e.g., `"github.com/org/repo"`) — as of v2.1.119 the `hostPattern` and `pathPattern` matchers are correctly enforced before any download touches the filesystem, so blocked marketplaces never reach disk. As of v2.1.232, URL-typed entries and bare repo URLs continue to block git URLs from matching repositories (v2.1.232) |
 | `pluginTrustMessage` | string | Managed only | Custom message displayed when prompting users to trust plugins |
 | `disableSideloadFlags` | boolean | Managed only | Reject the `--plugin-dir`, `--plugin-url`, `--agents`, and `--mcp-config` startup flags. When `true`, users cannot bypass `strictKnownMarketplaces` by passing sideload flags at launch. Use in managed environments to enforce marketplace-only plugin distribution (v2.1.193) |
+| `disableCommandPluginSources` | boolean | Managed only | When `true`, blocks the `command` plugin source entirely; `false` explicitly allows it. When unset, follows `allowManagedHooksOnly`. Applies a degraded (not stripped) behavior on invalid values — the invalid entry is dropped and enforcement continues with remaining sources (v2.1.229) |
+| `additionalMarketplaces` | array | Managed only | Alias for `extraKnownMarketplaces`. Accepts the same array-of-marketplace-objects shape. Intended for use in managed policy files where array-union semantics apply across admin sources (v2.1.232) |
+| `allowedMarketplaces` | array | Managed only | Alias for `strictKnownMarketplaces`. When set to an array, restricts allowed marketplaces to the listed names. Prefer over `strictKnownMarketplaces` in admin policy files for clarity (v2.1.232) |
 
-**Marketplace source types:** `github`, `git`, `directory`, `settings`, `url`, `npm`, `file`, `archive`. Use `source: 'settings'` to declare a small set of plugins inline without setting up a hosted marketplace repository. Use `source: 'archive'` for zip-based plugin installation with SHA-256 pinning (v2.1.224). Note: `hostPattern` is a *matcher* field for `blockedMarketplaces`, not a source type.
+**Marketplace source types:** `github`, `git`, `directory`, `settings`, `url`, `npm`, `file`, `archive`, `command`. Use `source: 'settings'` to declare a small set of plugins inline without setting up a hosted marketplace repository. Use `source: 'archive'` for zip-based plugin installation with SHA-256 pinning (v2.1.224). Use `source: 'command'` for dynamically-generated plugin manifests that are re-resolved per session; supports `mode: "link"` (v2.1.229). GitLab repositories are supported as a marketplace source as of v2.1.232. Note: `hostPattern` is a *matcher* field for `blockedMarketplaces`, not a source type.
 
 **Owner wildcard entries (v2.1.223):** `strictKnownMarketplaces` and `blockedMarketplaces` now accept `"owner/*"` wildcard entries to match all repositories from a specific organization or user.
 
@@ -955,9 +961,11 @@ Set environment variables for all Claude Code sessions.
 | `MAX_MCP_OUTPUT_TOKENS` | Max MCP output tokens (default: 25000). Warning displayed when output exceeds 10,000 tokens |
 | `API_TIMEOUT_MS` | Timeout in ms for API requests (default: 600000) |
 | `API_FORCE_IDLE_TIMEOUT` | Override the 5-minute idle timeout for streaming connections. Set to `0` to disable the idle timeout entirely, `1` to enforce it on all connections, or leave unset for the default (auto-enabled on slow or unreliable gateways that frequently stall). Useful for slow API gateways (v2.1.169) |
+| `CLAUDE_CODE_WEBFETCH_CACHE_TTL_MS` | WebFetch response cache TTL in milliseconds. Default: `900000` (15 minutes). Set to `0` to disable caching. Reduce for frequently-updated pages; increase for static documentation to reduce network requests (v2.1.233) |
 | `CLAUDE_CODE_CONNECT_TIMEOUT_MS` | **REMOVED in v2.1.186.** This variable is a no-op. Use `API_TIMEOUT_MS` instead. Previously controlled the connect, TLS, and response-header phase timeout for streaming API requests |
 | `CLAUDE_AFK_TIMEOUT_MS` | How many milliseconds before an unanswered AskUserQuestion dialog auto-continues, when `askUserQuestionTimeout` is set to a duration. As of v2.1.200, the default is `"never"` (no auto-continue) controlled by `askUserQuestionTimeout`; this env var applies only when a timeout duration is active. Setting to `0` closes the dialog immediately. To keep questions open, prefer `askUserQuestionTimeout: "never"` (v2.1.198; default changed v2.1.200) |
 | `CLAUDE_AFK_COUNTDOWN_MS` | How many milliseconds before auto-continue the on-screen countdown appears on an unanswered AskUserQuestion dialog (default: `20000` / 20 seconds) (v2.1.198) |
+| `CLAUDE_CODE_USER_DIALOG_TIMEOUT_MS` | Override the `dialogExpiry` setting in milliseconds for the current process. Controls how long forwarded Remote Control dialogs and held cross-session messages wait before being discarded. Takes precedence over the `dialogExpiry` settings key (v2.1.224) |
 | `BASH_MAX_TIMEOUT_MS` | Bash command timeout |
 | `BASH_MAX_OUTPUT_LENGTH` | Max bash output length |
 | `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` | Auto-compact threshold percentage (1-100). Default is ~95%. Set lower (e.g., `50`) to trigger compaction earlier. Values above 95% have no effect. Use `/context` to monitor current usage. Example: `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=50 claude` |
@@ -991,6 +999,7 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_GLOB_NO_IGNORE` | Set to `false` to make the Glob tool respect `.gitignore` patterns. By default, Glob returns all matching files including gitignored ones. Does not affect `@` file autocomplete, which has its own `respectGitignore` setting |
 | `CLAUDE_CODE_GLOB_TIMEOUT_SECONDS` | Timeout in seconds for Glob file discovery |
 | `CLAUDE_CODE_ENABLE_TASKS` | Controls whether sessions use the structured Task tools (`TaskCreate`, `TaskUpdate`, `TaskGet`, `TaskList`) or the legacy `TodoWrite` tool. As of v2.1.142, Task tools are the default in all modes. Set to `0` to revert to `TodoWrite` |
+| `CLAUDE_CODE_ENABLE_TODO_TOOLS` | Set to `1` to restore the legacy todo/task tracking tools (`TaskCreate`, `TodoWrite`, etc.) on newer models where they were removed (Opus 4.8, Sonnet 5, Fable 5, Mythos 5+). Newer models handle task tracking via the system prompt rather than dedicated tools; this flag re-enables the old toolset if your workflows depend on it (v2.1.233) |
 | `CLAUDE_CODE_SIMPLE` | Set to `1` to run with a minimal system prompt and only the Bash, file read, and file edit tools. Also configurable as a startup-only var — see [CLI Startup Flags](./claude-cli-startup-flags.md#environment-variables) |
 | `CLAUDE_CODE_EXIT_AFTER_STOP_DELAY` | Auto-exit SDK mode after idle duration (ms) |
 | `CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING` | Disable adaptive thinking (`1` to disable) |
@@ -1153,7 +1162,7 @@ Set environment variables for all Claude Code sessions.
 | `OTEL_METRICS_INCLUDE_VERSION` | Set to `1` to include the Claude Code version as a label on all OpenTelemetry metric data points |
 | `OTEL_METRICS_INCLUDE_RESOURCE_ATTRIBUTES` | Set to `1` to promote `OTEL_RESOURCE_ATTRIBUTES` key/value pairs onto every metric data point as dimensions |
 | `CLAUDE_CODE_OTEL_DIAG_STDERR` | Set to `1` to emit OpenTelemetry SDK diagnostic output to stderr. Use to troubleshoot collector connectivity or exporter configuration issues |
-| `CLAUDE_CODE_FORK_SUBAGENT` | Set to `1` to enable forked subagents on external builds (non-Anthropic-signed distributions). Forked subagents run in an isolated child process instead of sharing the main agent's context *(in v2.1.117 changelog, not yet on official env-vars page)* |
+| `CLAUDE_CODE_FORK_SUBAGENT` | Subagent forking is **on by default** as of v2.1.232. Set to `0` to disable forked subagents. Forked subagents run in an isolated child process instead of sharing the main agent's context; previously required explicit opt-in via `1` on external builds *(in v2.1.117 changelog, default changed v2.1.232; not yet on official env-vars page)* |
 | `CLAUDE_CODE_MCP_SERVER_NAME` | Name of the MCP server, passed as an environment variable to `headersHelper` scripts so they can generate server-specific authentication headers *(in v2.1.85 changelog, not yet on official env-vars page)* |
 | `CLAUDE_CODE_MCP_SERVER_URL` | URL of the MCP server, passed as an environment variable to `headersHelper` scripts alongside `CLAUDE_CODE_MCP_SERVER_NAME` *(in v2.1.85 changelog, not yet on official env-vars page)* |
 | `ANTHROPIC_DEFAULT_OPUS_MODEL` | Override Opus model alias (e.g., `claude-opus-4-6[1m]`) |

--- a/changelog/best-practice/claude-settings/changelog.md
+++ b/changelog/best-practice/claude-settings/changelog.md
@@ -1262,3 +1262,24 @@
 | 20 | LOW | New Env Var | Add `ANTHROPIC_BEDROCK_REGION_PREFIX` (v2.1.224 changelog — cross-region inference prefix). Not yet on official env-vars page; annotated as changelog-only | COMPLETE (annotated as changelog-only) — NEW |
 | 21 | LOW | New Settings | `crossSessionInbound` and `dialogExpiry` noted in v2.1.224 changelog. Not yet on official settings page — confidence 0.75 | ON HOLD (not yet on official docs — awaiting docs page update) — NEW |
 | 22 | LOW | Unverified Keys | v2.1.224 JWT masking options (`decode`, `maskClaims`, `awsPairs`/`sigv4`) for `sandbox.credentials.files[]` — not yet on official settings page, changelog-only, confidence 0.70 | ON HOLD (not yet on official docs — awaiting docs page update) — NEW |
+
+---
+
+## [2026-08-15 10:49 AM PKT] Claude Code v2.1.233
+
+| # | Priority | Type | Action | Status |
+|---|----------|------|--------|--------|
+| 1 | HIGH | Version Metadata | Update version badge v2.1.224 → v2.1.233; update header counts "127+ settings / 311 env vars" → "133+ settings / 338+ env vars". Confirmed via official settings docs | ✅ COMPLETE (badge and header updated) — NEW |
+| 2 | HIGH | Resolved ON HOLD | Add `dialogExpiry` (string, `"5m"`, user/managed/`--settings` only) and `crossSessionInbound` (string, unset) to General Settings — both confirmed on official settings page. Was ON HOLD item #21 from 2026-08-07 awaiting docs page update | ✅ COMPLETE (both added to General Settings table) — RESOLVED (ON HOLD since 2026-08-07; 1 run) |
+| 3 | HIGH | New Setting | Add `disableCommandPluginSources` (boolean, Managed only) to Plugin Settings. Blocks the `command` plugin source; follows `allowManagedHooksOnly` when unset. Confirmed on official settings page (v2.1.229) | ✅ COMPLETE (added to Plugin Settings table) — NEW |
+| 4 | HIGH | New Settings | Add `additionalMarketplaces` (array, alias for `extraKnownMarketplaces`) and `allowedMarketplaces` (array, alias for `strictKnownMarketplaces`) to Plugin Settings. Both v2.1.232, both Managed only. Confirmed on official settings page | ✅ COMPLETE (both added to Plugin Settings table) — NEW |
+| 5 | HIGH | New Setting | Add `sandbox.ripgrep` (object) to Sandbox Settings with scope restriction: only honored from user/managed/`--settings` as of v2.1.232. Confirmed in v2.1.232 changelog | ✅ COMPLETE (added to Sandbox Settings table) — NEW |
+| 6 | HIGH | New Env Var | Add `CLAUDE_CODE_WEBFETCH_CACHE_TTL_MS` (WebFetch response cache TTL, default 15 min). Confirmed on official env-vars page (v2.1.233) | ✅ COMPLETE (added to env vars table) — NEW |
+| 7 | HIGH | New Env Var | Add `CLAUDE_CODE_ENABLE_TODO_TOOLS` (set to `1` to restore todo/task tools on Opus 4.8/Sonnet 5/Fable 5/Mythos 5+ where they were removed). Confirmed on official env-vars page (v2.1.233) | ✅ COMPLETE (added to env vars table) — NEW |
+| 8 | MED | New Env Var | Add `CLAUDE_CODE_USER_DIALOG_TIMEOUT_MS` (overrides `dialogExpiry` in ms for the current process). Confirmed on official settings env table (v2.1.224) | ✅ COMPLETE (added to env vars table) — NEW |
+| 9 | MED | New Source Type | Add `command` marketplace source type (v2.1.229) and GitLab marketplace support (v2.1.232) to Plugin source types note. Confirmed in changelog | ✅ COMPLETE (source types note updated) — NEW |
+| 10 | MED | Changed Behavior | Update `blockedMarketplaces`: add bare repo URL entries and URL-typed entry behavior (v2.1.232). Confirmed in changelog | ✅ COMPLETE (description updated) — NEW |
+| 11 | MED | Changed Behavior | Update `CLAUDE_CODE_FORK_SUBAGENT`: subagent forking is on by default as of v2.1.232; description updated to reflect on-by-default and opt-out with `0`. Confirmed in v2.1.232 changelog | ✅ COMPLETE (description updated) — NEW |
+| 12 | MED | Hooks Count | Update hooks redirect: "all 26 hook events" → "all 30 hook events". Hooks repo badge shows 30 official events (latest: `MessageDisplay`, `DirectoryAdded`). Confirmed via hooks repo | ✅ COMPLETE (count updated) — NEW |
+| 13 | MED | Changed Description | Add read-once startup note to `model` setting: "Read once at startup; use `/model` to change the active model mid-session." Confirmed on official settings page | ✅ COMPLETE (note added) — NEW |
+| 14 | LOW | Unverified Keys | v2.1.224 JWT masking options (`decode`, `awsPairs`, `sigv4`) for `sandbox.credentials.files[]` — neither agent explicitly confirmed these on the official settings page (one agent cites changelog only, confidence 0.90 but no docs page URL). Carrying forward from 2026-08-07 item #22 | ✋ ON HOLD (not confirmed on official settings page — awaiting docs page update; 2 consecutive runs) — RECURRING (first seen 2026-08-07) |


### PR DESCRIPTION
## Summary

Automated daily drift check covering **Claude Code v2.1.224 → v2.1.233** (9 versions). Two parallel research agents cross-referenced the official settings docs, CLI reference, and CHANGELOG against `best-practice/claude-settings.md`. All 25+ verification checklist rules executed.

### Resolved from Previous Run

| Item | Resolution |
|------|-----------|
| `dialogExpiry` + `crossSessionInbound` (ON HOLD since 2026-08-07) | Both now confirmed on official settings page → added to General Settings |

---

## Changes Applied

### New Settings Keys (6)

| Key | Section | Type / Default | Version |
|-----|---------|---------------|---------|
| `dialogExpiry` | General Settings | string, `"5m"` | v2.1.224 |
| `crossSessionInbound` | General Settings | string, unset | v2.1.224 |
| `disableCommandPluginSources` | Plugin Settings | boolean, Managed only | v2.1.229 |
| `additionalMarketplaces` | Plugin Settings | array, Managed only | v2.1.232 |
| `allowedMarketplaces` | Plugin Settings | array, Managed only | v2.1.232 |
| `sandbox.ripgrep` | Sandbox Settings | object, user/managed/`--settings` only | v2.1.232 |

### New Environment Variables (3)

| Variable | Description | Version |
|----------|-------------|---------|
| `CLAUDE_CODE_WEBFETCH_CACHE_TTL_MS` | WebFetch response cache TTL (default 15 min) | v2.1.233 |
| `CLAUDE_CODE_ENABLE_TODO_TOOLS` | Restore todo/task tools on Opus 4.8/Sonnet 5/Fable 5/Mythos 5+ | v2.1.233 |
| `CLAUDE_CODE_USER_DIALOG_TIMEOUT_MS` | Override `dialogExpiry` in ms for current process | v2.1.224 |

### Updated Descriptions

- **`model`**: Added "Read once at startup; use `/model` to change mid-session"
- **`blockedMarketplaces`**: Added bare repo URL entry support (v2.1.232)
- **`CLAUDE_CODE_FORK_SUBAGENT`**: Forking is now **on by default** since v2.1.232; set `0` to disable
- **Plugin source types note**: Added `command` source type (v2.1.229) and GitLab marketplace support (v2.1.232)
- **Hooks redirect**: Updated event count from 26 → 30

### Metadata

- Badge: v2.1.224 → v2.1.233, date Aug 15, 2026
- Header counts: 127+ settings / 311 env vars → **133+ settings / 338+ env vars**

---

## Verification Log (all 25+ checklist rules)

| Rule | Category | Depth | Result | Notes |
|------|----------|-------|--------|-------|
| 1A | Key Completeness | field-level | PASS | All official settings keys now present after additions |
| 1B | Key Types | content-match | PASS | All types match official docs |
| 1C | Key Defaults | content-match | PASS | Defaults verified |
| 1D | Key Descriptions | content-match | PASS | Descriptions accurate |
| 1E | Scope Column | content-match | PASS | Plugin/managed scopes verified |
| 1F | Inverse Completeness | field-level | PASS | All report keys traceable to official docs or annotated unverified |
| 1G | Edge-Case Semantics | content-match | PASS | `dialogExpiry` values documented; `cleanupPeriodDays` zero-value note intact |
| 1H | File Scope Check | content-match | PASS | No settings.json keys in wrong scope |
| 1I | Skills Settings Keys | field-level | PASS | `skillListingMaxDescChars`, `skillListingBudgetFraction`, `skillOverrides`, `disableSkillShellExecution` all present |
| 2A | Priority Levels | field-level | PASS | 5-level chain + managed policy correct |
| 2B | File Locations | content-match | PASS | All paths correct |
| 2C | Merge Semantics | content-match | PASS | "concatenated and deduplicated" wording present; admin-union exceptions documented |
| 2D | Managed Internals | field-level | PASS | Delivery methods, precedence, deprecation notes all present |
| 3A | Permission Modes | field-level | PASS | All 7 modes including `manual` alias present |
| 3B | Tool Syntax Patterns | content-match | PASS | All patterns correct |
| 3C | Bidirectional Mode Check | field-level | PASS | No orphaned modes in report |
| 3D | Evaluation Semantics | content-match | PASS | Deny-first, path-prefix patterns documented |
| 4A | Hooks Redirect | exists | PASS | Redirect link valid; count updated 26→30 |
| 5A | Env Var Completeness | field-level | PASS | 3 new vars added; all official vars now present |
| 5B | Ownership Boundary | cross-file | PASS | No violations; dual-listed vars have cross-references in both directions |
| 5C | Env Var Descriptions | content-match | PASS | All descriptions match official env-vars page |
| 5D | Inverse Env Var Check | field-level | PASS | All report vars traceable to official docs or annotated |
| 6A | Quick Reference Example | content-match | PASS | Example syntax valid; no stale keys |
| 6B | Example URL Validation | exists | PASS | `json.schemastore.org/claude-code-settings.json` returns 200 |
| 7A | CLAUDE.md Sync | cross-file | PASS | CLAUDE.md hierarchy matches report; no drift |
| 8A | Source Credibility Guard | content-match | PASS | All changes sourced from official settings/env-vars/CLI docs or confirmed v2.1.232–233 changelog |
| 9A | Local File Links | exists | PASS | `../.claude/settings.json` exists |
| 9B | External URL Links | exists | PASS | All 10+ external URLs return 200 (confirmed by workflow agent) |
| 9C | Anchor Links | exists | PASS | No broken anchors in `claude-settings.md` |
| 10A | Version Metadata | content-match | PASS | Badge v2.1.233, counts 133+/338+ match actual table rows |
| 10B | Suspect Key Escalation | exists | PASS | decode/awsPairs/sigv4 at 2 consecutive runs (below 5-run escalation threshold) |
| 10C | Bidirectional Completeness | field-level | PASS | All report keys traceable; no orphaned entries |

---

## ON HOLD

| Item | Reason | Runs |
|------|--------|------|
| `sandbox.credentials.files[]` JWT sub-keys (`decode`, `awsPairs`, `sigv4`) | Changelog-only — neither agent confirmed on official settings docs page; confidence 0.90 but no docs page URL. Will escalate at 5 runs (3 remaining). | 2 |

## Out-of-Scope Note

`claude-cli-startup-flags.md:211` has a broken anchor `#environment-variables` (should be `#environment-variables-via-env`). Noted for a follow-up fix outside this workflow.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZDHug6yCuSnn72c5LxNwh)_