### PR TITLE
Daily settings drift check — 2026-08-20 (Claude Code v2.1.237)

### DIFF
--- a/best-practice/claude-settings.md
+++ b/best-practice/claude-settings.md
@@ -1,9 +1,9 @@
 # Settings Best Practice
 
-![Last Updated](https://img.shields.io/badge/Last_Updated-Aug%2007%2C%202026%2010%3A48%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.224-blue?style=flat&labelColor=555)<br>
+![Last Updated](https://img.shields.io/badge/Last_Updated-Aug%2020%2C%202026%2010%3A44%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.237-blue?style=flat&labelColor=555)<br>
 [![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../.claude/settings.json)
 
-A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.224, Claude Code exposes **127+ settings** and **311 environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
+A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.237, Claude Code exposes **133+ settings** and **318 environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
 
 <table width="100%">
 <tr>
@@ -67,6 +67,7 @@ Within the managed tier, precedence is: server-managed > MDM/OS-level policies >
 | `browserExternalPageTools` | string | - | **(Managed only)** Set to `"disabled"` to prevent Claude from using tools to read or act on external pages in the desktop app's Browser pane. Users can still navigate to external sites themselves, and local dev server previews are unaffected |
 | `disableBrowserExternalNavigation` | boolean | - | **(Managed only)** Set to `true` (JSON boolean only — string `"true"` is silently ignored) to prevent Claude from navigating the desktop app's Browser pane to external URLs. Only JSON boolean `true` is honored |
 | `disableMobileSimulatorTools` | boolean | - | **(Managed only)** Set to `true` (JSON boolean only — a malformed value logs a warning) to remove mobile simulator tools from Claude. Only JSON boolean `true` is honored |
+| `disableCommandPluginSources` | boolean | - | **(Managed only)** When `true`, command-sourced plugins are blocked: commands never run, and plugins are not installed, updated, or loaded from command sources. When `false`, explicitly allows them. When unset, follows `allowManagedHooksOnly`. If the value is invalid, treated as `true` (fail-closed). Only `true` or `false` JSON booleans are honored (v2.1.229+) |
 
 **Important**:
 - `deny` rules have highest safety precedence and cannot be overridden by lower-priority allow/ask rules.
@@ -131,12 +132,14 @@ Within the managed tier, precedence is: server-managed > MDM/OS-level policies >
 | `feedbackSurveyRate` | number | - | Probability (0–1) that the session quality survey appears when eligible. Enterprise admins can control how often the survey is shown. Example: `0.05` = 5% of eligible sessions |
 | `advisorModel` | string | - | Model for the server-side advisor tool. Accepts a model alias (`opus`, `sonnet`) or a full model ID. When unset, the advisor uses the session model. Requires v2.1.98+. **v2.1.210+:** Setting `"fable"` no longer attaches an advisor — Fable 5 is temporarily unavailable in the advisor picker; use `"opus"` or `"sonnet"` instead |
 | `respondToBashCommands` | boolean | `true` | Whether Claude automatically responds after a `!` shell command completes. Set to `false` to disable the automatic follow-up response when a `!` bash command finishes (v2.1.186) |
-| `askUserQuestionTimeout` | string | `"never"` | How long to wait before an unanswered AskUserQuestion dialog auto-continues without the user. Values: `"60s"`, `"5m"`, `"10m"`, `"never"` (no auto-continue — the default). Set via `/config` as **Question auto-continue timeout**. Pairs with the `CLAUDE_AFK_TIMEOUT_MS` env var; the env var applies only when this setting is set to a duration. Only honored from project and local settings — managed and user settings values are ignored. (v2.1.200) |
+| `askUserQuestionTimeout` | string | `"never"` | How long to wait before an unanswered AskUserQuestion dialog auto-continues without the user. Values: `"60s"`, `"5m"`, `"10m"`, `"never"` (no auto-continue — the default). Set via `/config` as **Question auto-continue timeout**. Pairs with the `CLAUDE_AFK_TIMEOUT_MS` env var; the env var applies only when this setting is set to a duration. **User only** — not read from project, local, or managed settings. (v2.1.200) |
 | `theme` | string | `"dark"` | UI color theme. Values: `"auto"` (follow OS), `"dark"`, `"light"`, `"dark-daltonized"`, `"light-daltonized"`, `"dark-ansi"`, `"light-ansi"`, `"custom:<slug>"`, `"custom:<plugin>:<slug>"`. Plugin-provided themes use the `custom:` prefix |
 | `verbose` | boolean | `false` | Show full tool output instead of truncated summaries. Equivalent to running with `--verbose`; persists the verbose view across sessions |
 | `switchModelsOnFlag` | boolean | `true` | Automatically switch to the fallback model when a safety classifier flags a request. When `false`, flagged requests are blocked rather than rerouted (v2.1.170) |
 | `processWrapper` | string | - | Corporate launcher command used for background processes (e.g., a credential-injecting wrapper). Only honored from managed settings, user settings (`~/.claude/settings.json`), or `--settings`; ignored from project and local settings to prevent untrusted repos from hijacking background process launches (v2.1.210) |
 | `remote.defaultEnvironmentId` | string | - | Default environment ID to use when launching remote sessions or background agents via `--remote` without an explicit environment ID. When set, Claude Code selects this environment automatically rather than prompting. Only honored from user and managed settings (v2.1.200+) |
+| `crossSessionInbound` | string | - | How this session treats inbound cross-session messages from your other Claude Code sessions. Values: `"accept"` (deliver the message directly to Claude), `"hold"` (surface a notice so you can approve or dismiss), `"refuse"` (silently drop inbound messages). Read from managed settings, `--settings` flag, and user settings in that order — the first match applies. Set via `/config` as **Messages from your other sessions** (v2.1.224+) |
+| `dialogExpiry` | string | `"5m"` | Deadline for dialogs forwarded to a Remote Control client or held cross-session message approval. After this duration the dialog is auto-dismissed. Values: `"60s"`, `"5m"`, `"10m"`, `"never"` (never auto-dismiss). **User/managed/`--settings` only** — not read from project or local settings. Set via `/config` as **Dialog expiry** (v2.1.224+) |
 
 **Example:**
 ```json
@@ -536,6 +539,8 @@ Configure Claude Code plugins and marketplaces.
 |-----|------|-------|-------------|
 | `enabledPlugins` | object | Any | Enable/disable specific plugins |
 | `extraKnownMarketplaces` | object | Project | Add custom plugin marketplaces (team sharing via `.claude/settings.json`) |
+| `additionalMarketplaces` | object | Project | Friendlier alias for `extraKnownMarketplaces` — accepted interchangeably (v2.1.232) |
+| `allowedMarketplaces` | object | Project | Friendlier alias for `extraKnownMarketplaces` — accepted interchangeably (v2.1.232) |
 | `strictKnownMarketplaces` | boolean | Managed only | When `true`, only the official Anthropic marketplace is permitted; no additional or custom marketplaces may be installed |
 | `strictPluginOnlyCustomization` | boolean \| array | Managed only | Block skills, agents, hooks, and MCP servers from user and project sources, so they can only come from plugins or managed settings. `true` locks all four surfaces; an array such as `["skills", "hooks"]` locks only the named ones |
 | `pluginSuggestionMarketplaces` | array | Managed only | Allowlist of marketplace names whose plugins may appear as contextual install suggestions during a session. Restricts which marketplaces can surface "you might want this plugin" prompts (v2.1.152) |
@@ -675,7 +680,7 @@ Configure via `env` key:
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `statusLine` | object | - | Custom status line configuration |
-| `outputStyle` | string | `"default"` | Output style (e.g., `"Explanatory"`) |
+| `outputStyle` | string | `"default"` | Output style for Claude's responses. Values include `"default"`, `"Explanatory"` (detailed educational responses), and `"Concise"` (shorter, to-the-point responses, v2.1.237). Restart the session after changing for the new style to take effect |
 | `spinnerTipsEnabled` | boolean | `true` | Show tips while waiting |
 | `spinnerVerbs` | object | - | Custom spinner verbs with `mode` ("append" or "replace") and `verbs` array |
 | `spinnerTipsOverride` | object | - | Custom spinner tips with `tips` (string array) and optional `excludeDefault` (boolean). When `excludeDefault` is `true`, only custom tips show; when `false` or absent, custom tips merge with built-in tips. As of v2.1.121, `excludeDefault: true` also suppresses time-based spinner tips |
@@ -694,6 +699,7 @@ Configure via `env` key:
 | `wheelScrollAccelerationEnabled` | boolean | `true` | Disable mouse-wheel scroll acceleration in fullscreen mode. Set to `false` to use fixed per-tick scroll steps instead of the OS-level acceleration curve (v2.1.174) |
 | `footerLinksRegexes` | array | - | Array of objects matched against **turn output** (tool results, file contents, fetched pages, Claude's responses) to display as link badges in the footer row. Each entry is `{type, pattern, url, label}` where `pattern` is a regex with named capture groups and `url`/`label` may reference those groups. Matched patterns produce a clickable badge at the bottom of the chat UI. Capped at 5 badges per turn; URL max 2048 chars; allowed schemes: `http`, `https`, `vscode`, `cursor`, `windsurf`, `zed`, `jetbrains`, `idea`, `slack`, `linear`, `notion`, `figma`, `vscode-insiders`. User/`--settings`/managed only (v2.1.176) |
 | `emojiCompletionEnabled` | boolean | `true` | Enable emoji shortcode autocomplete in the prompt input (e.g., `:tada:` → 🎉). Set to `false` to disable. Requires v2.1.217+ |
+| `spellcheck` | boolean | `false` | Enable inline spell-checking with misspelled word underlining in the prompt input. Requires `aspell`, `hunspell`, or `ispell` to be installed on the system. Set to `true` to enable (v2.1.235) |
 
 ### Global Config Settings (`~/.claude.json`)
 
@@ -915,6 +921,7 @@ Set environment variables for all Claude Code sessions.
 | `ANTHROPIC_CUSTOM_MODEL_OPTION_DESCRIPTION` | Display description for the custom model entry in the `/model` picker. Defaults to `Custom model (<model-id>)` when not set |
 | `ANTHROPIC_CUSTOM_MODEL_OPTION_SUPPORTED_CAPABILITIES` | Override capability detection for the custom model entry. Comma-separated values (e.g., `effort,thinking`). Required when the custom model supports features the auto-detection cannot confirm. See [model configuration](https://code.claude.com/docs/en/model-config#customize-pinned-model-display-and-capabilities) |
 | `ANTHROPIC_MODEL` | Name of the model to use. Accepts aliases (`sonnet`, `opus`, `haiku`) or full model IDs. Overrides the `model` setting |
+| `ANTHROPIC_DEFAULT_MODEL` | Model for new sessions to start on. Unlike `ANTHROPIC_MODEL`, this sets the default that `/model` and `--model` can still override rather than forcing a fixed model for the entire session. Precedence: env vars in `settings.json` **do not** override `ANTHROPIC_DEFAULT_MODEL` set in the shell (opposite of most other env vars) (v2.1.236) |
 | `INIT_PROMPT` | Custom system prompt injected at session initialization |
 | `ANTHROPIC_DEFAULT_HAIKU_MODEL` | Override the Haiku model alias with a custom model ID (e.g., for third-party deployments) |
 | `ANTHROPIC_DEFAULT_HAIKU_MODEL_NAME` | Customize the Haiku entry label in the `/model` picker when using a pinned model on Bedrock/Vertex/Foundry. Defaults to the model ID |
@@ -923,6 +930,7 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_PID` | Read-only. Set to the PID of the Claude Code process in every subprocess it spawns (Bash tool, hooks, status line commands, MCP stdio servers). Use in scripts to signal the parent Claude Code process or to detect the Claude Code lineage. Introduced in v2.1.214 |
 | `CLAUDECODE` | Set to `1` in shell environments Claude Code spawns (Bash tool, tmux sessions). Not set in hooks or status line commands. Use to detect when a script is running inside a Claude Code shell |
 | `CLAUDE_CODE_CHILD_SESSION` | Set to `1` in subprocesses Claude Code spawns via the Bash, PowerShell, and Monitor tools, hook commands, and status line commands. Not set for stdio MCP server subprocesses. Unlike `CLAUDECODE`, this is only set by Claude Code's own spawn path (not IDE extensions), so it reliably distinguishes a nested `claude` session from a top-level `claude` launched in an IDE-integrated terminal. Nested interactive TUI sessions are automatically excluded from `--resume`, `--continue`, up-arrow history, and `claude agents`. Non-interactive `claude -p` sessions still persist. Set `CLAUDE_CODE_FORCE_SESSION_PERSISTENCE=1` to override this exclusion (v2.1.172) |
+| `CLAUDE_CODE_PROJECT_DIR_NAME` | Override the per-project subdirectory name used for transcript and state storage inside `~/.claude/projects/`. By default Claude Code derives the name from the working directory path. Set this to a fixed string to give a project a stable, human-readable transcript folder name regardless of where on disk it lives (v2.1.234) |
 | `CLAUDE_CODE_FORCE_SESSION_PERSISTENCE` | Set to `1` to override the automatic exclusion of nested interactive TUI sessions from `--resume`, `--continue`, up-arrow history, and `claude agents`. By default, nested sessions (where `CLAUDE_CODE_CHILD_SESSION=1`) are excluded to prevent them from polluting history. Set this to force persistence when you want nested sessions tracked |
 | `CLAUDE_CODE_SESSION_ID` | Read-only. Set automatically in Bash and PowerShell tool subprocesses to the current session ID. Matches the `session_id` field passed to hooks. Updated on `/clear`. Use to correlate scripts and external tools with the Claude Code session that launched them (v2.1.132). Also injected into stdio MCP server environments on `--resume` (v2.1.163 changelog) *(in v2.1.163 changelog; not yet on official env-vars page — read-only)* |
 | `AI_AGENT` | Set automatically by Claude Code in subprocess environments (Bash tool, hooks, MCP stdio servers). Generic flag identifying the parent process as an AI agent — useful for tools that adapt behavior when invoked from any AI agent rather than checking each agent-specific variable like `CLAUDECODE` *(in v2.1.120 changelog, not yet on official env-vars page)* |
@@ -938,6 +946,7 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_BRIDGE_SESSION_ID` | Read-only. Set automatically in Bash tool and hook command subprocesses while the session has an active Remote Control connection. Value is the session ID in `session_` form (same identifier in the session's `claude.ai/code` URL). Removed when the connection ends. Allows scripts to link back to the session that ran them. In cloud sessions, read `CLAUDE_CODE_REMOTE_SESSION_ID` instead (v2.1.199) |
 | `CLAUDE_REMOTE_CONTROL_SESSION_NAME_PREFIX` | Prefix for auto-generated Remote Control session names. Defaults to the machine hostname |
 | `CLAUDE_CLIENT_PRESENCE_FILE` | Path to a file that, when present, signals an active client and suppresses mobile push notifications from Remote Control. Useful in environments where a desktop client is always running and mobile pings are unwanted |
+| `notify_when_idle` | macOS/Linux only. When set, Claude Code uses this mechanism to send a system notification when a cross-session `SendMessage` targets your session and no response has been seen for a period. Enables passive idle-session notifications via system-level notification APIs (v2.1.236) |
 | `CLAUDE_CODE_DISABLE_NOTIFICATION_PRESENCE_CHECK` | Set to `1` to send push notifications even while the user is actively typing in the session. By default, notifications are suppressed when active user presence is detected (v2.1.193) |
 | `CLAUDE_CODE_ENABLE_TELEMETRY` | Enable/disable telemetry (`0` or `1`) |
 | `DISABLE_ERROR_REPORTING` | Disable error reporting (`1` to disable) |
@@ -955,6 +964,7 @@ Set environment variables for all Claude Code sessions.
 | `MAX_MCP_OUTPUT_TOKENS` | Max MCP output tokens (default: 25000). Warning displayed when output exceeds 10,000 tokens |
 | `API_TIMEOUT_MS` | Timeout in ms for API requests (default: 600000) |
 | `API_FORCE_IDLE_TIMEOUT` | Override the 5-minute idle timeout for streaming connections. Set to `0` to disable the idle timeout entirely, `1` to enforce it on all connections, or leave unset for the default (auto-enabled on slow or unreliable gateways that frequently stall). Useful for slow API gateways (v2.1.169) |
+| `CLAUDE_CODE_WEBFETCH_CACHE_TTL_MS` | Session-level URL cache TTL in milliseconds for the WebFetch tool. Fetches of the same URL within this window return the cached response instead of hitting the network. Default is 15 minutes (900000). Set to `0` to disable caching (v2.1.233) |
 | `CLAUDE_CODE_CONNECT_TIMEOUT_MS` | **REMOVED in v2.1.186.** This variable is a no-op. Use `API_TIMEOUT_MS` instead. Previously controlled the connect, TLS, and response-header phase timeout for streaming API requests |
 | `CLAUDE_AFK_TIMEOUT_MS` | How many milliseconds before an unanswered AskUserQuestion dialog auto-continues, when `askUserQuestionTimeout` is set to a duration. As of v2.1.200, the default is `"never"` (no auto-continue) controlled by `askUserQuestionTimeout`; this env var applies only when a timeout duration is active. Setting to `0` closes the dialog immediately. To keep questions open, prefer `askUserQuestionTimeout: "never"` (v2.1.198; default changed v2.1.200) |
 | `CLAUDE_AFK_COUNTDOWN_MS` | How many milliseconds before auto-continue the on-screen countdown appears on an unanswered AskUserQuestion dialog (default: `20000` / 20 seconds) (v2.1.198) |
@@ -971,6 +981,7 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_DISABLE_EXPLORE_PLAN_AGENTS` | Set to `1` to disable the built-in Explore and Plan subagents. Claude explores with search tools or the general-purpose subagent instead. Plan mode reads files directly rather than launching Explore and Plan agents (v2.1.198) |
 | `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` | Enable the experimental agent teams feature (`1` to enable). Allows spawning coordinated teams of subagents within a session. Also configurable as a startup-only var — see [CLI Startup Flags](./claude-cli-startup-flags.md#environment-variables) |
 | `CLAUDE_CODE_DISABLE_WORKFLOWS` | Set to `1` to disable [dynamic workflows](https://code.claude.com/docs/en/workflows) (`/workflows`) and the bundled workflow slash commands. Env-var equivalent of the `disableWorkflows` setting |
+| `CLAUDE_CODE_WORKFLOW_PREFIX_STAGGER_MS` | Milliseconds to stagger the fan-out start of workflow agents. When many agents launch simultaneously, setting this (e.g., `200`) introduces a rolling delay between agent starts to avoid thundering-herd API bursts (v2.1.229) |
 | `CLAUDE_CODE_ENABLE_AUTO_MODE` | **As of v2.1.207, auto mode is available on Bedrock, Vertex AI, and Foundry by default — this opt-in is no longer required.** Previously (v2.1.158–v2.1.206): set to `1` to make [auto mode](https://code.claude.com/docs/en/permission-modes#eliminate-prompts-with-auto-mode) available on those providers. Use `disableAutoMode: "disable"` in settings to turn auto mode off |
 | `CLAUDE_CODE_DISABLE_BUNDLED_SKILLS` | Set to `1` to conceal Claude Code's built-in capabilities (bundled skills) from the model. Env-var equivalent of the `disableBundledSkills` setting (v2.1.169) |
 | `CLAUDE_CODE_DISABLE_ARTIFACT` | Set to `1` to disable the [Artifact](https://code.claude.com/docs/en/artifacts) tool, which publishes session output as a private web page on claude.ai. Equivalent to the `disableArtifact` setting |
@@ -1123,6 +1134,8 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_HIDE_CWD` | Set to `1` to hide the current working directory in the Claude Code startup logo banner. Useful in screen recordings, demos, or shared sessions where the CWD path leaks information about the host or project layout (v2.1.119) |
 | `CLAUDE_CODE_ACCESSIBILITY` | Set to `1` to keep native terminal cursor visible for screen readers and accessibility tools |
 | `CLAUDE_AX_SCREEN_READER` | Set to `1` to render screen-reader friendly output: flat text without decorative borders or animations. Set to `0` to force screen-reader mode off even when the `axScreenReader` setting is `true`. The `--ax-screen-reader` CLI flag takes precedence (v2.1.181+) |
+| `CLAUDE_AX_PREPARK_MS` | Milliseconds to wait before writing a new or changed line in screen-reader mode (range: 0–5000; default: `50`). Increase to give assistive technology time to finish speaking the previous line before Claude Code overwrites it |
+| `CLAUDE_AX_STARTUP_QUIET_MS` | Milliseconds to hold the first interface render in screen-reader mode (range: 0–600000; default: `3000`). Delays the initial TUI paint so a screen reader can finish reading the terminal state at startup before Claude Code takes over |
 | `CLAUDE_CODE_NATIVE_CURSOR` | Set to `1` to show the terminal's own cursor at the input caret position instead of Claude Code's custom cursor character |
 | `CLAUDE_CODE_SYNTAX_HIGHLIGHT` | Set to `0` to disable syntax highlighting in diff output |
 | `CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL` | Skip automatic IDE extension installation (`1` to skip) |

--- a/changelog/best-practice/claude-settings/changelog.md
+++ b/changelog/best-practice/claude-settings/changelog.md
@@ -1262,3 +1262,24 @@
 | 20 | LOW | New Env Var | Add `ANTHROPIC_BEDROCK_REGION_PREFIX` (v2.1.224 changelog — cross-region inference prefix). Not yet on official env-vars page; annotated as changelog-only | COMPLETE (annotated as changelog-only) — NEW |
 | 21 | LOW | New Settings | `crossSessionInbound` and `dialogExpiry` noted in v2.1.224 changelog. Not yet on official settings page — confidence 0.75 | ON HOLD (not yet on official docs — awaiting docs page update) — NEW |
 | 22 | LOW | Unverified Keys | v2.1.224 JWT masking options (`decode`, `maskClaims`, `awsPairs`/`sigv4`) for `sandbox.credentials.files[]` — not yet on official settings page, changelog-only, confidence 0.70 | ON HOLD (not yet on official docs — awaiting docs page update) — NEW |
+
+---
+
+## [2026-08-20 10:44 AM PKT] Claude Code v2.1.237
+
+| # | Priority | Type | Action | Status |
+|---|----------|------|--------|--------|
+| 1 | HIGH | Wrong Description | Fix `askUserQuestionTimeout` scope: report said "Only honored from project and local settings — managed and user settings values are ignored" but official docs say "User only, not read from project/local/managed" — scope was exactly backwards | ✅ COMPLETE (scope corrected to "User only") — NEW |
+| 2 | HIGH | New Settings | Add `crossSessionInbound` and `dialogExpiry` to General Settings — now confirmed on official settings page as v2.1.224+ keys | ✅ COMPLETE (both keys added to General Settings table) — RESOLVED (ON HOLD since 2026-08-07) |
+| 3 | HIGH | New Setting | Add `disableCommandPluginSources` managed-only setting (v2.1.229) to Managed-only policy keys — confirmed on official settings page | ✅ COMPLETE (added to Managed-only policy keys) — NEW |
+| 4 | HIGH | New Env Var | Add `ANTHROPIC_DEFAULT_MODEL` to Common Environment Variables — sets the default starting model per session, distinct from `ANTHROPIC_MODEL` which forces the model for the entire session. Confirmed on official env-vars page (v2.1.236) | ✅ COMPLETE (added after `ANTHROPIC_MODEL`) — NEW |
+| 5 | HIGH | Version Metadata | Update badge from v2.1.224 → v2.1.237 and header counts from "127+ settings / 311 env vars" to "133+ settings / 318 env vars" | ✅ COMPLETE (badge and header updated) — NEW |
+| 6 | MED | Changed Behavior | Update `outputStyle` to document "Concise" mode added in v2.1.237 alongside existing "default" and "Explanatory" values | ✅ COMPLETE (description updated with Concise mode) — NEW |
+| 7 | MED | New Setting | Add `spellcheck` to Display Settings — enables inline misspelled-word underlining via aspell/hunspell/ispell (v2.1.235 changelog) | ✅ COMPLETE (added to Display Settings table) — NEW |
+| 8 | MED | New Settings | Add `additionalMarketplaces` and `allowedMarketplaces` as alias keys in Plugin Settings — friendlier alternatives to `extraKnownMarketplaces` (v2.1.232 changelog) | ✅ COMPLETE (both aliases added to Plugin Settings table) — NEW |
+| 9 | MED | New Env Vars | Add `CLAUDE_AX_PREPARK_MS` and `CLAUDE_AX_STARTUP_QUIET_MS` — accessibility timing controls for screen-reader mode. Confirmed on official env-vars page | ✅ COMPLETE (both added after `CLAUDE_AX_SCREEN_READER`) — NEW |
+| 10 | MED | New Env Var | Add `CLAUDE_CODE_PROJECT_DIR_NAME` — overrides per-project transcript subdirectory name (v2.1.234 changelog) | ✅ COMPLETE (added near session env vars) — NEW |
+| 11 | MED | New Env Var | Add `CLAUDE_CODE_WEBFETCH_CACHE_TTL_MS` — configures WebFetch session URL cache TTL, default 15 minutes (v2.1.233 changelog) | ✅ COMPLETE (added near API timeout env vars) — NEW |
+| 12 | MED | New Env Var | Add `CLAUDE_CODE_WORKFLOW_PREFIX_STAGGER_MS` — stagger delay for workflow fan-out agent launches (v2.1.229 changelog) | ✅ COMPLETE (added after `CLAUDE_CODE_DISABLE_WORKFLOWS`) — NEW |
+| 13 | LOW | New Env Var | Add `notify_when_idle` — macOS/Linux system notification for idle cross-session SendMessage targeting (v2.1.236 changelog) | ✅ COMPLETE (added near Remote Control notification env vars) — NEW |
+| 14 | LOW | Unverified Keys | v2.1.224 JWT masking options (`decode`, `maskClaims`, `awsPairs`/`sigv4`) for `sandbox.credentials.files[]` — still changelog-only, not yet on official settings page | ✋ ON HOLD (changelog-only; 2 consecutive runs ON HOLD — escalation at 5) — RECURRING (first seen: 2026-08-07) |


### PR DESCRIPTION
## Summary

Automated drift check run on 2026-08-20 against Claude Code **v2.1.237**. All changes confirmed against official sources: [settings docs](https://code.claude.com/docs/en/settings), [env-vars docs](https://code.claude.com/docs/en/env-vars), and [CHANGELOG.md](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md).

### `best-practice/claude-settings.md` changes

**Resolved ON HOLD items (confirmed on official settings page)**
- Added `crossSessionInbound` — inbound cross-session message handling (`"accept"` / `"hold"` / `"refuse"`), v2.1.224+
- Added `dialogExpiry` — auto-dismiss deadline for forwarded dialogs, default `"5m"`, v2.1.224+

**Bug fix**
- Fixed `askUserQuestionTimeout` scope description: report said "only honored from project and local settings" but official docs say **User only**, not read from project/local/managed — scope was exactly backwards

**New settings keys**
- `disableCommandPluginSources` — managed-only, blocks command-sourced plugins (v2.1.229)
- `additionalMarketplaces` + `allowedMarketplaces` — friendlier aliases for `extraKnownMarketplaces` (v2.1.232)
- `spellcheck` — inline spell-checking via aspell/hunspell/ispell (v2.1.235)

**Changed descriptions**
- `outputStyle` — documented new **Concise** mode added in v2.1.237

**New environment variables**
- `ANTHROPIC_DEFAULT_MODEL` — sets default starting model (overrideable), confirmed on official env-vars page (v2.1.236)
- `CLAUDE_AX_PREPARK_MS` + `CLAUDE_AX_STARTUP_QUIET_MS` — screen-reader timing controls, confirmed on official env-vars page
- `CLAUDE_CODE_PROJECT_DIR_NAME` — per-project transcript subdirectory override (v2.1.234)
- `CLAUDE_CODE_WEBFETCH_CACHE_TTL_MS` — WebFetch session URL cache TTL, default 15 min (v2.1.233)
- `CLAUDE_CODE_WORKFLOW_PREFIX_STAGGER_MS` — workflow fan-out stagger delay (v2.1.229)
- `notify_when_idle` — macOS/Linux idle cross-session SendMessage notification (v2.1.236)

**Version metadata**
- Badge: `v2.1.224` → `v2.1.237`
- Header counts: `127+ settings / 311 env vars` → `133+ settings / 318 env vars`

### `changelog/best-practice/claude-settings/changelog.md`

Appended `[2026-08-20 10:44 AM PKT]` entry with 14 action items (13 COMPLETE, 1 ON HOLD). JWT masking keys (`decode`, `maskClaims`, `awsPairs`, `sigv4`) remain ON HOLD at 2 consecutive runs (escalation threshold: 5).

---
_Generated by [Claude Code](https://claude.ai/code/session_0188wAzXhn57C3Bv1Em8cAL4)_