### PR TITLE
Daily settings drift check — 2026-09-07 (Claude Code v2.1.263)

### DIFF
--- a/best-practice/claude-settings.md
+++ b/best-practice/claude-settings.md
@@ -1,9 +1,9 @@
 # Settings Best Practice
 
-![Last Updated](https://img.shields.io/badge/Last_Updated-Sep%2001%2C%202026%2010%3A39%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.252-blue?style=flat&labelColor=555)<br>
+![Last Updated](https://img.shields.io/badge/Last_Updated-Sep%2007%2C%202026%2010%3A47%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.263-blue?style=flat&labelColor=555)<br>
 [![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../.claude/settings.json)
 
-A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.252, Claude Code exposes **140+ settings** and **315+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
+A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.263, Claude Code exposes **145+ settings** and **320+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
 
 <table width="100%">
 <tr>
@@ -127,11 +127,11 @@ Within the managed tier, precedence is: server-managed > MDM/OS-level policies >
 | `workflowSizeGuideline` | string | `"medium"` | Advisory guideline for the dynamic workflow fleet size, settable from any settings file. Values: `"small"`, `"medium"` (default as of v2.1.219), `"large"`, `"unrestricted"`. The default fleet size now renders in the running-workflow status line. Use this key instead of `dynamicWorkflowSize` — it propagates from managed or user settings (v2.1.219) |
 | `disableBundledSkills` | boolean | `false` | Conceal Claude Code's built-in capabilities (bundled skills) from the model. When `true`, the model cannot invoke built-in skills. Paired with the `CLAUDE_CODE_DISABLE_BUNDLED_SKILLS` env var. Useful when strict plugin-only customization is required (v2.1.169) |
 | `disableArtifact` | boolean | `false` | Disable the Artifact web publishing tool. When `true`, Claude cannot create or publish web artifacts. Can be set at any scope |
-| `enableArtifact` | boolean | - | **(v2.1.196+)** User-level opt-in for the Artifact web publishing tool. When set to `true`, enables Artifact for the user even when no organization policy requires it. `disableArtifact: true` takes precedence and overrides this setting |
+| `enableArtifact` | boolean | - | **(v2.1.196+)** Scope exception key for the Artifact web publishing tool. `false` disables Artifact for every session the file applies to — functions as a turn-off, not an opt-in. `true` is the same as unset and cannot re-enable Artifact when a higher-precedence source has set it `false`. **`false` from any scope wins** (strict-value exception). Use `disableArtifact: true` as the conventional disabler |
 | `feedbackSurveyRate` | number | - | Probability (0–1) that the session quality survey appears when eligible. Enterprise admins can control how often the survey is shown. Example: `0.05` = 5% of eligible sessions |
 | `advisorModel` | string | - | Model for the server-side advisor tool. Accepts a model alias (`opus`, `sonnet`) or a full model ID. When unset, the advisor uses the session model. Requires v2.1.98+. **v2.1.210+:** Setting `"fable"` no longer attaches an advisor — Fable 5 is temporarily unavailable in the advisor picker; use `"opus"` or `"sonnet"` instead |
 | `respondToBashCommands` | boolean | `true` | Whether Claude automatically responds after a `!` shell command completes. Set to `false` to disable the automatic follow-up response when a `!` bash command finishes (v2.1.186) |
-| `askUserQuestionTimeout` | string | `"never"` | How long to wait before an unanswered AskUserQuestion dialog auto-continues without the user. Values: `"60s"`, `"5m"`, `"10m"`, `"never"` (no auto-continue — the default). Set via `/config` as **Question auto-continue timeout**. Pairs with the `CLAUDE_AFK_TIMEOUT_MS` env var; the env var applies only when this setting is set to a duration. Only honored from project and local settings — managed and user settings values are ignored. (v2.1.200) |
+| `askUserQuestionTimeout` | string | `"never"` | How long to wait before an unanswered AskUserQuestion dialog auto-continues without the user. Values: `"60s"`, `"5m"`, `"10m"`, `"never"` (no auto-continue — the default). Set via `/config` as **Question auto-continue timeout**. Pairs with the `CLAUDE_AFK_TIMEOUT_MS` env var; the env var applies only when this setting is set to a duration. **Scope: `User or managed`** — project and local settings values are ignored (v2.1.200) |
 | `theme` | string | `"dark"` | UI color theme. Values: `"auto"` (follow OS), `"dark"`, `"light"`, `"dark-daltonized"`, `"light-daltonized"`, `"dark-ansi"`, `"light-ansi"`, `"custom:<slug>"`, `"custom:<plugin>:<slug>"`. Plugin-provided themes use the `custom:` prefix |
 | `verbose` | boolean | `false` | Show full tool output instead of truncated summaries. Equivalent to running with `--verbose`; persists the verbose view across sessions |
 | `switchModelsOnFlag` | boolean | `true` | Automatically switch to the fallback model when a safety classifier flags a request. When `false`, flagged requests are blocked rather than rerouted (v2.1.170) |
@@ -142,6 +142,8 @@ Within the managed tier, precedence is: server-managed > MDM/OS-level policies >
 | `autoContinueAtUsageLimit` | boolean | - | When `true`, Claude Code automatically continues the session when a usage limit (API rate limit, daily cap) resets instead of waiting for user input. Appears in `/config` as **Auto-continue at usage limit** (v2.1.234) |
 | `feedbackDrafts` | boolean | `true` | When `true`, Claude Code queues bug-report drafts in the background when it encounters surprising errors. Set to `false` to disable background draft queuing. Gates the `SendFeedback` tool. Appears in `/config` as **Feedback drafts** (v2.1.247) |
 | `desktopSessionCleanupPeriodDays` | number | - | Age cutoff in days for cleaning up desktop session data (separate from transcript cleanup controlled by `cleanupPeriodDays`). Inactive desktop session artifacts older than this threshold are removed during the startup cleanup sweep (v2.1.248) |
+| `bashOutputMaxChars` | number | unset (30k) | How many characters of a successful Bash or PowerShell command's output Claude receives inline. When output exceeds the limit, Claude Code saves it to a file and Claude receives a short preview + file path. Value clamped to `4000`–`128000`. When set, **overrides** the `BASH_MAX_OUTPUT_LENGTH` env var. Requires v2.1.261+ |
+| `taskOutputMaxChars` | number | unset (32k) | How many characters of a background task's output Claude receives inline when it reads the task via the `TaskOutput` tool. When output is longer, Claude receives the most recent characters. Value clamped to `4000`–`128000`. When set, **overrides** the `TASK_MAX_OUTPUT_LENGTH` env var. Requires v2.1.261+ |
 
 **Example:**
 ```json
@@ -289,9 +291,10 @@ Control what tools and operations Claude can perform.
 | `permissions.ask` | array | Rules requiring user confirmation |
 | `permissions.deny` | array | Rules blocking tool use (highest precedence) |
 | `permissions.additionalDirectories` | array | Extra directories Claude can access |
-| `permissions.defaultMode` | string | Default permission mode. Valid values: `"default"`, `"manual"` (alias for `"default"`, v2.1.200), `"acceptEdits"`, `"dontAsk"`, `"bypassPermissions"`, `"auto"`, `"plan"`. In Remote environments, only `acceptEdits` and `plan` are honored (v2.1.70+). **Note (v2.1.142):** `"auto"` is ignored when set in project (`.claude/settings.json`) or local settings — a repository cannot grant itself auto mode; use `~/.claude/settings.json` instead |
+| `permissions.defaultMode` | string | Default permission mode. Valid values: `"default"`, `"manual"` (alias for `"default"`, v2.1.200), `"acceptEdits"`, `"dontAsk"`, `"bypassPermissions"`, `"auto"`, `"plan"`. In Remote environments, only `acceptEdits` and `plan` are honored (v2.1.70+). **Note (v2.1.142):** `"auto"` is ignored when set in project (`.claude/settings.json`) or local settings — a repository cannot grant itself auto mode; use `~/.claude/settings.json` instead. **Note (v2.1.257):** `"bypassPermissions"` is also now ignored from project and local settings (before v2.1.257, it took effect from any file) |
 | `permissions.disableBypassPermissionsMode` | string | Prevent bypass mode activation |
 | `permissions.skipDangerousModePermissionPrompt` | boolean | Skip the confirmation prompt shown before entering bypass permissions mode via `--dangerously-skip-permissions` or `defaultMode: "bypassPermissions"`. Ignored when set in project settings (`.claude/settings.json`) to prevent untrusted repositories from auto-bypassing the prompt |
+| `permissions.blockReadsOutsideWorkingDirectories` | boolean | **(v2.1.257+)** When `true`, blocks file reads outside the session's working directories (using Read, Grep, Glob, LSP tools) in every permission mode including `bypassPermissions`. Bash commands reading outside paths still prompt even in auto mode. `true` from any scope applies — a project file can enable the block but cannot lift a block set by another source. Claude Code also writes `true` here when you choose to block outside reads on auto mode's first-read prompt |
 | `allowManagedPermissionRulesOnly` | boolean | **(Managed only)** Only managed permission rules apply; user/project `allow`, `ask`, `deny` rules are ignored |
 | `autoMode` | object | Customize what the [auto mode](https://code.claude.com/docs/en/permission-modes#eliminate-prompts-with-auto-mode) classifier blocks and allows. Contains `environment` (trusted infrastructure descriptions), `allow` (exceptions to block rules), `soft_deny` (block rules), and `hard_deny` (unconditional block rules — cannot be overridden by `allow` exceptions or the `$defaults` sentinel, v2.1.136) — all arrays of prose strings. Also accepts `classifyAllShell` (boolean, default `false`): when `true`, routes all Bash/PowerShell commands through the auto-mode classifier instead of only arbitrary-code-execution patterns, giving stricter coverage at the cost of more classifier calls (v2.1.193). **Not read from shared project settings** (`.claude/settings.json`) **or local settings** (`.claude/settings.local.json`) to prevent repo injection (v2.1.207 removed local-settings scope). Available in user and managed settings only; configure in `~/.claude/settings.json`. Setting `allow` or `soft_deny` **replaces** the entire default list for that section unless you include the literal string `"$defaults"` in the array — the sentinel inherits the built-in rules at that position so custom entries are added alongside them (v2.1.118). Run `claude auto-mode defaults` to see built-in rules before customizing |
 | `disableAutoMode` | string | Set to `"disable"` to prevent [auto mode](https://code.claude.com/docs/en/permission-modes#eliminate-prompts-with-auto-mode) from being activated. Removes `auto` from the `Shift+Tab` cycle and rejects `--permission-mode auto` at startup. Can be set at any settings level; most useful in managed settings where users cannot override it |
@@ -414,8 +417,8 @@ Configure Model Context Protocol servers for extended capabilities.
 | `enableAllProjectMcpServers` | boolean | Any | Auto-approve all `.mcp.json` servers. **Security note (v2.1.196):** `.mcp.json` servers no longer self-approve — explicit opt-in via `enableAllProjectMcpServers: true` or `enabledMcpjsonServers` is now required |
 | `enabledMcpjsonServers` | array | Any | Allowlist specific server names |
 | `disabledMcpjsonServers` | array | Any | Blocklist specific server names |
-| `allowedMcpServers` | array | Managed only | Allowlist with name/command/URL matching |
-| `deniedMcpServers` | array | Managed only | Blocklist with matching |
+| `allowedMcpServers` | array | Any | Allowlist with name/command/URL matching. Entries merge across all settings files. Once the list contains any `serverCommand` entry, stdio servers must match a `serverCommand` (name match no longer admits them); same logic for `serverUrl` and remote servers |
+| `deniedMcpServers` | array | Any | Blocklist with matching. Entries merge across all settings files. Takes precedence over `allowedMcpServers`. Also covers claude.ai connectors Claude Code fetches itself |
 | `allowManagedMcpServersOnly` | boolean | Managed only | Only allow MCP servers explicitly listed in managed allowlist |
 | `channelsEnabled` | boolean | Managed only | Allow [channels](https://code.claude.com/docs/en/channels) for Team and Enterprise users. When unset or `false`, channel message delivery is blocked regardless of `--channels` flag |
 | `allowedChannelPlugins` | array | Managed only | Allowlist of channel plugins that may push messages. Replaces the default Anthropic allowlist when set. Undefined = fall back to the default, empty array = block all channel plugins. Requires `channelsEnabled: true`. Each entry is an object with `marketplace` and `plugin` fields (v2.1.84) |
@@ -428,7 +431,7 @@ Configure Model Context Protocol servers for extended capabilities.
 {
   "allowedMcpServers": [
     { "serverName": "github" },
-    { "serverCommand": "npx @modelcontextprotocol/*" },
+    { "serverCommand": ["npx", "-y", "@modelcontextprotocol/server-filesystem"] },
     { "serverUrl": "https://mcp.company.com/*" }
   ],
   "deniedMcpServers": [
@@ -606,7 +609,8 @@ Configure Claude Code plugins and marketplaces.
 | `"sonnet[1m]"` | Sonnet with 1M token context |
 | `"opus[1m]"` | Opus with 1M token context (default on Max, Team, and Enterprise since v2.1.75) |
 | `"opusplan"` | Opus for planning, Sonnet for execution |
-| `"fable"` | Claude Fable 5 — long-horizon reasoning model. Anthropic API only (v2.1.170+). Fable 5 includes 1M context by default; the `[1m]` suffix is auto-stripped, so `fable[1m]` is redundant (v2.1.173) |
+| `"best"` | Resolves to the latest Fable model where it's available to you, otherwise the same model as `opus` |
+| `"fable"` | **Claude Fable 5.1** (since v2.1.255; before that, Fable 5) — long-horizon reasoning model. Anthropic API only. Fable 5.1 requires v2.1.255+; select Fable 5 by full model ID (`claude-fable-5`) if needed. Fable includes 1M context by default; the `[1m]` suffix is auto-stripped, so `fable[1m]` is redundant (v2.1.173). Saved `claude-fable-5` user-settings values are auto-migrated to the `fable` alias once on v2.1.255+ |
 
 **Example:**
 ```json
@@ -707,10 +711,12 @@ Configure via `env` key:
 | `wheelScrollAccelerationEnabled` | boolean | `true` | Disable mouse-wheel scroll acceleration in fullscreen mode. Set to `false` to use fixed per-tick scroll steps instead of the OS-level acceleration curve (v2.1.174) |
 | `footerLinksRegexes` | array | - | Array of objects matched against **turn output** (tool results, file contents, fetched pages, Claude's responses) to display as link badges in the footer row. Each entry is `{type, pattern, url, label}` where `pattern` is a regex with named capture groups and `url`/`label` may reference those groups. Matched patterns produce a clickable badge at the bottom of the chat UI. Capped at 5 badges per turn; URL max 2048 chars; allowed schemes: `http`, `https`, `vscode`, `cursor`, `windsurf`, `zed`, `jetbrains`, `idea`, `slack`, `linear`, `notion`, `figma`, `vscode-insiders`. User/`--settings`/managed only (v2.1.176) |
 | `emojiCompletionEnabled` | boolean | `true` | Enable emoji shortcode autocomplete in the prompt input (e.g., `:tada:` → 🎉). Set to `false` to disable. Requires v2.1.217+ |
-| `keybindingFlavor` | string | - | Keyboard shortcut style for word deletion. Set to `"readline"` for Bash/GNU readline-style Ctrl+W behavior (delete word backward to whitespace boundary). When unset, uses the default word-deletion behavior (v2.1.236) |
+| `keybindingFlavor` | string | - | **DEPRECATED since v2.1.261 — accepted but has no effect.** The prompt's word-editing keys now always follow readline conventions. Previously set to `"readline"` or `"classic"` to choose Ctrl+W behavior (v2.1.236–v2.1.260) |
 | `spellcheck` | object | - | Spell-check underlines in the prompt input. Requires an installed spell-check binary (`aspell`, `hunspell`, or `ispell`). Object with `enabled` (boolean) and `binary` (string — path to the spell checker). Set via `/config`. Requires v2.1.235+ (binary path required as of v2.1.236) |
 | `promptCacheTtl` | string | - | Keep the 1-hour prompt cache tier active on the main conversation for API-key and cloud-provider users who have access to extended cache TTLs. When unset, the default 5-minute cache TTL applies. Example: `"1h"`. Pairs with `subagentPromptCacheTtl` (v2.1.243+) |
 | `subagentPromptCacheTtl` | string | - | Keep the 5-minute prompt cache tier active for subagents when set. Controls the cache TTL for subagent turns separately from the main conversation. Use with `promptCacheTtl` for independent control of caching behavior in orchestrated workflows (v2.1.243+) |
+| `timeFormat` | string | `"auto"` | **(v2.1.257+)** How Claude Code writes times in the interface (e.g., turn-end `done 6:05 PM` messages and transcript-view timestamps). Presets: `"auto"` (locale/built-in format), `"12-hour"`, `"24-hour"`, `"24-hour-utc"` (UTC with `Z` suffix, ignores `timeZone`). Any string containing `%` is a strftime pattern (e.g., `"%H:%M"`). Set via `/config` → **Time format** |
+| `timeZone` | string | system TZ | **(v2.1.257+)** Show interface times in an IANA time zone name (e.g., `"UTC"`, `"Europe/Dublin"`, `"Asia/Karachi"`) instead of your system timezone. Ignored when `timeFormat` is `"24-hour-utc"`. Must be set in a settings file — `/config` has no row for it |
 
 ### Global Config Settings (`~/.claude.json`)
 
@@ -1105,6 +1111,7 @@ Set environment variables for all Claude Code sessions.
 | `CLAUDE_CODE_GIT_BASH_PATH` | Windows only: path to the Git Bash executable (`bash.exe`). Use when Git Bash is installed but not in your PATH |
 | `DISABLE_COST_WARNINGS` | Disable cost warning messages |
 | `CLAUDE_CODE_SUBAGENT_MODEL` | Default model for subagents (e.g., `haiku`, `sonnet`). **As of v2.1.238 (breaking change):** changed from an override to a default — agent definitions that explicitly set a model and subagent tool calls that pass an explicit model now take precedence over this variable |
+| `CLAUDE_CODE_SUBAGENT_MODEL_FORCE` | Apply `CLAUDE_CODE_SUBAGENT_MODEL` (or the main session model if that var is unset) to **every** subagent, ignoring per-spawn and agent-definition model overrides. Takes precedence over `CLAUDE_CODE_SUBAGENT_MODEL`'s default-only behavior (v2.1.257) *(in v2.1.257 changelog, not yet on official env-vars page)* |
 | `CLAUDE_CODE_FORWARD_SUBAGENT_TEXT` | Set to `1` to forward subagent streaming text output to the parent session in real time. By default, subagent output is buffered until the subagent completes. As of v2.1.219, forwarding also works for nested subagents at depth 2+ (v2.1.211) |
 | `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB` | Set to `1` to strip Anthropic and cloud provider credentials from subprocess environments (Bash tool, hooks, MCP stdio servers). Use for defense-in-depth when subprocesses should not inherit API keys (v2.1.83) |
 | `CLAUDE_CODE_SCRIPT_CAPS` | JSON object limiting how many times specific scripts may be invoked per session when `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB` is set. Keys are substrings matched against the command text; values are integer call limits. For example, `{"deploy.sh": 2}` allows `deploy.sh` to be called at most twice. Matching is substring-based; runtime fan-out via `xargs` or `find -exec` is not detected — this is a defense-in-depth control |
@@ -1269,6 +1276,7 @@ Set environment variables for all Claude Code sessions.
 | `claude plugin details <plugin>` | Show the plugin's component inventory (commands, agents, skills, hooks) and the per-session context-token cost it adds. Useful for auditing token spend before enabling a plugin in a managed environment (v2.1.139) |
 | `/keybindings` | Configure custom keyboard shortcuts |
 | `/skills` | View and manage skills |
+| `/skill-doctor` | Show which loaded skills go unused in this session and what each costs in context tokens, so you can prune them. Useful for auditing token spend in long sessions (v2.1.263) |
 | `/permissions` | View and manage permission rules |
 | `/usage-credits` | View remaining usage credits and limits. Renamed from `/extra-usage` in v2.1.144 (the old name still works) |
 | `claude gateway` | Manage Claude Gateway connections for organization-managed deployments. Requires `forceLoginMethod: "gateway"` in managed settings (v2.1.195) |

--- a/changelog/best-practice/claude-settings/changelog.md
+++ b/changelog/best-practice/claude-settings/changelog.md
@@ -1283,3 +1283,25 @@
 | 12 | HIGH | Wrong Description | Fix `teammateDefaultModel` (Global Config) — removed in v2.1.251; teammates now inherit the lead's model by default. Marked as removed. Confirmed in v2.1.251 changelog | ✅ COMPLETE (marked removed) — NEW |
 | 13 | HIGH | Hook Count | Update hooks redirect blurb from "26 hook events" to "28 hook events" — `PreModelSwitch` and `PostModelSwitch` added in v2.1.252. Confirmed in v2.1.252 changelog | ✅ COMPLETE (count updated) — NEW |
 | 14 | MED | Missing Env Vars | Add 6 missing env vars: `ANTHROPIC_DEFAULT_MODEL` (v2.1.236+, last-resort model fallback), `CLAUDE_CODE_PROJECT_DIR_NAME` (v2.1.234+, transcript dir name), `CLAUDE_CODE_TOOL_MEMORY_LIMIT` (v2.1.233, Linux cgroup memory cap), `CLAUDE_CODE_WEBFETCH_CACHE_TTL_MS` (v2.1.233, WebFetch cache TTL), `CLAUDE_CODE_ENABLE_TODO_TOOLS` (v2.1.234, legacy todo tools), `CLAUDE_CODE_WORKFLOW_PREFIX_STAGGER_MS` (v2.1.229, agent launch stagger). Confirmed in changelog | ✅ COMPLETE (all 6 added) — NEW |
+
+---
+
+## [2026-09-07 10:53 AM PKT] Claude Code v2.1.263
+
+| # | Priority | Type | Action | Status |
+|---|----------|------|--------|--------|
+| 1 | HIGH | Version Metadata | Update version badge v2.1.252 → v2.1.263; update header counts from "140+ settings / 315+ env vars" to "145+ settings / 320+ env vars". Confirmed via official settings-reference page | ✅ COMPLETE (badge and header updated) — NEW |
+| 2 | HIGH | Missing Settings | Add `bashOutputMaxChars` and `taskOutputMaxChars` (number, unset/30k–32k, v2.1.261+) to General Settings — inline output cap for Bash and background-task tools, clamped 4000–128000. Confirmed in v2.1.261 changelog | ✅ COMPLETE (both added to General Settings table) — NEW |
+| 3 | HIGH | Missing Settings | Add `permissions.blockReadsOutsideWorkingDirectories` (boolean, v2.1.257+) to Permission Keys — blocks file reads outside session working dirs in all permission modes. Confirmed in settings-reference | ✅ COMPLETE (added to Permission Keys table) — NEW |
+| 4 | HIGH | Missing Settings | Add `timeFormat` (string, "auto", v2.1.257+) and `timeZone` (string, system TZ, v2.1.257+) to Display Settings. Confirmed in v2.1.257 changelog and settings-reference | ✅ COMPLETE (both added to Display Settings table) — NEW |
+| 5 | HIGH | Wrong Description | Fix `enableArtifact` semantics — `false` disables artifacts entirely; `true` is same as unset (strict-value exception from any scope). Original description was inverted. Confirmed in settings-reference | ✅ COMPLETE (description corrected) — NEW |
+| 6 | HIGH | Wrong Scope | Fix `askUserQuestionTimeout` scope — honored from User or managed settings only; project and local values are silently ignored. Confirmed in settings-reference | ✅ COMPLETE (scope corrected) — NEW |
+| 7 | HIGH | Wrong Scope | Fix `allowedMcpServers` and `deniedMcpServers` scope from "Managed only" → "Any". Entry-level `serverCommand` confirms this is used in project settings. Confirmed in settings-reference | ✅ COMPLETE (scope corrected) — NEW |
+| 8 | HIGH | Wrong Example | Fix `allowedMcpServers.serverCommand` from string to array format: `["npx", "-y", "@modelcontextprotocol/server-filesystem"]`. Confirmed in settings-reference | ✅ COMPLETE (example corrected) — NEW |
+| 9 | HIGH | Model Config | Add `"best"` model alias (resolves to latest Fable where available, else Opus equivalent). Update `"fable"` → Claude Fable 5.1 (since v2.1.255). Confirmed in v2.1.255 and v2.1.263 changelog | ✅ COMPLETE (added alias, updated description) — NEW |
+| 10 | HIGH | Wrong Description | Add `permissions.defaultMode` note: as of v2.1.257, `"bypassPermissions"` value is also ignored when set from project/local settings. Confirmed in v2.1.257 changelog | ✅ COMPLETE (note added) — NEW |
+| 11 | MED | Deprecated Setting | Add `keybindingFlavor` deprecation notice — DEPRECATED since v2.1.261, accepted but has no effect. Confirmed in v2.1.261 changelog | ✅ COMPLETE (deprecation note added) — NEW |
+| 12 | MED | Missing Env Var | Add `CLAUDE_CODE_SUBAGENT_MODEL_FORCE` (v2.1.257) — forces model onto all subagents overriding per-spawn/agent-definition overrides. In v2.1.257 changelog; not yet on official env-vars page | ✅ COMPLETE (added with changelog-only annotation) — NEW |
+| 13 | MED | Missing Command | Add `/skill-doctor` to Useful Commands — shows unused skills and their context token cost (v2.1.263). Confirmed in v2.1.263 changelog | ✅ COMPLETE (added to Useful Commands table) — NEW |
+| 14 | LOW | Persistent Suspect | `OTEL_LOG_TOOL_DETAILS` — 56th consecutive ON HOLD run. Not on official env-vars page. Rule 10B escalation: confirms presence in JSON schema only; annotated "in JSON schema, not on official page" | ✋ ON HOLD (schema-only annotation added in prior run; monitoring) — RECURRING (first seen: 2026-03-05) |
+| 15 | LOW | Persistent Suspect | `CLAUDE_CODE_RETRY_WATCHDOG` — confirmed on official env-vars page in v2.1.199 changelog. Annotation "not yet on official env-vars page" removed in prior run | ✅ COMPLETE (resolved in prior run) — RESOLVED |


### PR DESCRIPTION
## Summary

Automated daily drift audit comparing `best-practice/claude-settings.md` against the official Claude Code settings reference, changelog (v2.1.252 → v2.1.263), and env-vars page. All changes are confirmed by official sources (Rule 8A).

**10 HIGH priority items fixed:**
- Version badge/header updated: v2.1.252 → v2.1.263, counts 140+/315+ → 145+/320+
- `enableArtifact` semantics corrected (description was inverted — `false` disables, `true` is same as unset)
- `askUserQuestionTimeout` scope corrected (project/local silently ignored; User or managed only)
- `bashOutputMaxChars` + `taskOutputMaxChars` added — inline output caps, clamped 4000–128000, v2.1.261+
- `permissions.blockReadsOutsideWorkingDirectories` added — blocks reads outside working dirs in all modes, v2.1.257+
- `allowedMcpServers` / `deniedMcpServers` scope fixed: "Managed only" → "Any" (they work in project settings)
- `allowedMcpServers.serverCommand` example fixed: string → array (correct format per settings-reference)
- `"best"` model alias added; `"fable"` updated to Claude Fable 5.1 (since v2.1.255)
- `permissions.defaultMode` note added: `"bypassPermissions"` now ignored from project/local (v2.1.257)
- `timeFormat` + `timeZone` added to Display Settings — 12h/24h/UTC/strftime + IANA TZ, v2.1.257+

**3 MEDIUM priority items fixed:**
- `keybindingFlavor` deprecation notice added (DEPRECATED v2.1.261, accepted but no effect)
- `CLAUDE_CODE_SUBAGENT_MODEL_FORCE` added to env vars — forces model onto all subagents, v2.1.257+
- `/skill-doctor` added to Useful Commands — shows unused skills + context cost, v2.1.263

## Files changed

| File | Change |
|------|--------|
| `best-practice/claude-settings.md` | 13 HIGH/MED fixes applied; badge + header updated |
| `changelog/best-practice/claude-settings/changelog.md` | New entry appended: `[2026-09-07 10:53 AM PKT] Claude Code v2.1.263` |

## Verification log (checklist rules executed)

All 26 verification checklist rules (1A–1I, 2A–2D, 3A–3D, 4A, 5A–5D, 6A–6B, 7A, 8A, 9A–9C, 10A–10C) executed. No new rule additions were required this run.

All hyperlinks validated: 2 local file links (OK), 10 external URLs (OK, including `json.schemastore.org` HTTP 200), GitHub CHANGELOG.md link (403 via proxy, confirmed live). No broken links.

## Source confirmation

Every change traced to official documentation:
- Settings Reference: `code.claude.com/docs/en/settings-reference`
- Env Vars: `code.claude.com/docs/en/env-vars`
- Changelog: `github.com/anthropics/claude-code/blob/main/CHANGELOG.md` (v2.1.253–v2.1.263)

> Do not merge yourself — leave open for human review.

---
Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01X5wF6h175smJweXbnVoaKo

---
_Generated by [Claude Code](https://claude.ai/code/session_01X5wF6h175smJweXbnVoaKo)_