### PR TITLE
Daily settings drift check — 2026-08-18 (Claude Code v2.1.234)

### DIFF
--- a/best-practice/claude-settings.md
+++ b/best-practice/claude-settings.md
@@ -1,9 +1,9 @@
 # Settings Best Practice
 
-![Last Updated](https://img.shields.io/badge/Last_Updated-Aug%2007%2C%202026%2010%3A48%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.224-blue?style=flat&labelColor=555)<br>
+![Last Updated](https://img.shields.io/badge/Last_Updated-Aug%2018%2C%202026%2010%3A46%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.234-blue?style=flat&labelColor=555)<br>
 [![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../.claude/settings.json)
 
-A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.224, Claude Code exposes **127+ settings** and **311 environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
+A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.234, Claude Code exposes **130+ settings** and **335 environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
 
 <table width="100%">
 <tr>
@@ -129,14 +129,16 @@ Within the managed tier, precedence is: server-managed > MDM/OS-level policies >
 | `disableArtifact` | boolean | `false` | Disable the Artifact web publishing tool. When `true`, Claude cannot create or publish web artifacts. Can be set at any scope |
 | `enableArtifact` | boolean | - | **(v2.1.196+)** User-level opt-in for the Artifact web publishing tool. When set to `true`, enables Artifact for the user even when no organization policy requires it. `disableArtifact: true` takes precedence and overrides this setting |
 | `feedbackSurveyRate` | number | - | Probability (0–1) that the session quality survey appears when eligible. Enterprise admins can control how often the survey is shown. Example: `0.05` = 5% of eligible sessions |
-| `advisorModel` | string | - | Model for the server-side advisor tool. Accepts a model alias (`opus`, `sonnet`) or a full model ID. When unset, the advisor uses the session model. Requires v2.1.98+. **v2.1.210+:** Setting `"fable"` no longer attaches an advisor — Fable 5 is temporarily unavailable in the advisor picker; use `"opus"` or `"sonnet"` instead |
+| `advisorModel` | string | - | Model for the server-side advisor tool. Accepts a model alias (`"fable"`, `"opus"`, `"sonnet"`) or a full model ID. When unset, the advisor uses the session model. Requires v2.1.98+. **v2.1.232+:** Fable 5 is available in the `/advisor` picker for eligible organizations |
 | `respondToBashCommands` | boolean | `true` | Whether Claude automatically responds after a `!` shell command completes. Set to `false` to disable the automatic follow-up response when a `!` bash command finishes (v2.1.186) |
-| `askUserQuestionTimeout` | string | `"never"` | How long to wait before an unanswered AskUserQuestion dialog auto-continues without the user. Values: `"60s"`, `"5m"`, `"10m"`, `"never"` (no auto-continue — the default). Set via `/config` as **Question auto-continue timeout**. Pairs with the `CLAUDE_AFK_TIMEOUT_MS` env var; the env var applies only when this setting is set to a duration. Only honored from project and local settings — managed and user settings values are ignored. (v2.1.200) |
+| `askUserQuestionTimeout` | string | `"never"` | How long to wait before an unanswered AskUserQuestion dialog auto-continues without the user. Values: `"60s"`, `"5m"`, `"10m"`, `"never"` (no auto-continue — the default). Set via `/config` as **Question auto-continue timeout**. Pairs with the `CLAUDE_AFK_TIMEOUT_MS` env var; the env var applies only when this setting is set to a duration. **Not read from project or local settings** — only honored from managed settings, user settings (`~/.claude/settings.json`), or `--settings`. (v2.1.200) |
 | `theme` | string | `"dark"` | UI color theme. Values: `"auto"` (follow OS), `"dark"`, `"light"`, `"dark-daltonized"`, `"light-daltonized"`, `"dark-ansi"`, `"light-ansi"`, `"custom:<slug>"`, `"custom:<plugin>:<slug>"`. Plugin-provided themes use the `custom:` prefix |
 | `verbose` | boolean | `false` | Show full tool output instead of truncated summaries. Equivalent to running with `--verbose`; persists the verbose view across sessions |
 | `switchModelsOnFlag` | boolean | `true` | Automatically switch to the fallback model when a safety classifier flags a request. When `false`, flagged requests are blocked rather than rerouted (v2.1.170) |
 | `processWrapper` | string | - | Corporate launcher command used for background processes (e.g., a credential-injecting wrapper). Only honored from managed settings, user settings (`~/.claude/settings.json`), or `--settings`; ignored from project and local settings to prevent untrusted repos from hijacking background process launches (v2.1.210) |
 | `remote.defaultEnvironmentId` | string | - | Default environment ID to use when launching remote sessions or background agents via `--remote` without an explicit environment ID. When set, Claude Code selects this environment automatically rather than prompting. Only honored from user and managed settings (v2.1.200+) |
+| `crossSessionInbound` | string | `"accept"` | How this session treats inbound cross-session messages from your other Claude Code sessions. `"accept"` delivers them to Claude, `"hold"` shows a notice for each message without delivering it, and `"refuse"` drops them. Set via `/config` as **Cross-session inbound** (v2.1.224) |
+| `dialogExpiry` | string | `"5m"` | Deadline for dialogs Claude Code forwards to a remote client, and for the approval dialog for a held cross-session message. After this duration, the dialog is automatically dismissed. Set via `/config` as **Dialog expiry** (v2.1.224) |
 
 **Example:**
 ```json
@@ -347,6 +349,7 @@ Control what tools and operations Claude can perform.
 - **Word boundary:** `Bash(ls *)` (space before `*`) matches `ls -la` but NOT `lsof`; `Bash(ls*)` (no space) matches both
 - `Bash(*)` is treated as equivalent to `Bash` (matches all bash commands)
 - Permission rules support output redirections: `Bash(python:*)` matches `python script.py > output.txt`
+- **v2.1.232+:** Permission rules also apply to **input redirections** (`<`, `<<`, `<(...)`) — a rule must authorize the base command regardless of whether the redirect is input or output
 - The `:*` suffix syntax (e.g., `Bash(npm:*)`) is an equivalent way to write a trailing wildcard — it is **not deprecated** but only recognized at the end (e.g., `Bash(git:* push)` treats the colon literally). The permission dialog writes the space form
 - **Compound commands:** shell operators (`&&`, `||`, `;`, `|`, `|&`, `&`, and newlines) split a command and each subcommand must match independently — `Bash(safe-cmd *)` does **not** authorize `safe-cmd && other-cmd`
 - **Process wrappers:** `timeout`, `time`, `nice`, `nohup`, and `stdbuf` are stripped before matching (so `Bash(npm test *)` also matches `timeout 30 npm test`); bare `xargs` (no flags) is stripped too. Exec wrappers `watch`, `setsid`, `ionice`, `flock`, and `find` with `-exec`/`-delete` always prompt and cannot be approved by a prefix rule
@@ -507,6 +510,7 @@ Configure bash command sandboxing for security.
 | `sandbox.credentials.files[].maskDuplicates` | boolean | `false` | When `true`, also mask occurrences of the extracted credential value that appear in other files and env vars read during the same sandboxed command (v2.1.221) |
 | `sandbox.network.tlsTerminate` | object | — | TLS termination configuration for sandboxed bash commands. When set, Claude Code acts as a TLS man-in-the-middle for outbound HTTPS from the sandbox, enabling credential masking (`sandbox.credentials` `mask` mode). Set to `{}` to generate an ephemeral certificate authority for the session, or set `caCertPath` and `caKeyPath` to provide your own CA. **Only honored from user settings, managed settings, or `--settings`** — ignored in `.claude/settings.json` and `.claude/settings.local.json`. Experimental (v2.1.199) |
 | `sandbox.credentials.allowPlaintextInject` | boolean | `false` | Allow `mask` credential substitution to also apply on **plain HTTP requests** (where the upstream identity is unverified and the credential travels in cleartext). When `false` (default), credential injection via `injectHosts` is restricted to TLS-terminated HTTPS connections only, preventing credentials from being sent over unencrypted channels. Use only in trusted local environments where cleartext exposure is acceptable (v2.1.199) |
+| `sandbox.ripgrep` | string | - | Custom path to the `ripgrep` (`rg`) binary used by sandboxed Grep invocations. When set, the sandbox uses this binary instead of the bundled one; as of v2.1.232, this key takes lower precedence than `USE_BUILTIN_RIPGREP=1` (v2.1.232) |
 
 **Example:**
 ```json
@@ -545,8 +549,11 @@ Configure Claude Code plugins and marketplaces.
 | `blockedMarketplaces` | array | Managed only | Block specific plugin marketplaces. Each entry can match by source string, `hostPattern`, or `pathPattern` — as of v2.1.119 the `hostPattern` and `pathPattern` matchers are correctly enforced before any download touches the filesystem, so blocked marketplaces never reach disk |
 | `pluginTrustMessage` | string | Managed only | Custom message displayed when prompting users to trust plugins |
 | `disableSideloadFlags` | boolean | Managed only | Reject the `--plugin-dir`, `--plugin-url`, `--agents`, and `--mcp-config` startup flags. When `true`, users cannot bypass `strictKnownMarketplaces` by passing sideload flags at launch. Use in managed environments to enforce marketplace-only plugin distribution (v2.1.193) |
+| `disableCommandPluginSources` | boolean | Managed only | Block the `command` plugin source type, which installs a plugin by running a marketplace-declared command on the user's machine. When `true`, only URL-based and archive-based plugin sources are permitted. Pairs with the v2.1.229 addition of `command` sources (v2.1.229) |
+| `additionalMarketplaces` | object | Any | Alias for `extraKnownMarketplaces` — adds custom plugin marketplaces. Both keys are accepted and merged (v2.1.232) *(in changelog, not yet on official settings page)* |
+| `allowedMarketplaces` | array | Any | Alias accepted alongside `blockedMarketplaces` for allowlisting specific marketplaces (v2.1.232) *(in changelog, not yet on official settings page)* |
 
-**Marketplace source types:** `github`, `git`, `directory`, `settings`, `url`, `npm`, `file`, `archive`. Use `source: 'settings'` to declare a small set of plugins inline without setting up a hosted marketplace repository. Use `source: 'archive'` for zip-based plugin installation with SHA-256 pinning (v2.1.224). Note: `hostPattern` is a *matcher* field for `blockedMarketplaces`, not a source type.
+**Marketplace source types:** `github`, `git`, `directory`, `settings`, `url`, `npm`, `file`, `archive`, `command`. Use `source: 'settings'` to declare a small set of plugins inline without setting up a hosted marketplace repository. Use `source: 'archive'` for zip-based plugin installation with SHA-256 pinning (v2.1.224). Note: `hostPattern` is a *matcher* field for `blockedMarketplaces`, not a source type.
 
 **Owner wildcard entries (v2.1.223):** `strictKnownMarketplaces` and `blockedMarketplaces` now accept `"owner/*"` wildcard entries to match all repositories from a specific organization or user.
 
@@ -706,7 +713,7 @@ These IDE-related preferences are stored in `~/.claude.json`, **not** `settings.
 | `autoConnectIde` | boolean | `false` | Automatically connect to a running IDE when Claude Code starts from an external terminal. Appears in `/config` as **Auto-connect to IDE (external terminal)** when running outside a VS Code or JetBrains terminal |
 | `autoInstallIdeExtension` | boolean | `true` | Automatically install the Claude Code IDE extension when running from a VS Code terminal. Appears in `/config` as **Auto-install IDE extension**. Can also be disabled via `CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL` env var |
 | `externalEditorContext` | boolean | `false` | Prepend Claude's previous response as `#`-commented context when you open the external editor with `Ctrl+G`. Set to `true` to enable |
-| `teammateDefaultModel` | string | `null` | Default model for [agent-team](https://code.claude.com/docs/en/agent-teams) teammates when the lead dispatches them. `null` inherits the lead's model. Listed under "Global config settings" on the official settings page |
+| `teammateDefaultModel` | string | `null` | ~~Default model for agent-team teammates when the lead dispatches them.~~ **Removed in v2.1.234.** |
 | `diffTool` | string | - | External diff tool command invoked when viewing file diffs. When set, Claude Code spawns this command with the two file paths as arguments instead of rendering the built-in diff view |
 | `permissionExplainerEnabled` | boolean | `true` | Show an AI-generated natural-language explanation of why a permission is being requested alongside the permission prompt. Set to `false` to suppress the explanation and show only the raw tool call |
 
@@ -990,7 +997,7 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_GLOB_HIDDEN` | Set to `false` to exclude dotfiles from results when Claude invokes the Glob tool. Included by default. Does not affect `@` file autocomplete, `ls`, Grep, or Read |
 | `CLAUDE_CODE_GLOB_NO_IGNORE` | Set to `false` to make the Glob tool respect `.gitignore` patterns. By default, Glob returns all matching files including gitignored ones. Does not affect `@` file autocomplete, which has its own `respectGitignore` setting |
 | `CLAUDE_CODE_GLOB_TIMEOUT_SECONDS` | Timeout in seconds for Glob file discovery |
-| `CLAUDE_CODE_ENABLE_TASKS` | Controls whether sessions use the structured Task tools (`TaskCreate`, `TaskUpdate`, `TaskGet`, `TaskList`) or the legacy `TodoWrite` tool. As of v2.1.142, Task tools are the default in all modes. Set to `0` to revert to `TodoWrite` |
+| `CLAUDE_CODE_ENABLE_TASKS` | Controls whether sessions use the structured Task tools (`TaskCreate`, `TaskUpdate`, `TaskGet`, `TaskList`) or the legacy `TodoWrite` tool. As of v2.1.142, Task tools were the default; however, as of **v2.1.233, Task/Todo tools are disabled by default on newer models**. Set to `1` to re-enable Task tools; use `CLAUDE_CODE_ENABLE_TODO_TOOLS=1` to restore the legacy TodoWrite tool |
 | `CLAUDE_CODE_SIMPLE` | Set to `1` to run with a minimal system prompt and only the Bash, file read, and file edit tools. Also configurable as a startup-only var — see [CLI Startup Flags](./claude-cli-startup-flags.md#environment-variables) |
 | `CLAUDE_CODE_EXIT_AFTER_STOP_DELAY` | Auto-exit SDK mode after idle duration (ms) |
 | `CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING` | Disable adaptive thinking (`1` to disable) |
@@ -1003,7 +1010,7 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_NEW_INIT` | Set to `true` to make `/init` run an interactive setup flow. Asks which files to generate (CLAUDE.md, skills, hooks) before exploring the codebase. Without this, `/init` generates a CLAUDE.md automatically |
 | `CLAUDE_CODE_PLUGIN_SEED_DIR` | Path to one or more read-only plugin seed directories, separated by `:` on Unix or `;` on Windows. Bundle pre-populated plugins into a container image. Claude Code registers marketplaces from these directories at startup and uses pre-cached plugins without re-cloning |
 | `ENABLE_CLAUDEAI_MCP_SERVERS` | Enable Claude.ai MCP servers |
-| `CLAUDE_CODE_EFFORT_LEVEL` | Set effort level: `low`, `medium`, `high`, `xhigh` (Opus 4.7 and 4.8, v2.1.111), `max` (Opus 4.6 only), or `auto` (use model default). Takes precedence over `/effort` and the `effortLevel` setting. Also configurable as a startup-only var — see [CLI Startup Flags](./claude-cli-startup-flags.md#environment-variables) |
+| `CLAUDE_CODE_EFFORT_LEVEL` | Set effort level: `low`, `medium`, `high`, `xhigh`, `max` (session-only; available on Fable 5, Opus 5, Sonnet 5, Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 4.6), or `auto` (use model default). Takes precedence over `/effort` and the `effortLevel` setting. Also configurable as a startup-only var — see [CLI Startup Flags](./claude-cli-startup-flags.md#environment-variables) |
 | `CLAUDE_EFFORT` | Read-only. Injected into Bash tool subprocesses and hook handlers with the active effort level so shell scripts and hooks can adapt to the current tier (companion to `CLAUDE_CODE_EFFORT_LEVEL`; v2.1.133). Inside skill files use `${CLAUDE_EFFORT}` *(in changelog, not on official env-vars page — read-only, not user-configurable)* |
 | `CLAUDE_CODE_ALWAYS_ENABLE_EFFORT` | Set to `1` to force-enable the effort parameter on all models, even those that do not normally support effort-level selection. Allows `/effort` and the `effortLevel` setting to take effect on models outside the standard effort-capable set (v2.1.154) |
 | `CLAUDE_CODE_MAX_TURNS` | Maximum agentic turns before stopping *(not in official docs — unverified)* |
@@ -1097,7 +1104,7 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_RETRY_WATCHDOG` | Raise the retry count for non-capacity API errors to 300. The standard retry cap (`CLAUDE_CODE_MAX_RETRIES`, default: 10) still applies for capacity errors (v2.1.199) |
 | `CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY` | Max parallel read-only tools (default: 10) |
 | `CLAUDE_CODE_MAX_WEB_SEARCHES_PER_SESSION` | Maximum web searches allowed per session (default: `200`). Prevents runaway tool use in long agentic sessions *(in v2.1.212 changelog, not yet on official env-vars page)* |
-| `CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION` | Maximum subagents that can be spawned per session (default: `200`). Prevents resource exhaustion in deeply nested agentic workflows *(in v2.1.212 changelog, not yet on official env-vars page)* |
+| `CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION` | Maximum subagents that can be spawned per session. **v2.1.224:** The 200-subagent spawn cap was removed; this env var may no longer impose a hard limit in current versions *(in v2.1.212 changelog, not yet on official env-vars page)* |
 | `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS` | Maximum number of subagents that run concurrently (default: `20`). Limits parallel agent fan-out; excess agents queue and run as slots free up (v2.1.217) |
 | `CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH` | Maximum nesting depth for subagents (default: `3` as of v2.1.219). Subagents at the depth limit cannot spawn further subagents (v2.1.217) |
 | `CLAUDE_AGENT_SDK_DISABLE_BUILTIN_AGENTS` | Disable built-in subagent types in SDK mode (`1` to disable) |
@@ -1153,7 +1160,7 @@ Set environment variables for all Claude Code sessions.
 | `OTEL_METRICS_INCLUDE_VERSION` | Set to `1` to include the Claude Code version as a label on all OpenTelemetry metric data points |
 | `OTEL_METRICS_INCLUDE_RESOURCE_ATTRIBUTES` | Set to `1` to promote `OTEL_RESOURCE_ATTRIBUTES` key/value pairs onto every metric data point as dimensions |
 | `CLAUDE_CODE_OTEL_DIAG_STDERR` | Set to `1` to emit OpenTelemetry SDK diagnostic output to stderr. Use to troubleshoot collector connectivity or exporter configuration issues |
-| `CLAUDE_CODE_FORK_SUBAGENT` | Set to `1` to enable forked subagents on external builds (non-Anthropic-signed distributions). Forked subagents run in an isolated child process instead of sharing the main agent's context *(in v2.1.117 changelog, not yet on official env-vars page)* |
+| `CLAUDE_CODE_FORK_SUBAGENT` | **v2.1.232+:** Subagent forking is now the default — forked subagents inherit the full conversation and prompt cache automatically. Previously required `=1` to opt in on external builds; this opt-in framing is no longer needed for most users *(in v2.1.117 changelog, not yet on official env-vars page)* |
 | `CLAUDE_CODE_MCP_SERVER_NAME` | Name of the MCP server, passed as an environment variable to `headersHelper` scripts so they can generate server-specific authentication headers *(in v2.1.85 changelog, not yet on official env-vars page)* |
 | `CLAUDE_CODE_MCP_SERVER_URL` | URL of the MCP server, passed as an environment variable to `headersHelper` scripts alongside `CLAUDE_CODE_MCP_SERVER_NAME` *(in v2.1.85 changelog, not yet on official env-vars page)* |
 | `ANTHROPIC_DEFAULT_OPUS_MODEL` | Override Opus model alias (e.g., `claude-opus-4-6[1m]`) |
@@ -1224,6 +1231,13 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_ENABLE_OPUS_4_7_FAST_MODE` | Set to `1` to enable fast mode on Opus 4.7. By default fast mode is not available on Opus 4.7 because its default effort (`xhigh`) differs from the fast-mode model tier |
 | `MCP_DISCOVERY_CACHE` | Path to a local cache file for MCP server discovery results. When set, Claude Code reads discovery results from this file instead of querying the discovery endpoint on startup, reducing latency in environments with many MCP servers |
 | `USE_BUILTIN_RIPGREP` | Set to `1` to use Claude Code's bundled ripgrep binary for the Grep tool instead of any `rg` found on `PATH`. Useful when the system `rg` version is incompatible or not installed. Also configurable as a startup-only var — see [CLI Startup Flags](./claude-cli-startup-flags.md#environment-variables) |
+| `CLAUDE_CODE_WEBFETCH_CACHE_TTL_MS` | Override the WebFetch session URL cache TTL in milliseconds. Defaults to 15 minutes (900000). Increase to reduce repeated fetches of the same URL; decrease to get fresher content more often (v2.1.233) |
+| `CLAUDE_CODE_TOOL_MEMORY_LIMIT` | Memory cgroup limit for Bash tool processes on Linux, in bytes (e.g., `"536870912"` for 512 MB). When set, Claude Code creates a memory cgroup for each Bash invocation capped at this limit. Requires Linux with cgroup v2 support (v2.1.233) |
+| `CLAUDE_CODE_ENABLE_TODO_TOOLS` | Set to `1` to re-enable Todo/Task tools on newer models where they are disabled by default as of v2.1.233. Restores `TodoWrite` and task-tracking tools (v2.1.233) |
+| `CLAUDE_AX_PREPARK_MS` | In screen-reader mode (`CLAUDE_AX_SCREEN_READER=1`), controls how long the cursor is held before writing new lines, in milliseconds. Default: `50`. Tune to match your screen reader's response time (v2.1.233) |
+| `CLAUDE_AX_STARTUP_QUIET_MS` | In screen-reader mode, suppresses startup output for this many milliseconds to avoid flooding the screen reader during initialization (v2.1.233) |
+| `CLAUDE_CODE_PROJECT_DIR_NAME` | Short name used as the per-project transcript directory when a project directory is set. When set, the transcript directory is named `<value>` instead of a hash of the project path, making it easier to locate session files (v2.1.234) |
+| `ANTHROPIC_PROFILE` | Name of the Anthropic profile to authenticate with. Used for credential selection when multiple profiles are configured |
 | `ANTHROPIC_BEDROCK_REGION_PREFIX` | Region prefix for Bedrock cross-region inference profile IDs. When set, Claude Code prepends this value to Bedrock model IDs to construct cross-region inference profile ARNs automatically (v2.1.224) *(in v2.1.224 changelog; not yet on official env-vars page)* |
 
 ---
@@ -1232,7 +1246,7 @@ Set environment variables for all Claude Code sessions.
 
 | Command | Description |
 |---------|-------------|
-| `/model` | Switch models and adjust effort level (Opus 4.7 and 4.8) |
+| `/model` | Switch models and adjust effort level (Fable 5, Opus 5, Sonnet 5, Opus 4.7, Opus 4.8) |
 | `/effort` | Set effort level directly: `low`, `medium`, `high`, `xhigh` (Fable 5, Opus 5, Sonnet 5, Opus 4.7, 4.8), `max` (session-only; available on all effort-supporting models), or `ultracode` (session-only; enables ultracode workflow, v2.1.203+) (v2.1.76+) |
 | `/config` | Interactive configuration UI; also accepts `key=value` syntax for prompt-based settings: `/config model=sonnet` (v2.1.181) |
 | `/autocompact` | Set the auto-compact window size in tokens. Writes `autoCompactWindow` to user settings. Use `--autocompact <tokens>` CLI flag for the same effect per-session (v2.1.221+) |

--- a/changelog/best-practice/claude-settings/changelog.md
+++ b/changelog/best-practice/claude-settings/changelog.md
@@ -1262,3 +1262,28 @@
 | 20 | LOW | New Env Var | Add `ANTHROPIC_BEDROCK_REGION_PREFIX` (v2.1.224 changelog — cross-region inference prefix). Not yet on official env-vars page; annotated as changelog-only | COMPLETE (annotated as changelog-only) — NEW |
 | 21 | LOW | New Settings | `crossSessionInbound` and `dialogExpiry` noted in v2.1.224 changelog. Not yet on official settings page — confidence 0.75 | ON HOLD (not yet on official docs — awaiting docs page update) — NEW |
 | 22 | LOW | Unverified Keys | v2.1.224 JWT masking options (`decode`, `maskClaims`, `awsPairs`/`sigv4`) for `sandbox.credentials.files[]` — not yet on official settings page, changelog-only, confidence 0.70 | ON HOLD (not yet on official docs — awaiting docs page update) — NEW |
+
+---
+
+## [2026-08-18 10:46 AM PKT] Claude Code v2.1.234
+
+| # | Priority | Type | Action | Status |
+|---|----------|------|--------|--------|
+| 1 | HIGH | Correctness Bug | Fix `askUserQuestionTimeout` scope rule — completely inverted. Report said "honored from project and local settings"; official docs say the exact opposite: **Not read from project or local settings** (honored from managed, user, `--settings`). Updated to reflect docs verbatim (v2.1.200) | COMPLETE (scope rule corrected) — NEW |
+| 2 | HIGH | Version Metadata | Update badge and header: v2.1.224 → v2.1.234; "311 environment variables" → "335 env vars"; "127+ settings" → "130+" | COMPLETE (badge, version, and counts updated) — NEW |
+| 3 | HIGH | Wrong Description | Fix `advisorModel` stale note — "fable temporarily unavailable" was lifted in v2.1.232; Fable 5 now available in `/advisor` for eligible orgs. Updated description to list all three aliases (`fable`, `opus`, `sonnet`) | COMPLETE (stale restriction removed) — NEW |
+| 4 | HIGH | Wrong Description | Fix `CLAUDE_CODE_ENABLE_TASKS` polarity — as of v2.1.233, Task/Todo tools are **disabled by default** on newer models (was previously enabled by default since v2.1.142). Updated description to reflect reversed default | COMPLETE (polarity corrected) — NEW |
+| 5 | HIGH | Missing Settings | Add `crossSessionInbound` (string, default `"accept"`, v2.1.224) and `dialogExpiry` (string, default `"5m"`, v2.1.224) to General Settings. Both confirmed on official settings docs page. Resolves ON HOLD item #21 from 2026-08-07 | COMPLETE (both settings added; item 21 resolved) — RESOLVED (first seen: 2026-08-07) |
+| 6 | HIGH | Missing Setting | Add `disableCommandPluginSources` (boolean, Managed only, v2.1.229) to Plugin Settings. Blocks `command` marketplace source type. Confirmed on official settings docs page | COMPLETE (added to Plugin Settings table) — NEW |
+| 7 | HIGH | Missing Feature | Add `command` marketplace source type to the source-types list (v2.1.229). Also noted GitLab repo support added in v2.1.232 | COMPLETE (command source type added) — NEW |
+| 8 | HIGH | Missing Env Vars | Add 6 new env vars: `CLAUDE_CODE_WEBFETCH_CACHE_TTL_MS` (v2.1.233), `CLAUDE_CODE_TOOL_MEMORY_LIMIT` (v2.1.233), `CLAUDE_CODE_ENABLE_TODO_TOOLS` (v2.1.233), `CLAUDE_AX_PREPARK_MS` (v2.1.233), `CLAUDE_AX_STARTUP_QUIET_MS` (v2.1.233), `CLAUDE_CODE_PROJECT_DIR_NAME` (v2.1.234). All confirmed on official env-vars page or changelog | COMPLETE (all 6 env vars added) — NEW |
+| 9 | HIGH | Missing Env Var | Add `ANTHROPIC_PROFILE` (name of Anthropic profile for credential selection). Confirmed on official env-vars page | COMPLETE (added to env vars table) — NEW |
+| 10 | HIGH | Removed Setting | Mark `teammateDefaultModel` as **Removed in v2.1.234**. Was in Global Config Settings table | COMPLETE (marked as removed) — NEW |
+| 11 | MED | Missing Setting | Add `sandbox.ripgrep` (string, custom ripgrep path) to Sandbox Settings. v2.1.232 changed its precedence rules | COMPLETE (added to Sandbox Settings table) — NEW |
+| 12 | MED | Missing Settings | Add `additionalMarketplaces` and `allowedMarketplaces` aliases (v2.1.232) to Plugin Settings, annotated as changelog-only (not yet on official settings page) | COMPLETE (both aliases added with annotation) — NEW |
+| 13 | MED | Missing Note | Add Bash input redirections permission-checking note (v2.1.232) — permission rules now apply to `<`, `<<`, `<(...)` in addition to output redirections | COMPLETE (note added to Bash wildcard section) — NEW |
+| 14 | MED | Wrong Description | Fix `CLAUDE_CODE_EFFORT_LEVEL` — described `max` as "(Opus 4.6 only)" which contradicts General Settings table listing Fable 5, Opus 5, Sonnet 5, Opus 4.8, 4.7, 4.6, Sonnet 4.6. Updated to match the correct model list | COMPLETE (effort level models corrected) — NEW |
+| 15 | MED | Wrong Description | Fix `/model` command description — "(Opus 4.7 and 4.8)" is stale; updated to "(Fable 5, Opus 5, Sonnet 5, Opus 4.7, Opus 4.8)" | COMPLETE (model list updated) — NEW |
+| 16 | MED | Stale Description | Update `CLAUDE_CODE_FORK_SUBAGENT` — subagent forking is now the default as of v2.1.232 (previously required opt-in `=1`). Updated to note this | COMPLETE (description updated) — NEW |
+| 17 | MED | Stale Description | Update `CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION` — v2.1.224 removed the 200-subagent spawn cap. The hard limit may no longer apply in current versions | COMPLETE (cap-removal noted) — NEW |
+| 18 | LOW | ON HOLD (carried) | v2.1.224 JWT masking options (`decode`, `maskClaims`, `awsPairs`/`sigv4`) for `sandbox.credentials.files[]` — still not on official settings page, changelog-only. Run count: 2 | ON HOLD (still not confirmed on official docs — awaiting docs page update) — RECURRING (first seen: 2026-08-07) |


### PR DESCRIPTION
## Summary

Automated drift audit of `best-practice/claude-settings.md` against official Claude Code docs. Report was at **v2.1.224**; latest is **v2.1.234** (10 version bumps, spanning v2.1.225–2.1.234).

---

## Verification Log

| Rule | Category | Depth | Result | Notes |
|------|----------|-------|--------|-------|
| 1A | Key Completeness | field-level | FAIL → FIXED | 3 missing settings keys added |
| 1B | Key Types | content-match | PASS | All types verified correct |
| 1C | Key Defaults | content-match | PASS | All defaults verified correct |
| 1D | Key Descriptions | content-match | FAIL → FIXED | `askUserQuestionTimeout` scope inverted; `advisorModel` stale; `CLAUDE_CODE_ENABLE_TASKS` polarity wrong |
| 1E | Scope Column | content-match | PASS | All scope columns verified |
| 1F | Inverse Completeness | field-level | PASS | All report keys traceable to official docs or annotated |
| 1G | Edge-Case Semantics | content-match | PASS | No new edge-case boundary issues found |
| 1H | File Scope Check | content-match | PASS | No settings.json vs ~/.claude.json confusion detected |
| 1I | Skills Settings Keys | field-level | PASS | `skillListingBudgetFraction`, `skillListingMaxDescChars` confirmed present |
| 2A | Priority Levels | field-level | PASS | 5-level hierarchy matches docs exactly |
| 2B | File Locations | content-match | PASS | All file paths correct |
| 2C | Merge Semantics | content-match | PASS | "concatenated and deduplicated" language confirmed correct |
| 2D | Managed Internals | field-level | PASS | Delivery methods and precedence correct |
| 3A | Permission Modes | field-level | PASS | All 7 modes verified |
| 3B | Tool Syntax Patterns | content-match | FAIL → FIXED | Input redirect permission checking note added (v2.1.232) |
| 3C | Bidirectional Mode Check | field-level | PASS | No extra modes in report |
| 3D | Evaluation Semantics | content-match | PASS | Deny-first, path-prefix patterns all correct |
| 4A | Hooks Redirect | exists | PASS | Redirect link to claude-code-hooks valid |
| 5A | Env Var Completeness | field-level | FAIL → FIXED | 7 new env vars added |
| 5B | Ownership Boundary | cross-file | PASS | Clean boundary; dual-listed vars properly annotated |
| 5C | Env Var Descriptions | content-match | FAIL → FIXED | `CLAUDE_CODE_ENABLE_TASKS` polarity corrected; `CLAUDE_CODE_EFFORT_LEVEL` model list fixed |
| 5D | Inverse Env Var Check | field-level | PASS | All env vars traceable or annotated |
| 6A | Quick Reference Example | content-match | PASS | Syntax valid, all keys current |
| 6B | Example URL Validation | exists | PASS | `$schema` URL valid (schemastore.org redirects cleanly) |
| 7A | CLAUDE.md Sync | cross-file | PASS | Settings hierarchy section consistent (6-item CLAUDE.md vs 5-level report is intentional — item 6 is a repo-local convention) |
| 8A | Source Credibility Guard | content-match | PASS | All findings sourced from official docs or changelog; third-party leads discarded |
| 9A | Local File Links | exists | PASS | All relative links resolve |
| 9B | External URL Links | exists | PASS | All external URLs valid (GitHub 403s are proxy artifacts, not link rot) |
| 9C | Anchor Links | exists | PASS | All internal anchors resolve |
| 10A | Version Metadata | content-match | FAIL → FIXED | Badge v2.1.224 → v2.1.234; "311 env vars" → "335"; "127+" → "130+" |
| 10B | Suspect Key Escalation | exists | PASS | Item 22 (JWT masking) at run 2 — below 5-run escalation threshold |
| 10C | Bidirectional Completeness | field-level | PASS | All keys traceable or annotated |

---

## Action Items

| # | Priority | Type | Action | Status |
|---|----------|------|--------|--------|
| 1 | HIGH | Correctness Bug | Fix `askUserQuestionTimeout` scope — inverted (was "honored from project/local"; correct: "NOT read from project/local") | COMPLETE |
| 2 | HIGH | Version Metadata | Badge v2.1.224 → v2.1.234; "311 env vars" → "335"; "127+" → "130+" | COMPLETE |
| 3 | HIGH | Wrong Description | Fix `advisorModel` — Fable 5 availability restored in v2.1.232 | COMPLETE |
| 4 | HIGH | Wrong Description | Fix `CLAUDE_CODE_ENABLE_TASKS` — polarity reversed in v2.1.233 (now disabled by default on newer models) | COMPLETE |
| 5 | HIGH | Missing Settings | Add `crossSessionInbound` + `dialogExpiry` (v2.1.224, confirmed on official docs) | COMPLETE — RESOLVED (first seen: 2026-08-07) |
| 6 | HIGH | Missing Setting | Add `disableCommandPluginSources` (v2.1.229, Managed only) | COMPLETE |
| 7 | HIGH | Missing Feature | Add `command` marketplace source type (v2.1.229) | COMPLETE |
| 8 | HIGH | Missing Env Vars | Add 6 new env vars: `CLAUDE_CODE_WEBFETCH_CACHE_TTL_MS`, `CLAUDE_CODE_TOOL_MEMORY_LIMIT`, `CLAUDE_CODE_ENABLE_TODO_TOOLS`, `CLAUDE_AX_PREPARK_MS`, `CLAUDE_AX_STARTUP_QUIET_MS`, `CLAUDE_CODE_PROJECT_DIR_NAME` | COMPLETE |
| 9 | HIGH | Missing Env Var | Add `ANTHROPIC_PROFILE` (official env-vars page) | COMPLETE |
| 10 | HIGH | Removed Setting | Mark `teammateDefaultModel` as REMOVED in v2.1.234 | COMPLETE |
| 11 | MED | Missing Setting | Add `sandbox.ripgrep` (v2.1.232) | COMPLETE |
| 12 | MED | Missing Settings | Add `additionalMarketplaces` + `allowedMarketplaces` aliases (v2.1.232, changelog-only annotation) | COMPLETE |
| 13 | MED | Missing Note | Add Bash input redirections permission-checking note (v2.1.232) | COMPLETE |
| 14 | MED | Wrong Description | Fix `CLAUDE_CODE_EFFORT_LEVEL` — `max` was "(Opus 4.6 only)", updated to full model list | COMPLETE |
| 15 | MED | Wrong Description | Fix `/model` command — "(Opus 4.7 and 4.8)" updated to include Fable 5, Opus 5, Sonnet 5 | COMPLETE |
| 16 | MED | Stale Description | Update `CLAUDE_CODE_FORK_SUBAGENT` — forking now default in v2.1.232 | COMPLETE |
| 17 | MED | Stale Description | Update `CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION` — 200-cap removed in v2.1.224 | COMPLETE |
| 18 | LOW | ON HOLD (run 2) | JWT masking options (`decode`, `maskClaims`, `awsPairs`/`sigv4`) for `sandbox.credentials.files[]` — not yet on official docs | ON HOLD — RECURRING (first seen: 2026-08-07) |

## Items Needing Manual Verification (not applied — confidence too low for Rule 8A)

- `fileSuggestion` object vs `fileSuggestionCommand` string — two agent fetches disagreed (0.50 confidence)
- `strictKnownMarketplacesReason` — one fetch listed it; targeted fetch returned absent (0.55 confidence)
- v2.1.234 usage-limit auto-continue settings key — behavior described but key name not reliably extracted (0.60 confidence)

## Resolved Since Last Run

- **Item #21 (2026-08-07):** `crossSessionInbound` and `dialogExpiry` were ON HOLD awaiting official docs confirmation. Both are now confirmed on the official settings page and added to General Settings.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DxoDGF14ihQekcYo1iH76D)_