### PR TITLE
Add OrcaReplay to 🔀 CROSS-MODEL WORKFLOWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Methodology: [Cross-Model (Claude Code + Codex) Workflow](development-workflows/
 | [router-for-me/CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI) | 32k | Router | Gemini CLI, Codex, Claude Code, Antigravity | Wraps each CLI as an OpenAI/Gemini/Claude/Codex-compatible API service |
 | [openai/codex-plugin-cc](https://github.com/openai/codex-plugin-cc) | 18k | Plugin | Codex / GPT-5 | Official OpenAI plugin: `/codex:review`, `/codex:adversarial-review`, `/codex:rescue` inside Claude Code |
 | [BeehiveInnovations/pal-mcp-server](https://github.com/BeehiveInnovations/pal-mcp-server) | 12k | MCP | Gemini, OpenAI, Azure, Grok, Ollama, OpenRouter (50+ models) | Multi-model MCP server (formerly `zen-mcp-server`) — call other models as Claude tools |
+| [Continuum-AI-Corp/OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay) | 173 | Fork | any OpenAI- or Anthropic-compatible endpoint, or one gateway | Records a Claude Code run, then re-runs the *same* recorded work on other models: `orca compare last --models a,b,c --verify "npm test"` restores the git tree to a checkpoint, replays up to it, and goes live from there on each model in its own worktree — the verify command's exit code is the verdict. Also replays a run offline with the network off. |
 
 <p align="center">
   <img src="!/claude-jumping.svg" alt="section divider" width="60" height="50">


### PR DESCRIPTION
Adds [OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay) to **🔀 CROSS-MODEL WORKFLOWS**.

**Disclosure: I work on it.** Apache-2.0, free, no paid tier.

## Read this bit first — it is a fourth mechanism, not one of your three

The section says cross-model work happens via **Plugin**, **MCP**, or **Router**. OrcaReplay is none of those, so I have put `Fork` in the Type column rather than pretend otherwise. **If a fourth type is not something you want in this taxonomy, please just close it** — that is a reasonable call and I would rather you did that than bend the table.

Here is what the mechanism actually is, so you can judge it:

The three listed mechanisms all send **new** work to another model. This one sends **the work Claude Code already did**. It records the run first — the model calls, tool calls and per-turn file changes — and then re-runs that same recorded work from a chosen checkpoint against other models:

```bash
orca record claude -- -p "fix the failing test"
orca compare last --models gpt-5.6-sol,claude-opus-5,gemini-3-pro --verify "npm test"
```

Each model gets the git tree restored to that checkpoint, in its own worktree, and continues live from there. The `--verify` command's exit code is the verdict, so the output is a table of which models actually fixed it — not three transcripts to read.

The other half is that a recording replays **offline**: `orca replay last` re-executes the run with the network off, served the recorded bytes back. That is the part the routers cannot do, because they forward requests rather than keep them.

## Why it goes here rather than under Skills or Agents

It is not a skill collection and not an agent. Cross-model comparison is the thing it is *for* — the recording exists so the comparison can be fair, since every model starts from byte-identical context rather than from a re-typed prompt.

## Verified

`npm i -g orcareplay` (0.2.3, published with provenance). Claude Code is [walked through against a real bug fix](https://github.com/Continuum-AI-Corp/OrcaReplay/blob/main/docs/validation.md); goose 1.49.0 and Hermes v0.21.0 have both been driven end to end too. ~1,700 tests, trace-format conformance suite, listed in the official MCP Registry.

Star count in the table is 173 — small, and I have written the real number rather than rounding it up. Happy to reword the row, move it, or drop it.
