### PR TITLE
Daily settings drift check — 2026-09-08 (Claude Code v2.1.263)

### DIFF
--- a/best-practice/claude-settings.md
+++ b/best-practice/claude-settings.md
@@ -1,9 +1,9 @@
 # Settings Best Practice
 
-![Last Updated](https://img.shields.io/badge/Last_Updated-Sep%2001%2C%202026%2010%3A39%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.252-blue?style=flat&labelColor=555)<br>
+![Last Updated](https://img.shields.io/badge/Last_Updated-Sep%2008%2C%202026%2010%3A47%20AM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.263-blue?style=flat&labelColor=555)<br>
 [![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../.claude/settings.json)
 
-A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.252, Claude Code exposes **140+ settings** and **315+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
+A comprehensive guide to all available configuration options in Claude Code's `settings.json` files. As of v2.1.263, Claude Code exposes **220+ settings** and **315+ environment variables** (use the `"env"` field in `settings.json` to avoid wrapper scripts).
 
 <table width="100%">
 <tr>
@@ -60,6 +60,7 @@ Within the managed tier, precedence is: server-managed > MDM/OS-level policies >
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| `managedSourcesBehavior` | string | `"first-wins"` | Controls how multiple managed setting sources (server-managed, MDM, file) are combined when more than one is present. `"first-wins"`: the highest-precedence source applies and others are ignored. `"merge"`: sources are merged with higher-precedence sources winning scalar conflicts. Requires v2.1.259+ |
 | `parentSettingsBehavior` | string | `"first-wins"` | Controls whether managed settings supplied programmatically by an embedding host process (SDK parent) apply when an admin-deployed managed tier is also present. `"first-wins"`: parent-supplied settings are dropped and only the admin tier applies. `"merge"`: parent-supplied settings apply under the admin tier and are filtered so they can **tighten** policy but not loosen it. Requires v2.1.133+ |
 | `policyHelper` | object | - | Admin-deployed executable that computes managed settings dynamically at startup. Object shape: `{path: string, timeoutMs?: number, refreshIntervalMs?: number}` — `path` points at the helper binary; `timeoutMs` caps the wait (omit or `0` for no timeout); `refreshIntervalMs` controls re-runs at session start (omit for startup-only, `0` disables, otherwise must be ≥ `60000`). Only honored from MDM or a system `managed-settings.json` file (never from user/project settings). **When configured, `policyHelper` output is the sole active managed source — other managed-tier sources (server-managed, MDM, file) are ignored for that run.** Requires v2.1.136+ |
 | `requiredMinimumVersion` | string | - | **(Managed only)** Prevents Claude Code from starting if the installed version is below this floor. CLI exits with an error prompting the user to upgrade. Complements `minimumVersion` (which controls auto-update floor) — this one enforces at startup. Example: `"2.1.163"` |
@@ -92,6 +93,8 @@ Within the managed tier, precedence is: server-managed > MDM/OS-level policies >
 | `minimumVersion` | string | - | Prevent the auto-updater from downgrading below a specific version. Automatically set when switching to the stable channel and choosing to stay on the current version until stable catches up. Used with `autoUpdatesChannel` |
 | `alwaysThinkingEnabled` | boolean | `false` | Enable extended thinking by default for all sessions |
 | `thinkingBudgetTokens` | number | - | Set a fixed token budget for extended thinking per response. When set, limits the number of thinking tokens to the specified value. If unset, Claude Code uses a dynamic budget based on the model and effort level. Works alongside `alwaysThinkingEnabled` *(not in official settings page — unverified)* |
+| `bashOutputMaxChars` | number | `30000` | Maximum number of characters captured from a single Bash tool invocation's combined stdout+stderr. Output beyond this limit is truncated. Increase for commands that produce large outputs (v2.1.256+) |
+| `taskOutputMaxChars` | number | `30000` | Maximum number of characters captured from a subagent task's output. Controls how much of a subagent's response is visible to the orchestrating agent. Increase for complex multi-step tasks that produce verbose output (v2.1.256+) |
 | `skipWebFetchPreflight` | boolean | `false` | Skip the WebFetch domain safety check that sends each requested hostname to `api.anthropic.com` before fetching. Set to `true` in environments that block outbound traffic to Anthropic, such as Bedrock, Vertex AI, or Foundry deployments with restrictive egress |
 | `availableModels` | array | - | Restrict which models users can select via `/model`, `--model`, Config tool, or `ANTHROPIC_MODEL`. Does not affect the Default option. As of v2.1.172, also constrains the model picker for subagent dispatching and the `advisorModel` picker. Use `enforceAvailableModels: true` to additionally constrain the Default model option. Example: `["sonnet", "haiku"]` |
 | `enforceAvailableModels` | boolean | `false` | **(Managed only)** When `true`, the `availableModels` allowlist also constrains the Default model option — users cannot select a model outside the allowlist even via the Default slot. Without this flag, `availableModels` leaves the Default option unrestricted. Pair with `availableModels` for full model lockdown (v2.1.175) |
@@ -289,12 +292,14 @@ Control what tools and operations Claude can perform.
 | `permissions.ask` | array | Rules requiring user confirmation |
 | `permissions.deny` | array | Rules blocking tool use (highest precedence) |
 | `permissions.additionalDirectories` | array | Extra directories Claude can access |
-| `permissions.defaultMode` | string | Default permission mode. Valid values: `"default"`, `"manual"` (alias for `"default"`, v2.1.200), `"acceptEdits"`, `"dontAsk"`, `"bypassPermissions"`, `"auto"`, `"plan"`. In Remote environments, only `acceptEdits` and `plan` are honored (v2.1.70+). **Note (v2.1.142):** `"auto"` is ignored when set in project (`.claude/settings.json`) or local settings — a repository cannot grant itself auto mode; use `~/.claude/settings.json` instead |
+| `permissions.defaultMode` | string | Default permission mode. Valid values: `"default"`, `"manual"` (alias for `"default"`, v2.1.200), `"acceptEdits"`, `"dontAsk"`, `"bypassPermissions"`, `"auto"`, `"plan"`. In Remote environments, only `acceptEdits` and `plan` are honored (v2.1.70+). **Note (v2.1.142):** `"auto"` is ignored when set in project (`.claude/settings.json`) or local settings — a repository cannot grant itself auto mode; use `~/.claude/settings.json` instead. **Note (v2.1.258+):** `"bypassPermissions"` is also ignored when set in project or local settings — repositories cannot self-grant bypass mode; set in `~/.claude/settings.json` or managed settings only |
 | `permissions.disableBypassPermissionsMode` | string | Prevent bypass mode activation |
 | `permissions.skipDangerousModePermissionPrompt` | boolean | Skip the confirmation prompt shown before entering bypass permissions mode via `--dangerously-skip-permissions` or `defaultMode: "bypassPermissions"`. Ignored when set in project settings (`.claude/settings.json`) to prevent untrusted repositories from auto-bypassing the prompt |
+| `permissions.blockReadsOutsideWorkingDirectories` | boolean | When `true`, blocks all `Read` tool calls that target paths outside the working directory or `additionalDirectories`. Acts as a deny rule without requiring an explicit glob pattern. Useful for restricting Claude to only files within the project (v2.1.256+) |
+| `skipAutoPermissionPrompt` | boolean | `false` | Skip the one-time confirmation prompt shown before entering auto-permission mode for the first time. When `true`, auto mode activates without displaying the introductory prompt. Useful for scripted or CI environments where interactive prompts are unwanted (v2.1.258+) |
 | `allowManagedPermissionRulesOnly` | boolean | **(Managed only)** Only managed permission rules apply; user/project `allow`, `ask`, `deny` rules are ignored |
 | `autoMode` | object | Customize what the [auto mode](https://code.claude.com/docs/en/permission-modes#eliminate-prompts-with-auto-mode) classifier blocks and allows. Contains `environment` (trusted infrastructure descriptions), `allow` (exceptions to block rules), `soft_deny` (block rules), and `hard_deny` (unconditional block rules — cannot be overridden by `allow` exceptions or the `$defaults` sentinel, v2.1.136) — all arrays of prose strings. Also accepts `classifyAllShell` (boolean, default `false`): when `true`, routes all Bash/PowerShell commands through the auto-mode classifier instead of only arbitrary-code-execution patterns, giving stricter coverage at the cost of more classifier calls (v2.1.193). **Not read from shared project settings** (`.claude/settings.json`) **or local settings** (`.claude/settings.local.json`) to prevent repo injection (v2.1.207 removed local-settings scope). Available in user and managed settings only; configure in `~/.claude/settings.json`. Setting `allow` or `soft_deny` **replaces** the entire default list for that section unless you include the literal string `"$defaults"` in the array — the sentinel inherits the built-in rules at that position so custom entries are added alongside them (v2.1.118). Run `claude auto-mode defaults` to see built-in rules before customizing |
-| `disableAutoMode` | string | Set to `"disable"` to prevent [auto mode](https://code.claude.com/docs/en/permission-modes#eliminate-prompts-with-auto-mode) from being activated. Removes `auto` from the `Shift+Tab` cycle and rejects `--permission-mode auto` at startup. Can be set at any settings level; most useful in managed settings where users cannot override it |
+| `disableAutoMode` | boolean | Set to `true` to prevent [auto mode](https://code.claude.com/docs/en/permission-modes#eliminate-prompts-with-auto-mode) from being activated. Removes `auto` from the `Shift+Tab` cycle and rejects `--permission-mode auto` at startup. Can be set at any settings level; most useful in managed settings where users cannot override it |
 | `useAutoModeDuringPlan` | boolean | Whether plan mode uses auto mode semantics when auto mode is available. Default: `true`. Not read from shared project settings (`.claude/settings.json`). Appears in `/config` as "Use auto mode during plan" |
 
 ### Permission Modes
@@ -387,7 +392,7 @@ Control what tools and operations Claude can perform.
 
 Hook configuration (events, properties, matchers, exit codes, environment variables, and HTTP hooks) is maintained in a dedicated repository:
 
-> **[claude-code-hooks](https://github.com/shanraisshan/claude-code-hooks)** — Complete hook reference with sound notification system, all 28 hook events (including `PreModelSwitch` and `PostModelSwitch` added in v2.1.252), HTTP hooks, matcher patterns, exit codes, and environment variables.
+> **[claude-code-hooks](https://github.com/shanraisshan/claude-code-hooks)** — Complete hook reference with sound notification system, all 28 hook events (including `PreModelSwitch` and `PostModelSwitch` added in v2.1.251), HTTP hooks, matcher patterns, exit codes, and environment variables.
 
 Hook-related settings keys (`hooks`, `disableAllHooks` (also disables any custom status line), `allowManagedHooksOnly`, `allowedHttpHookUrls`, `httpHookAllowedEnvVars`) are documented there.
 
@@ -414,8 +419,9 @@ Configure Model Context Protocol servers for extended capabilities.
 | `enableAllProjectMcpServers` | boolean | Any | Auto-approve all `.mcp.json` servers. **Security note (v2.1.196):** `.mcp.json` servers no longer self-approve — explicit opt-in via `enableAllProjectMcpServers: true` or `enabledMcpjsonServers` is now required |
 | `enabledMcpjsonServers` | array | Any | Allowlist specific server names |
 | `disabledMcpjsonServers` | array | Any | Blocklist specific server names |
-| `allowedMcpServers` | array | Managed only | Allowlist with name/command/URL matching |
-| `deniedMcpServers` | array | Managed only | Blocklist with matching |
+| `allowedMcpServers` | array | Any file | Allowlist with name/command/URL matching (v2.1.259: scope expanded from Managed only to Any file) |
+| `deniedMcpServers` | array | Any file | Blocklist with matching (v2.1.259: scope expanded from Managed only to Any file) |
+| `managedMcpServers` | object | Managed only | Organization-deployed MCP server definitions that are automatically available to all users. Same structure as `mcpServers` in `.mcp.json`. When set in managed settings, these servers are pre-approved and loaded without requiring user opt-in (v2.1.259+) |
 | `allowManagedMcpServersOnly` | boolean | Managed only | Only allow MCP servers explicitly listed in managed allowlist |
 | `channelsEnabled` | boolean | Managed only | Allow [channels](https://code.claude.com/docs/en/channels) for Team and Enterprise users. When unset or `false`, channel message delivery is blocked regardless of `--channels` flag |
 | `allowedChannelPlugins` | array | Managed only | Allowlist of channel plugins that may push messages. Replaces the default Anthropic allowlist when set. Undefined = fall back to the default, empty array = block all channel plugins. Requires `channelsEnabled: true`. Each entry is an object with `marketplace` and `plugin` fields (v2.1.84) |
@@ -482,7 +488,8 @@ Configure bash command sandboxing for security.
 | `sandbox.excludedCommands` | array | `[]` | Commands to run outside sandbox |
 | `sandbox.allowUnsandboxedCommands` | boolean | `true` | Allow `dangerouslyDisableSandbox`. When set to `false`, the escape hatch is completely disabled and all commands must run sandboxed (or be in `excludedCommands`). Useful for enterprise policies that require strict sandboxing |
 | `sandbox.filesystem.disabled` | boolean | `false` | Skip filesystem isolation while keeping network egress control active. When `true`, the sandbox does not restrict file access but network egress stays confined to `sandbox.network.allowedDomains`. **Only honored from user settings, managed settings, or `--settings`** — ignored in `.claude/settings.json` and `.claude/settings.local.json` (v2.1.216) |
-| `sandbox.ignoreViolations` | object | `{}` | Map of command patterns to path arrays — suppress violation warnings *(in JSON schema, not on official settings page)* |
+| `sandbox.ignoreViolations` | object | `{}` | Map of command patterns to path arrays — suppress violation warnings for specific commands accessing specific paths. Useful for known-safe patterns that would otherwise generate sandbox alerts |
+| `sandbox.ripgrep` | string | - | Path to a custom `ripgrep` binary used by the Grep tool inside the sandbox. When set, overrides automatic `rg` detection from `PATH`. Useful in environments where the system `rg` is not in the sandbox's path (v2.1.256+) |
 | `sandbox.enableWeakerNestedSandbox` | boolean | `false` | **(Linux and WSL2 only)** Enable weaker sandbox for unprivileged Docker environments (reduces security) |
 | `sandbox.network.allowUnixSockets` | array | `[]` | **(macOS only)** Specific Unix socket paths accessible in sandbox. Ignored on Linux and WSL2, where the seccomp filter cannot inspect socket paths; use `allowAllUnixSockets` instead |
 | `sandbox.network.allowAllUnixSockets` | boolean | `false` | Allow all Unix sockets (overrides `allowUnixSockets`). On Linux and WSL2 this is the only way to permit Unix sockets, since it skips the seccomp filter that otherwise blocks `socket(AF_UNIX, ...)` calls |
@@ -606,7 +613,7 @@ Configure Claude Code plugins and marketplaces.
 | `"sonnet[1m]"` | Sonnet with 1M token context |
 | `"opus[1m]"` | Opus with 1M token context (default on Max, Team, and Enterprise since v2.1.75) |
 | `"opusplan"` | Opus for planning, Sonnet for execution |
-| `"fable"` | Claude Fable 5 — long-horizon reasoning model. Anthropic API only (v2.1.170+). Fable 5 includes 1M context by default; the `[1m]` suffix is auto-stripped, so `fable[1m]` is redundant (v2.1.173) |
+| `"fable"` | Claude Fable 5.1 — long-horizon reasoning model (updated to Fable 5.1 in v2.1.261; previously Fable 5). Anthropic API only (v2.1.170+). Fable 5.1 includes 1M context by default; the `[1m]` suffix is auto-stripped, so `fable[1m]` is redundant (v2.1.173) |
 
 **Example:**
 ```json
@@ -625,7 +632,7 @@ Map Anthropic model IDs to provider-specific model IDs for Bedrock, Vertex, or F
 |-----|------|---------|-------------|
 | `effortLevel` | string | - | Persist the effort level across sessions. Accepts `"low"`, `"medium"`, `"high"`, `"xhigh"` (Fable 5, Opus 5, Sonnet 5, Opus 4.7, Opus 4.8, v2.1.111). **`"max"` and `"ultracode"` are session-only and are not accepted here** — set them via `/effort` or `--settings` for a single session but do not write them to `settings.json`. Written automatically when you run `/effort <level>`. The default effort is `high` on every model that supports effort, except Opus 4.7 which defaults to `xhigh`. Unsupported levels fall back to the highest supported level on the active model. **As of v2.1.243, `/effort` saves defaults per-model via `modelSettings`** — use `modelSettings` when you want different effort defaults per model |
 | `modelSettings` | object | - | Per-model saved effort levels and configuration, keyed by model alias or ID. Each entry contains `effortLevel` and optionally other per-model overrides. `/effort` writes to this key as of v2.1.243, enabling different default effort levels on different models. **Does not merge across settings files** — the highest-precedence file that defines it supplies the entire object. Example: `{"opus": {"effortLevel": "xhigh"}, "sonnet": {"effortLevel": "high"}}` |
-| `modelPicker` | object | - | Curate and order the `/model` picker with labeled, ordered rows. Overrides the default model list when set. **Does not merge across settings files** — the highest-precedence file that defines it supplies the entire list. Example: `[{"id": "opus", "label": "Opus 5 (reasoning)"}, {"id": "sonnet", "label": "Sonnet 5 (balanced)"}]` (v2.1.242+) |
+| `modelPicker` | object | - | Curate and order the `/model` picker with labeled, ordered rows. Overrides the default model list when set. **Does not merge across settings files** — the highest-precedence file that defines it supplies the entire list. **Only honored from user and managed settings** — project (`.claude/settings.json`) and local settings values are ignored to prevent untrusted repos from restricting the model picker. Example: `[{"id": "opus", "label": "Opus 5 (reasoning)"}, {"id": "sonnet", "label": "Sonnet 5 (balanced)"}]` (v2.1.242+) |
 | `modelPricing` | object | - | **(Managed only)** Contracted per-model rates and discount multipliers applied to usage cost reporting. Allows organizations to configure accurate cost attribution when using negotiated pricing tiers rather than public list prices (v2.1.243+) |
 | `fallbackModel` | array | - | Up to 3 fallback model IDs tried sequentially when the primary model is unavailable (e.g., rate-limited or capacity issue). Each entry is a model ID or alias; `"default"` expands to the account default. Claude Code attempts the primary model first; if it fails, each fallback is tried in order. Stops at the first successful response. **Unlike most array settings, this key does not merge across settings files** — the highest-precedence file that defines it supplies the entire chain; entries beyond 3 (after deduplication) are silently ignored (v2.1.166) |
 | `modelOverrides` | object | - | Map model picker entries to provider-specific IDs (e.g., Bedrock inference profile ARNs). Each key is a model picker entry name, each value is the provider model ID |
@@ -707,10 +714,18 @@ Configure via `env` key:
 | `wheelScrollAccelerationEnabled` | boolean | `true` | Disable mouse-wheel scroll acceleration in fullscreen mode. Set to `false` to use fixed per-tick scroll steps instead of the OS-level acceleration curve (v2.1.174) |
 | `footerLinksRegexes` | array | - | Array of objects matched against **turn output** (tool results, file contents, fetched pages, Claude's responses) to display as link badges in the footer row. Each entry is `{type, pattern, url, label}` where `pattern` is a regex with named capture groups and `url`/`label` may reference those groups. Matched patterns produce a clickable badge at the bottom of the chat UI. Capped at 5 badges per turn; URL max 2048 chars; allowed schemes: `http`, `https`, `vscode`, `cursor`, `windsurf`, `zed`, `jetbrains`, `idea`, `slack`, `linear`, `notion`, `figma`, `vscode-insiders`. User/`--settings`/managed only (v2.1.176) |
 | `emojiCompletionEnabled` | boolean | `true` | Enable emoji shortcode autocomplete in the prompt input (e.g., `:tada:` → 🎉). Set to `false` to disable. Requires v2.1.217+ |
-| `keybindingFlavor` | string | - | Keyboard shortcut style for word deletion. Set to `"readline"` for Bash/GNU readline-style Ctrl+W behavior (delete word backward to whitespace boundary). When unset, uses the default word-deletion behavior (v2.1.236) |
+| `keybindingFlavor` | string | - | **Deprecated in v2.1.261.** Keyboard shortcut style for word deletion. Set to `"readline"` for Bash/GNU readline-style Ctrl+W behavior (delete word backward to whitespace boundary). When unset, uses the default word-deletion behavior (v2.1.236). Deprecated — use the replacement key binding configuration instead |
 | `spellcheck` | object | - | Spell-check underlines in the prompt input. Requires an installed spell-check binary (`aspell`, `hunspell`, or `ispell`). Object with `enabled` (boolean) and `binary` (string — path to the spell checker). Set via `/config`. Requires v2.1.235+ (binary path required as of v2.1.236) |
 | `promptCacheTtl` | string | - | Keep the 1-hour prompt cache tier active on the main conversation for API-key and cloud-provider users who have access to extended cache TTLs. When unset, the default 5-minute cache TTL applies. Example: `"1h"`. Pairs with `subagentPromptCacheTtl` (v2.1.243+) |
 | `subagentPromptCacheTtl` | string | - | Keep the 5-minute prompt cache tier active for subagents when set. Controls the cache TTL for subagent turns separately from the main conversation. Use with `promptCacheTtl` for independent control of caching behavior in orchestrated workflows (v2.1.243+) |
+| `timeFormat` | string | `"12h"` | Clock format used in session timestamps and status displays. Accepts `"12h"` (AM/PM) or `"24h"` (24-hour clock) (v2.1.258+) |
+| `timeZone` | string | - | IANA timezone name (e.g., `"America/New_York"`, `"Asia/Karachi"`) for timestamps displayed in the UI and session metadata. When unset, defaults to the system timezone (v2.1.258+) |
+| `promptSuggestionEnabled` | boolean | `true` | Show AI-generated prompt suggestions in the input box. Set to `false` to disable in-session prompt recommendations (v2.1.260+) |
+| `enableWorkflows` | boolean | `true` | Enable the Ultracode workflow system (`/workflows`, multi-agent orchestration). Set to `false` to disable the Workflow tool and hide workflow commands from the slash-command menu (v2.1.261+) |
+| `isolatePeerMachines` | boolean | `false` | **(Managed only)** When `true`, prevents Claude Code sessions on the same machine from sharing state with peer sessions (e.g., shared memories, cross-session coordination). Use in environments where session isolation is required (v2.1.262+) |
+| `syncClaudeAiSkills` | boolean | `true` | Sync skills from claude.ai to local Claude Code sessions. When `false`, claude.ai-sourced skills are not downloaded or applied locally (v2.1.262+) |
+| `disableDesktopLocalSessions` | boolean | `false` | **(Managed only)** Prevent local Claude Code sessions in the Desktop app. When `true`, only remote/cloud sessions are allowed; local terminal sessions are blocked (v2.1.262+) |
+| `sshHostAllowlist` | array | - | **(Managed only)** List of SSH host patterns permitted for remote session connections. When set, only hosts matching an entry in this list may be connected to via SSH. Supports glob patterns (e.g., `"*.corp.example.com"`) (v2.1.263+) |
 
 ### Global Config Settings (`~/.claude.json`)
 
@@ -725,7 +740,7 @@ These IDE-related preferences are stored in `~/.claude.json`, **not** `settings.
 | `externalEditorContext` | boolean | `false` | Prepend Claude's previous response as `#`-commented context when you open the external editor with `Ctrl+G`. Set to `true` to enable |
 | `teammateDefaultModel` | string | `null` | **Removed in v2.1.251.** Previously set the default model for [agent-team](https://code.claude.com/docs/en/agent-teams) teammates when the lead dispatched them. Teammates now inherit the lead's model by default |
 | `diffTool` | string | - | External diff tool command invoked when viewing file diffs. When set, Claude Code spawns this command with the two file paths as arguments instead of rendering the built-in diff view |
-| `permissionExplainerEnabled` | boolean | `true` | Show an AI-generated natural-language explanation of why a permission is being requested alongside the permission prompt. Set to `false` to suppress the explanation and show only the raw tool call |
+~~`permissionExplainerEnabled`~~ | — | **Removed in v2.1.257.** Previously showed an AI-generated natural-language explanation alongside permission prompts. This feature was removed and the key is no longer recognized |
 
 ### Workspace & Teams
 
@@ -873,6 +888,12 @@ The file suggestion script receives a JSON object on stdin (e.g., `{"query": "sr
   "awsCredentialExport": "/bin/generate_aws_grant.sh"
 }
 ```
+
+### OIDC Settings
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `oidc.scope_on_refresh` | string | Additional OAuth scopes to request during OIDC token refresh. Space-separated list of scope strings appended to the standard scopes on token refresh requests. Use when downstream services require non-standard OIDC claims (v2.1.262+) |
 
 ### OpenTelemetry
 
@@ -1412,7 +1433,7 @@ Set environment variables for all Claude Code sessions.
 
 ## Sources
 
-- [Claude Code Settings Reference](https://code.claude.com/docs/en/settings-reference) — canonical key index (~180 keys with Scope/Type/Default columns)
+- [Claude Code Settings Reference](https://code.claude.com/docs/en/settings-reference) — canonical key index (~196 keys with Scope/Type/Default columns; this report covers additional keys from JSON schema and changelog)
 - [Claude Code Settings Documentation](https://code.claude.com/docs/en/settings)
 - [Claude Code CLI Reference](https://code.claude.com/docs/en/cli-reference)
 - [Claude Code Model Configuration](https://code.claude.com/docs/en/model-config)

--- a/changelog/best-practice/claude-settings/changelog.md
+++ b/changelog/best-practice/claude-settings/changelog.md
@@ -1283,3 +1283,35 @@
 | 12 | HIGH | Wrong Description | Fix `teammateDefaultModel` (Global Config) — removed in v2.1.251; teammates now inherit the lead's model by default. Marked as removed. Confirmed in v2.1.251 changelog | ✅ COMPLETE (marked removed) — NEW |
 | 13 | HIGH | Hook Count | Update hooks redirect blurb from "26 hook events" to "28 hook events" — `PreModelSwitch` and `PostModelSwitch` added in v2.1.252. Confirmed in v2.1.252 changelog | ✅ COMPLETE (count updated) — NEW |
 | 14 | MED | Missing Env Vars | Add 6 missing env vars: `ANTHROPIC_DEFAULT_MODEL` (v2.1.236+, last-resort model fallback), `CLAUDE_CODE_PROJECT_DIR_NAME` (v2.1.234+, transcript dir name), `CLAUDE_CODE_TOOL_MEMORY_LIMIT` (v2.1.233, Linux cgroup memory cap), `CLAUDE_CODE_WEBFETCH_CACHE_TTL_MS` (v2.1.233, WebFetch cache TTL), `CLAUDE_CODE_ENABLE_TODO_TOOLS` (v2.1.234, legacy todo tools), `CLAUDE_CODE_WORKFLOW_PREFIX_STAGGER_MS` (v2.1.229, agent launch stagger). Confirmed in changelog | ✅ COMPLETE (all 6 added) — NEW |
+
+---
+
+## [2026-09-08 10:47 AM PKT] Claude Code v2.1.263
+
+| # | Priority | Type | Action | Status |
+|---|----------|------|--------|--------|
+| 1 | HIGH | Version Metadata | Update version badge v2.1.252 → v2.1.263; update header from "140+ settings" to "220+ settings". Confirmed via official settings-reference page and CHANGELOG.md (11 versions: v2.1.253–v2.1.263) | ✅ COMPLETE (badge, version, and header count updated) — NEW |
+| 2 | HIGH | Wrong Type | Fix `disableAutoMode` type: was documented as `string` (set to `"disable"`); official settings-reference shows `boolean`. Correct usage is `true`/`false`. Confirmed in official settings-reference | ✅ COMPLETE (type corrected to boolean) — NEW |
+| 3 | HIGH | Hook Attribution | Fix `PreModelSwitch`/`PostModelSwitch` hook attribution: report said v2.1.252 but these were added in v2.1.251. Confirmed in CHANGELOG.md | ✅ COMPLETE (attribution corrected to v2.1.251) — NEW |
+| 4 | HIGH | Wrong Scope | Fix `allowedMcpServers` scope: was "Managed only" — changed to "Any file" in v2.1.259. Confirmed in official settings-reference and v2.1.259 changelog | ✅ COMPLETE (scope updated) — NEW |
+| 5 | HIGH | Wrong Scope | Fix `deniedMcpServers` scope: was "Managed only" — changed to "Any file" in v2.1.259. Confirmed in official settings-reference and v2.1.259 changelog | ✅ COMPLETE (scope updated) — NEW |
+| 6 | HIGH | Stale Annotation | Remove stale "in JSON schema, not on official settings page" annotation from `sandbox.ignoreViolations` — this key is now documented on the official settings-reference page. Confirmed in official settings-reference | ✅ COMPLETE (annotation removed, description updated) — NEW |
+| 7 | HIGH | Removed Key | Remove `permissionExplainerEnabled` from active settings: removed in v2.1.257. Marked with strikethrough and removal notice. Confirmed in v2.1.257 changelog | ✅ COMPLETE (key marked removed) — NEW |
+| 8 | HIGH | Missing Settings | Add `bashOutputMaxChars` (number, 30000 default, v2.1.256+) and `taskOutputMaxChars` (number, 30000 default, v2.1.256+) to General Settings. Confirmed in official settings-reference | ✅ COMPLETE (both keys added) — NEW |
+| 9 | HIGH | Missing Setting | Add `permissions.blockReadsOutsideWorkingDirectories` (boolean, v2.1.256+) to Permission Keys table. Confirmed in official settings-reference | ✅ COMPLETE (key added) — NEW |
+| 10 | HIGH | Missing Setting | Add `managedMcpServers` (object, Managed only, v2.1.259+) to MCP Settings table. Confirmed in official settings-reference | ✅ COMPLETE (key added) — NEW |
+| 11 | MED | Deprecated Key | Mark `keybindingFlavor` as deprecated in v2.1.261. Confirmed in v2.1.261 changelog | ✅ COMPLETE (deprecation notice added) — NEW |
+| 12 | MED | Missing Setting | Add `sandbox.ripgrep` (string, path to custom rg binary, v2.1.256+) to Sandbox Settings. Confirmed in official settings-reference | ✅ COMPLETE (key added) — NEW |
+| 13 | MED | Missing Settings | Add `timeFormat` (string, 12h/24h, v2.1.258+) and `timeZone` (string, IANA timezone, v2.1.258+) to Display Settings. Confirmed in official settings-reference | ✅ COMPLETE (both keys added) — NEW |
+| 14 | MED | Missing Settings | Add `promptSuggestionEnabled` (boolean, v2.1.260+), `enableWorkflows` (boolean, v2.1.261+), `isolatePeerMachines` (boolean managed-only, v2.1.262+), `syncClaudeAiSkills` (boolean, v2.1.262+), `disableDesktopLocalSessions` (boolean managed-only, v2.1.262+), `sshHostAllowlist` (array managed-only, v2.1.263+). Confirmed in official settings-reference | ✅ COMPLETE (all 6 added) — NEW |
+| 15 | MED | Missing Setting | Add `managedSourcesBehavior` (string, first-wins/merge, v2.1.259+) to Managed-only policy keys. Confirmed in official settings-reference | ✅ COMPLETE (key added) — NEW |
+| 16 | MED | Missing Setting | Add `skipAutoPermissionPrompt` (boolean, v2.1.258+) to Permission Keys. Confirmed in official settings-reference | ✅ COMPLETE (key added) — NEW |
+| 17 | MED | Missing Setting | Add `oidc.scope_on_refresh` (string, v2.1.262+) to new OIDC Settings subsection under AWS & Cloud Credentials. Confirmed in official settings-reference | ✅ COMPLETE (key added in new section) — NEW |
+| 18 | MED | Wrong Scope | Fix `modelPicker`: add note that project and local settings are ignored — only user and managed settings are honored. Confirmed in official settings-reference | ✅ COMPLETE (scope restriction noted) — NEW |
+| 19 | MED | Wrong Scope | Fix `permissions.defaultMode`: add note that `"bypassPermissions"` is ignored in project/local settings (v2.1.258+), similar to existing `"auto"` restriction. Confirmed in official settings-reference | ✅ COMPLETE (restriction noted) — NEW |
+| 20 | MED | Model Update | Update `"fable"` alias: now resolves to Claude Fable 5.1 (updated in v2.1.261). Confirmed in v2.1.261 changelog | ✅ COMPLETE (description updated) — NEW |
+| 21 | MED | Sources Count | Update sources annotation from "~180 keys" to "~196 keys" for settings-reference page, noting report covers additional schema/changelog-only keys. Confirmed by inspection | ✅ COMPLETE (count updated) — NEW |
+| 22 | LOW | Wrong Attribution | Update hook events attribution: hooks blurb said v2.1.252 for PreModelSwitch/PostModelSwitch (covered by item 3 above) | ✅ COMPLETE (covered by item 3) — DUPLICATE |
+| 23 | LOW | Unverified — Skipped | `Bash(git * main)` pattern warning: research agents flagged potential startup warning for this example pattern in newer versions. No official source confirmation found — skipped per Rule 8A | ⚠️ SKIPPED (no official source — Rule 8A) — UNVERIFIED |
+| 24 | LOW | Unverified — Skipped | `disableArtifact` deprecation: research agents flagged possible deprecation. No official source confirmation found on settings-reference page — skipped per Rule 8A | ⚠️ SKIPPED (no official source — Rule 8A) — UNVERIFIED |
+| 25 | LOW | Unverified — Skipped | `askUserQuestionTimeout` scope fix: research agents flagged possible scope change. Current "project and local only" scope not contradicted by official page — skipped per Rule 8A | ⚠️ SKIPPED (no contradicting official source — Rule 8A) — UNVERIFIED |


### PR DESCRIPTION
## Drift Report — Claude Code v2.1.252 → v2.1.263

**Run date:** 2026-09-08 10:47 AM PKT  
**Version gap:** 11 versions (v2.1.253 through v2.1.263)  
**Files changed:** `best-practice/claude-settings.md`, `changelog/best-practice/claude-settings/changelog.md`

---

## Summary

| Priority | Count | Status |
|----------|-------|--------|
| HIGH | 11 | ✅ All applied |
| MED | 11 | ✅ All applied (2 unverified skipped per Rule 8A) |
| LOW | 3 | ✅ 1 duplicate closed, 2 skipped (Rule 8A) |

---

## Action Items

### HIGH Priority

| # | Type | Change |
|---|------|--------|
| 1 | Version Metadata | Badge v2.1.252 → v2.1.263; header "140+" → "220+ settings" |
| 2 | Wrong Type | `disableAutoMode`: `string` → `boolean` |
| 3 | Hook Attribution | `PreModelSwitch`/`PostModelSwitch` v2.1.252 → v2.1.251 |
| 4 | Wrong Scope | `allowedMcpServers`: "Managed only" → "Any file" (v2.1.259) |
| 5 | Wrong Scope | `deniedMcpServers`: "Managed only" → "Any file" (v2.1.259) |
| 6 | Stale Annotation | `sandbox.ignoreViolations`: removed "in JSON schema, not on official page" annotation |
| 7 | Removed Key | `permissionExplainerEnabled`: removed in v2.1.257 — marked with strikethrough |
| 8 | Missing Settings | Added `bashOutputMaxChars` (30000) and `taskOutputMaxChars` (30000) — v2.1.256+ |
| 9 | Missing Setting | Added `permissions.blockReadsOutsideWorkingDirectories` — v2.1.256+ |
| 10 | Missing Setting | Added `managedMcpServers` (Managed only) to MCP Settings — v2.1.259+ |
| 11 | Sources | Updated settings-reference annotation: ~180 → ~196 keys |

### MED Priority

| # | Type | Change |
|---|------|--------|
| 12 | Deprecated | `keybindingFlavor`: marked deprecated in v2.1.261 |
| 13 | Missing Setting | Added `sandbox.ripgrep` (custom rg path) — v2.1.256+ |
| 14 | Missing Settings | Added `timeFormat` (12h/24h) and `timeZone` (IANA) — v2.1.258+ |
| 15 | Missing Settings | Added `promptSuggestionEnabled`, `enableWorkflows`, `isolatePeerMachines`, `syncClaudeAiSkills`, `disableDesktopLocalSessions`, `sshHostAllowlist` — v2.1.260–v2.1.263 |
| 16 | Missing Setting | Added `managedSourcesBehavior` (first-wins/merge) — v2.1.259+ |
| 17 | Missing Setting | Added `skipAutoPermissionPrompt` — v2.1.258+ |
| 18 | Missing Setting | Added `oidc.scope_on_refresh` in new OIDC Settings section — v2.1.262+ |
| 19 | Wrong Scope | `modelPicker`: added project/local ignored restriction |
| 20 | Wrong Scope | `permissions.defaultMode`: `bypassPermissions` ignored in project/local — v2.1.258+ |
| 21 | Model Update | `"fable"` alias now resolves to Fable 5.1 (v2.1.261) |

### LOW Priority (Skipped per Rule 8A)

| # | Type | Notes |
|---|------|-------|
| 22 | Skipped | `Bash(git * main)` pattern warning — no official source confirmation |
| 23 | Skipped | `disableArtifact` deprecation — no official source confirmation |
| 24 | Skipped | `askUserQuestionTimeout` scope fix — not contradicted by official page |

---

## Verification Checklist Coverage

All 27 rules (1A–10C) executed. Notable findings:
- **1A/1F** (key completeness + inverse): 16 missing keys added; no orphaned keys found
- **1B/1C/1D** (type/default/description): `disableAutoMode` type corrected; 2 scope corrections; 1 annotation removal
- **1E** (scope column): `allowedMcpServers` + `deniedMcpServers` scope corrected
- **4A** (hooks redirect): redirect link valid ✅
- **8A** (source credibility): 3 items withheld — no official source backing
- **10A** (version metadata): badge, version, and count updated ✅

---

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01Jqfpf6HQW4CoGT6RLLwi9y

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jqfpf6HQW4CoGT6RLLwi9y)_